### PR TITLE
feat: add remora gateway fast mode

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -273,6 +273,108 @@ Likely break signs:
 - a valid partial-zero response is discarded
 - the module reports `0` candidates or the verifier reports an occurrence mismatch
 
+### `gateway-fast-mode`
+
+Intent:
+
+- extend Claude Code's built-in `/fast` command for remora/GPT gateway sessions instead of
+  registering a second command with the same name
+- when `REMORA_ACTIVE="1"`, `/fast on` publishes `service_tier:"priority"`, `/fast off` removes
+  only the top-level `service_tier`, and bare `/fast` toggles the effective gateway tier
+- keep the selection session-scoped and visible to the main process, thin/control requests, new
+  workers, already-running workers on their next request, and respawned workers
+- preserve the existing `remora --fast` startup body while the shared mode remains `inherit`
+
+Source of truth and process ownership:
+
+- `CALICO_GATEWAY_FAST_STATE_FILE` is a private locator inherited by worker processes
+- the located file is the cross-process source of truth and contains only `inherit`, `on`, or `off`;
+  it never contains the complete `CLAUDE_CODE_EXTRA_BODY`
+- only the process that creates the random temp directory owns cleanup; a child that inherits the
+  locator must not remove shared session state
+- the owner creates the directory with mode `0700` and the mode file with mode `0600`
+- `process.env.CLAUDE_CODE_EXTRA_BODY` is only the command process's local mirror; worker launch
+  snapshots remain intact but are not trusted for later cross-process Fast changes
+- every request-body builder reads the mode file again and applies it to that process's parsed body
+- once a remora locator exists, a missing, unreadable, or invalid mode file aborts body construction;
+  falling back to a stale worker environment is forbidden
+
+Atomic publish:
+
+- command handling validates and serializes the next body before changing either state surface
+- it writes the next mode to a same-directory exclusive temporary file, updates the local env mirror,
+  and atomically renames the temporary file over the mode file
+- synchronous command execution prevents a same-process request from interleaving between env update
+  and rename; other processes can observe only the complete old mode or complete new mode
+- write or rename failure restores the exact prior env presence/value and removes the temporary file;
+  the previously published mode remains authoritative
+
+Claude Code 2.1.211 semantic anchors:
+
+- the interactive handler is identified by the native availability reason, `"shortcut"` Fast action,
+  picker telemetry, JSX picker fallback, and app-state access
+- the thin/control handler is identified by the same native availability reason and action, the
+  `"bridge"` source, argument parsing, and `.options.fastMode` bare-toggle fallback
+- the `local-jsx` registration owns `thinClientDispatch:"control-request"`; the `local` registration
+  owns non-interactive support; both retain the same native model-description getter
+- the request-body builder parses `CLAUDE_CODE_EXTRA_BODY`, validates that the native result is an
+  object, merges `anthropic_beta`, and returns the resulting body
+- the worker dispatch record owns `respawnFlags`, the raw extra-body/PATH env snapshots, and the
+  `uea(...)` launch call used by initial and respawned workers
+- all six surfaces must be discovered exactly once before any replacement is applied; otherwise the
+  module returns the original bundle with `patched: 0`
+
+Command and JSON semantics:
+
+- blank extra body is `{}`; the top level must be a non-array object
+- the recursive scanner rejects duplicate decoded keys at every object level, so `"a"` conflicts
+  with a single-backslash Unicode escape for U+0061 while a literal `\\u0061` key remains distinct
+- parsed values are traversed to reject every non-finite number, including overflow such as `1e9999`
+- `on` accepts an absent tier or the legacy aliases `"fast"` and `"priority"`, then normalizes to
+  `"priority"`; another existing tier is a conflict
+- `off` removes only the outer `service_tier` regardless of its old value and preserves unrelated
+  and nested fields
+- bare `/fast` uses explicit shared `on`/`off` first; under `inherit` it derives the current state
+  from the strict-parsed body and publishes the opposite explicit mode
+- unknown arguments return usage text without changing the env mirror or shared mode
+
+Native compatibility and deliberate non-targets:
+
+- remora branches run before the native availability gate and never call the Anthropic Fast action
+- non-remora sessions retain the original provider/model/organization gates, picker telemetry,
+  app-state updates, command visibility, thin toggle, and model switching
+- the gateway path must never inject Anthropic's `speed:"fast"`; GPT priority uses only
+  `service_tier:"priority"`
+- the patch does not write Claude settings or reuse native `fastMode` app state for gateway state
+- an already in-flight request is not changed retroactively; the next request observes the new mode
+- changing the effective body/tier can cause one prompt-cache miss on the next request; that is an
+  expected cache-key transition, not a regression
+
+Atomicity and verification:
+
+- `scripts/verify-patched-binary.ts` requires one executable helper block, exact handler ordering,
+  preserved native fallbacks, registration ownership, parse-then-apply-then-beta order, and the
+  locator beside raw extra-body/PATH snapshots in the worker respawn dispatch record
+- verifier mutations cover commented/rebound helpers, missing command surfaces, parse/beta drift,
+  catch-only application, detached worker env data, registration drift, full-body persistence,
+  Anthropic speed injection, and stale thin toggles
+- fixture tests model shared request-time state, but they do not replace live proof with a real
+  existing worker process, thin client, request-capture gateway, and respawn
+
+Likely break signs and hard stops:
+
+- `/fast` opens the native picker in remora, or remora on/off calls the native Fast setter
+- main requests change tier while thin, new-worker, existing-worker, or respawn requests remain stale
+- unrelated extra-body fields disappear, nested `service_tier` is removed, or `speed:"fast"` reaches
+  the GPT gateway
+- deleting or corrupting the mode file still allows a request with stale worker env to be sent
+- non-remora `/fast` visibility, availability reason, picker, app state, or model switching changes
+- any request producer bypasses the patched body builder, or any persistent worker spawn path omits
+  the locator
+- if the same already-running worker cannot observe on/off on its next captured request, thin changes
+  only UI state, respawn falls back to an old snapshot, or a state-read failure still sends a request,
+  stop the release and redesign the IPC/shared-state seam; do not downgrade to main-process-only support
+
 ### `create-diff-colors`
 
 Intent:

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2164,6 +2164,267 @@ function patchStatuslineCommittedUsage(content) {
   return { content: output, candidates, patched: 6 };
 }
 
+function patchGatewayFastMode(content) {
+  const original = content;
+  const identifier = "[A-Za-z_$][\\w$]*";
+  const interactivePattern = new RegExp(
+    "async function (" +
+      identifier +
+      ")\\((" +
+      identifier +
+      "),(" +
+      identifier +
+      "),(" +
+      identifier +
+      ")\\)\\{if\\(!(" +
+      identifier +
+      ")\\(\\)\\)return \\2\\((" +
+      identifier +
+      ")\\(\\)\\?\\?\"Fast mode is not available\"\\),null;",
+    "g"
+  );
+  const thinPattern = new RegExp(
+    "async function (" +
+      identifier +
+      ")\\((" +
+      identifier +
+      "),(" +
+      identifier +
+      ")\\)\\{if\\(!(" +
+      identifier +
+      ")\\(\\)\\)return\\{type:\"text\",value:(" +
+      identifier +
+      ")\\(\\)\\?\\?\"Fast mode is not available\"\\};",
+    "g"
+  );
+  const localJsxPattern =
+    /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",get immediate\(\)\{return ([A-Za-z_$][\w$]*)\(\)\},requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
+  const localPattern =
+    /([A-Za-z_$][\w$]*)=\{type:"local",name:"fast",supportsNonInteractive:!0,get description\(\)\{return`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},argumentHint:"\[on\|off\]",isEnabled:\(\)=>([A-Za-z_$][\w$]*)\(\),get isHidden\(\)\{return!([A-Za-z_$][\w$]*)\(\)\}/g;
+  const builderPattern = new RegExp(
+    "function (" +
+      identifier +
+      ")\\((" +
+      identifier +
+      ")\\)\\{let (" +
+      identifier +
+      ")=process\\.env\\.CLAUDE_CODE_EXTRA_BODY,(" +
+      identifier +
+      ")=\\{\\};",
+    "g"
+  );
+  const workerPattern = new RegExp(
+    "\\.\\.\\.(" +
+      identifier +
+      ")\\.CLAUDE_CODE_EXTRA_BODY&&\\{CLAUDE_CODE_EXTRA_BODY:\\1\\.CLAUDE_CODE_EXTRA_BODY\\}",
+    "g"
+  );
+
+  const interactiveMatches = [...content.matchAll(interactivePattern)];
+  const thinMatches = [...content.matchAll(thinPattern)];
+  const localJsxMatches = [...content.matchAll(localJsxPattern)];
+  const localMatches = [...content.matchAll(localPattern)];
+  const builderMatches = [...content.matchAll(builderPattern)];
+  const workerMatches = [...content.matchAll(workerPattern)];
+  const candidates =
+    interactiveMatches.length +
+    thinMatches.length +
+    localJsxMatches.length +
+    localMatches.length +
+    builderMatches.length +
+    workerMatches.length;
+
+  if (
+    interactiveMatches.length !== 1 ||
+    thinMatches.length !== 1 ||
+    localJsxMatches.length !== 1 ||
+    localMatches.length !== 1 ||
+    builderMatches.length !== 1 ||
+    workerMatches.length !== 1
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const interactive = interactiveMatches[0];
+  const thin = thinMatches[0];
+  const localJsx = localJsxMatches[0];
+  const local = localMatches[0];
+  const builder = builderMatches[0];
+  const worker = workerMatches[0];
+
+  if (
+    interactive[5] !== thin[4] ||
+    interactive[6] !== thin[5] ||
+    local[3] !== local[4]
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const interactiveStart = interactive.index ?? -1;
+  const interactiveEndCandidate = content.indexOf(
+    "async function ",
+    interactiveStart + interactive[0].length
+  );
+  const interactiveEnd = interactiveEndCandidate === -1 ? content.length : interactiveEndCandidate;
+  const interactiveSegment = content.slice(interactiveStart, interactiveEnd);
+  const interactiveAction = interactiveSegment.match(
+    /await ([A-Za-z_$][\w$]*)\([^;]*?"shortcut"/
+  )?.[1];
+  if (
+    interactiveStart === -1 ||
+    !interactiveAction ||
+    !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
+    !interactiveSegment.includes(".getAppState") ||
+    !interactiveSegment.includes(".setAppState") ||
+    !interactiveSegment.includes(".jsx(")
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const thinStart = thin.index ?? -1;
+  const thinEndCandidate = content.indexOf("async function ", thinStart + thin[0].length);
+  const thinEnd = thinEndCandidate === -1 ? content.length : thinEndCandidate;
+  const thinSegment = content.slice(thinStart, thinEnd);
+  const thinAction = thinSegment.match(/await ([A-Za-z_$][\w$]*)\([^;]*?"bridge"/)?.[1];
+  if (
+    thinStart === -1 ||
+    !thinAction ||
+    thinAction !== interactiveAction ||
+    !thinSegment.includes(".options.fastMode") ||
+    !thinSegment.includes("Unknown argument") ||
+    !thinSegment.includes(".getAppState") ||
+    !thinSegment.includes(".setAppState")
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const builderStart = builder.index ?? -1;
+  const builderEndCandidate = content.indexOf("function ", builderStart + builder[0].length);
+  const builderEnd = builderEndCandidate === -1 ? content.length : builderEndCandidate;
+  const builderSegment = content.slice(builderStart, builderEnd);
+  const betaMergeNeedle = `if(${builder[2]}&&${builder[2]}.length>0){`;
+  const builderReturnNeedle = `return ${builder[4]}}`;
+  if (
+    builderStart === -1 ||
+    builderSegment.split(betaMergeNeedle).length - 1 !== 1 ||
+    builderSegment.split(builderReturnNeedle).length - 1 !== 1
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const workerIndex = worker.index ?? -1;
+  const workerStart = content.lastIndexOf("async function ", workerIndex);
+  if (workerIndex === -1 || workerStart === -1) {
+    return { content: original, candidates, patched: 0 };
+  }
+  const workerEndCandidate = content.indexOf("async function ", workerIndex + worker[0].length);
+  const workerEnd = workerEndCandidate === -1 ? content.length : workerEndCandidate;
+  const workerSegment = content.slice(workerStart, workerEnd);
+  if (
+    !workerSegment.includes("env:") ||
+    !workerSegment.includes("respawnFlags:") ||
+    !workerSegment.includes("uea(")
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const helperBlock = String.raw`var __calicoGatewayFastNode={fs:process.getBuiltinModule("fs"),path:process.getBuiltinModule("path"),os:process.getBuiltinModule("os"),crypto:process.getBuiltinModule("crypto")};
+var __calicoGatewayFastState={path:null,dir:null,owner:!1};
+function __calicoGatewayFastEnsure(){if(process.env.REMORA_ACTIVE!=="1")return __calicoGatewayFastState;let e=process.env.CALICO_GATEWAY_FAST_STATE_FILE;if(e){if(__calicoGatewayFastState.path!==e)__calicoGatewayFastState={path:e,dir:null,owner:!1};return __calicoGatewayFastState}if(__calicoGatewayFastState.path){process.env.CALICO_GATEWAY_FAST_STATE_FILE=__calicoGatewayFastState.path;return __calicoGatewayFastState}let t=__calicoGatewayFastNode,r=t.fs.mkdtempSync(t.path.join(t.os.tmpdir(),"calico-gateway-fast-"));try{t.fs.chmodSync(r,0o700);let n=t.path.join(r,"mode");t.fs.writeFileSync(n,"inherit",{encoding:"utf8",mode:0o600,flag:"wx"});t.fs.chmodSync(n,0o600);process.env.CALICO_GATEWAY_FAST_STATE_FILE=n;__calicoGatewayFastState={path:n,dir:r,owner:!0};typeof process.once==="function"&&process.once("exit",()=>{try{t.fs.rmSync(r,{recursive:!0,force:!0})}catch{}});return __calicoGatewayFastState}catch(n){try{t.fs.rmSync(r,{recursive:!0,force:!0})}catch{}throw n}}
+__calicoGatewayFastEnsure();
+function __calicoGatewayFastRead(){let e=__calicoGatewayFastEnsure();if(!e.path)throw Error("gateway fast state is unavailable");let t=__calicoGatewayFastNode.fs.readFileSync(e.path,"utf8");if(t!=="inherit"&&t!=="on"&&t!=="off")throw Error("gateway fast state is invalid");return t}
+function __calicoGatewayFastParse(e){let t=String(e??"");t=t.trim()===""?"{}":t;let r=0;function n(){while(r<t.length&&/\s/.test(t[r]))r++}function o(e=r){if(t[r++]!=='"')throw Error("expected JSON string");while(r<t.length){let n=t[r++];if(n==='"')return JSON.parse(t.slice(e,r));if(n==='\\'){if(r>=t.length)throw Error("invalid JSON escape");let e=t[r++];if(!'"\\/bfnrtu'.includes(e))throw Error("invalid JSON escape");if(e==='u'){if(r+4>t.length||!/^[0-9a-fA-F]{4}$/.test(t.slice(r,r+4)))throw Error("invalid JSON unicode escape");r+=4}}else if(n.charCodeAt(0)<32)throw Error("invalid JSON string character")}throw Error("unterminated JSON string")}
+function i(){n();if(t[r++]!=='{')throw Error("expected JSON object");let e=new Set;n();if(t[r]==='}'){r++;return}for(;;){n();let s=r,a=o(s);if(e.has(a))throw Error('duplicate JSON key "'+a+'"');e.add(a);n();if(t[r++]!==':')throw Error("expected JSON colon");l();n();if(t[r]==='}'){r++;return}if(t[r++]!==',')throw Error("expected JSON comma")}}
+function s(){n();if(t[r++]!=='[')throw Error("expected JSON array");n();if(t[r]===']'){r++;return}for(;;){l();n();if(t[r]===']'){r++;return}if(t[r++]!==',')throw Error("expected JSON comma")}}
+function a(){let e=r;while(r<t.length&&!/[\s,\]}]/.test(t[r]))r++;if(r===e)throw Error("expected JSON value")}
+function l(){n();if(t[r]==='{')return i();if(t[r]==='[')return s();if(t[r]==='"'){o(r);return}a()}
+l();n();if(r!==t.length)throw Error("unexpected JSON content");let c=JSON.parse(t);if(c===null||typeof c!=="object"||Array.isArray(c))throw Error("CLAUDE_CODE_EXTRA_BODY must be a JSON object");(function e(t){if(typeof t==="number"&&!Number.isFinite(t))throw Error("CLAUDE_CODE_EXTRA_BODY contains a non-finite number");if(Array.isArray(t))for(let r of t)e(r);else if(t&&typeof t==="object")for(let r of Object.values(t))e(r)})(c);return c}
+function __calicoGatewayFastTier(e){if(!Object.prototype.hasOwnProperty.call(e,"service_tier"))return!1;let t=e.service_tier;if(t==="fast"||t==="priority")return!0;throw Error('CLAUDE_CODE_EXTRA_BODY service_tier must be "fast" or "priority"')}
+function __calicoGatewayFastRestore(e,t){if(e)process.env.CLAUDE_CODE_EXTRA_BODY=t;else delete process.env.CLAUDE_CODE_EXTRA_BODY}
+function __calicoGatewayFastPublish(e,t,r,n){let o=__calicoGatewayFastEnsure();if(!o.path)throw Error("gateway fast state is unavailable");let i=__calicoGatewayFastNode,s=i.path.dirname(o.path),a=i.path.basename(o.path)+"."+process.pid+"."+i.crypto.randomBytes(8).toString("hex")+".tmp",l=i.path.join(s,a),c=!1;try{i.fs.writeFileSync(l,e,{encoding:"utf8",mode:0o600,flag:"wx"});c=!0;i.fs.chmodSync(l,0o600);process.env.CLAUDE_CODE_EXTRA_BODY=t;i.fs.renameSync(l,o.path)}catch(u){__calicoGatewayFastRestore(r,n);if(c)try{i.fs.unlinkSync(l)}catch{}throw u}}
+function __calicoGatewayFastCommandValue(e){let t=typeof e==="string"?e.trim().toLowerCase():"";if(t!==""&&t!=="on"&&t!=="off")return'Unknown argument "'+t+'". Use: /fast [on|off]';try{let r=__calicoGatewayFastRead(),n=Object.prototype.hasOwnProperty.call(process.env,"CLAUDE_CODE_EXTRA_BODY"),o=process.env.CLAUDE_CODE_EXTRA_BODY,i=__calicoGatewayFastParse(o),s;if(t==="on")s="on";else if(t==="off")s="off";else if(r==="on")s="off";else if(r==="off")s="on";else s=__calicoGatewayFastTier(i)?"off":"on";if(s==="on"){__calicoGatewayFastTier(i);i.service_tier="priority"}else delete i.service_tier;let a=JSON.stringify(i);__calicoGatewayFastPublish(s,a,n,o);return s==="on"?"Gateway priority mode ON (this session only)":"Gateway priority mode OFF (this session only)"}catch(r){return"Gateway priority mode error: "+(r&&r.message?r.message:String(r))}}
+function __calicoGatewayFastInteractive(e,t){e(__calicoGatewayFastCommandValue(t));return null}
+function __calicoGatewayFastThin(e){return{type:"text",value:__calicoGatewayFastCommandValue(e)}}
+function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r}
+`;
+
+  const interactiveReplacement = interactive[0].replace(
+    `if(!${interactive[5]}())return ${interactive[2]}(${interactive[6]}()??"Fast mode is not available"),null;`,
+    `if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastInteractive(${interactive[2]},${interactive[4]});if(!${interactive[5]}())return ${interactive[2]}(${interactive[6]}()??"Fast mode is not available"),null;`
+  );
+  const thinReplacement = thin[0].replace(
+    `if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`,
+    `if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(${thin[2]});if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`
+  );
+
+  const jsxDescription =
+    'get description(){return`Toggle fast mode (${'+localJsx[2]+'()})`}';
+  const jsxGatewayDescription =
+    'get description(){return process.env.REMORA_ACTIVE==="1"?"Toggle gateway priority tier":`Toggle fast mode (${'+localJsx[2]+'()})`}';
+  let localJsxReplacement = localJsx[0].replace(jsxDescription, jsxGatewayDescription);
+  localJsxReplacement = localJsxReplacement.replace(
+    `get isHidden(){return!${localJsx[3]}()}`,
+    `get isHidden(){return process.env.REMORA_ACTIVE==="1"?!1:!${localJsx[3]}()}`
+  );
+
+  const localDescription =
+    'get description(){return`Toggle fast mode (${'+local[2]+'()})`}';
+  const localGatewayDescription =
+    'get description(){return process.env.REMORA_ACTIVE==="1"?"Toggle gateway priority tier":`Toggle fast mode (${'+local[2]+'()})`}';
+  let localReplacement = local[0].replace(localDescription, localGatewayDescription);
+  localReplacement = localReplacement.replace(
+    `isEnabled:()=>${local[3]}(),get isHidden(){return!${local[4]}()}`,
+    `isEnabled:()=>process.env.REMORA_ACTIVE==="1"||${local[3]}(),get isHidden(){return process.env.REMORA_ACTIVE==="1"?!1:!${local[4]}()}`
+  );
+
+  const builderReplacement = builderSegment.replace(
+    betaMergeNeedle,
+    `${builder[4]}=__calicoGatewayFastApply(${builder[4]});${betaMergeNeedle}`
+  );
+  const workerReplacement =
+    worker[0] +
+    `,...${worker[1]}.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:${worker[1]}.CALICO_GATEWAY_FAST_STATE_FILE}`;
+
+  if (
+    interactiveReplacement === interactive[0] ||
+    thinReplacement === thin[0] ||
+    localJsxReplacement === localJsx[0] ||
+    localReplacement === local[0] ||
+    builderReplacement === builderSegment ||
+    helperBlock.includes('speed:"fast"')
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  let output = original;
+  output = output.replace(interactive[0], interactiveReplacement);
+  output = output.replace(thin[0], thinReplacement);
+  output = output.replace(localJsx[0], localJsxReplacement);
+  output = output.replace(local[0], localReplacement);
+  output = output.replace(builderSegment, builderReplacement);
+  output = output.replace(worker[0], workerReplacement);
+
+  const helperIndex = output.indexOf(interactiveReplacement);
+  if (helperIndex === -1) {
+    return { content: original, candidates, patched: 0 };
+  }
+  output = output.slice(0, helperIndex) + helperBlock + output.slice(helperIndex);
+
+  if (
+    output.split("function __calicoGatewayFastEnsure").length - 1 !== 1 ||
+    output.split("function __calicoGatewayFastParse").length - 1 !== 1 ||
+    output.split("function __calicoGatewayFastCommandValue").length - 1 !== 1 ||
+    output.split("function __calicoGatewayFastApply").length - 1 !== 1 ||
+    output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastInteractive').length - 1 !== 1 ||
+    output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin').length - 1 !== 1 ||
+    output.split(`CALICO_GATEWAY_FAST_STATE_FILE:${worker[1]}.CALICO_GATEWAY_FAST_STATE_FILE`).length - 1 !== 1 ||
+    output.split(`${builder[4]}=__calicoGatewayFastApply(${builder[4]});`).length - 1 !== 1
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  return { content: output, candidates, patched: 6 };
+}
 function patchActiveTurnPromptIdentity(content) {
   const original = content;
   let agentCandidates = 0;
@@ -2268,6 +2529,11 @@ function patchActiveTurnPromptIdentity(content) {
 }
 
 const PATCH_MODULES = [
+  {
+    id: "gateway-fast-mode",
+    description: "Expose remora gateway fast-mode controls",
+    apply: patchGatewayFastMode,
+  },
   {
     id: "active-turn-prompt-id",
     description: "Expose stable prompt and per-agent turn identity to remora gateways",
@@ -2497,6 +2763,7 @@ function main() {
 }
 
 module.exports = {
+  patchGatewayFastMode,
   patchActiveTurnPromptIdentity,
   patchBackgroundAgentUsage,
   patchStatuslineCommittedUsage,

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -53,6 +53,279 @@ function markerPresent(content: string, marker: RegExp | string): boolean {
 
 const CHECKS: Check[] = [
   {
+    id: "gateway-fast-mode",
+    kind: "custom",
+    describe: "remora gateway priority mode with shared request-time worker state",
+    run: (content: string): string | null => {
+      const identifier = "[A-Za-z_$][\\w$]*";
+      const nodeDeclaration =
+        'var __calicoGatewayFastNode={fs:process.getBuiltinModule("fs"),path:process.getBuiltinModule("path"),os:process.getBuiltinModule("os"),crypto:process.getBuiltinModule("crypto")};';
+      const stateDeclaration =
+        "var __calicoGatewayFastState={path:null,dir:null,owner:!1};";
+      const applyHelper =
+        'function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r}';
+
+      if (
+        countOccurrences(content, nodeDeclaration) !== 1 ||
+        countOccurrences(content, stateDeclaration) !== 1 ||
+        countOccurrences(content, applyHelper) !== 1
+      ) {
+        return "gateway fast state or request helper is missing, duplicated, or not exact";
+      }
+
+      const helperStart = content.indexOf(nodeDeclaration);
+      const interactiveStartMarker = content.indexOf("\nasync function ", helperStart);
+      if (helperStart === -1 || interactiveStartMarker === -1) {
+        return "gateway helper block is not adjacent to the interactive handler";
+      }
+      const helperBlock = content.slice(helperStart, interactiveStartMarker);
+      if (!helperBlock.endsWith(applyHelper)) {
+        return "gateway helper block is commented, detached, or followed by alternate code";
+      }
+
+      const expectedReferences: Array<[string, number]> = [
+        ["__calicoGatewayFastNode", 4],
+        ["__calicoGatewayFastState", 10],
+        ["__calicoGatewayFastEnsure", 4],
+        ["__calicoGatewayFastRead", 3],
+        ["__calicoGatewayFastParse", 2],
+        ["__calicoGatewayFastTier", 3],
+        ["__calicoGatewayFastRestore", 2],
+        ["__calicoGatewayFastPublish", 2],
+        ["__calicoGatewayFastCommandValue", 3],
+        ["__calicoGatewayFastInteractive", 2],
+        ["__calicoGatewayFastThin", 2],
+        ["__calicoGatewayFastApply", 2],
+      ];
+      for (const [name, expected] of expectedReferences) {
+        const actual = countOccurrences(content, name);
+        if (actual !== expected) {
+          return `expected ${expected} total references to ${name}, found ${actual}`;
+        }
+      }
+
+      for (const name of [
+        "__calicoGatewayFastEnsure",
+        "__calicoGatewayFastRead",
+        "__calicoGatewayFastParse",
+        "__calicoGatewayFastTier",
+        "__calicoGatewayFastRestore",
+        "__calicoGatewayFastPublish",
+        "__calicoGatewayFastCommandValue",
+        "__calicoGatewayFastInteractive",
+        "__calicoGatewayFastThin",
+        "__calicoGatewayFastApply",
+      ]) {
+        if (countOccurrences(content, `function ${name}`) !== 1) {
+          return `expected one function declaration for ${name}`;
+        }
+        const alternateBinding = new RegExp(
+          `(?:var|let|const)\\s+${name}\\b|(?:^|[;,])${name}=`,
+          "m"
+        );
+        if (alternateBinding.test(content)) {
+          return `${name} has an unexpected alternate binding`;
+        }
+      }
+
+      const requiredHelperMarkers = [
+        'writeFileSync(n,"inherit",{encoding:"utf8",mode:0o600,flag:"wx"})',
+        'writeFileSync(l,e,{encoding:"utf8",mode:0o600,flag:"wx"})',
+        "process.env.CLAUDE_CODE_EXTRA_BODY=t;i.fs.renameSync(l,o.path)",
+        "__calicoGatewayFastRestore(r,n)",
+        "JSON.parse(t.slice(e,r))",
+        "duplicate JSON key",
+        "Number.isFinite",
+        'Object.prototype.hasOwnProperty.call(e,"service_tier")',
+        'i.service_tier="priority"',
+        "delete i.service_tier",
+        "__calicoGatewayFastPublish(s,a,n,o)",
+      ];
+      const missingHelperMarkers = requiredHelperMarkers.filter(
+        (marker) => !helperBlock.includes(marker)
+      );
+      if (missingHelperMarkers.length > 0) {
+        return `gateway helper semantics missing marker(s): ${missingHelperMarkers.join(", ")}`;
+      }
+      if (
+        countOccurrences(helperBlock, "CALICO_GATEWAY_FAST_STATE_FILE") !== 3 ||
+        countOccurrences(helperBlock, "writeFileSync(") !== 2 ||
+        countOccurrences(helperBlock, "readFileSync(") !== 1 ||
+        countOccurrences(helperBlock, "renameSync(") !== 1
+      ) {
+        return "gateway mode-file ownership or atomic publish structure is invalid";
+      }
+      if (
+        helperBlock.includes('speed:"fast"') ||
+        helperBlock.includes("writeFileSync(l,t") ||
+        helperBlock.includes("writeFileSync(n,process.env.CLAUDE_CODE_EXTRA_BODY")
+      ) {
+        return "gateway helper injects Anthropic speed or persists the full extra body";
+      }
+
+      const interactivePattern = new RegExp(
+        `async function (${identifier})\\((${identifier}),(${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return __calicoGatewayFastInteractive\\(\\2,\\4\\);if\\(!(${identifier})\\(\\)\\)return \\2\\((${identifier})\\(\\)\\?\\?"Fast mode is not available"\\),null;`,
+        "g"
+      );
+      const interactiveMatches = [...content.matchAll(interactivePattern)];
+      if (
+        interactiveMatches.length !== 1 ||
+        interactiveMatches[0].index !== interactiveStartMarker + 1
+      ) {
+        return "interactive remora branch is missing, duplicated, or not before the native gate";
+      }
+      const interactive = interactiveMatches[0];
+      const interactiveEnd = content.indexOf(
+        "async function ",
+        (interactive.index ?? -1) + interactive[0].length
+      );
+      const interactiveSegment = content.slice(
+        interactive.index ?? -1,
+        interactiveEnd === -1 ? content.length : interactiveEnd
+      );
+      const interactiveAction = interactiveSegment.match(
+        /await ([A-Za-z_$][\w$]*)\([^;]*?"shortcut"/
+      )?.[1];
+      if (
+        !interactiveAction ||
+        !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
+        !interactiveSegment.includes(".getAppState") ||
+        !interactiveSegment.includes(".setAppState") ||
+        !interactiveSegment.includes(".jsx(")
+      ) {
+        return "interactive native Fast action, picker, or app-state fallback is missing";
+      }
+
+      const thinPattern = new RegExp(
+        `async function (${identifier})\\((${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return __calicoGatewayFastThin\\(\\2\\);if\\(!(${identifier})\\(\\)\\)return\\{type:"text",value:(${identifier})\\(\\)\\?\\?"Fast mode is not available"\\};`,
+        "g"
+      );
+      const thinMatches = [...content.matchAll(thinPattern)];
+      if (thinMatches.length !== 1) {
+        return "thin-client remora branch is missing, duplicated, or not before the native gate";
+      }
+      const thin = thinMatches[0];
+      const thinEnd = content.indexOf(
+        "async function ",
+        (thin.index ?? -1) + thin[0].length
+      );
+      const thinSegment = content.slice(
+        thin.index ?? -1,
+        thinEnd === -1 ? content.length : thinEnd
+      );
+      const thinAction = thinSegment.match(
+        /await ([A-Za-z_$][\w$]*)\([^;]*?"bridge"/
+      )?.[1];
+      if (
+        interactive[5] !== thin[4] ||
+        interactive[6] !== thin[5] ||
+        thinAction !== interactiveAction ||
+        !/\.options\.fastMode(?![A-Za-z0-9_$])/.test(thinSegment) ||
+        !thinSegment.includes("Unknown argument") ||
+        !thinSegment.includes(".getAppState") ||
+        !thinSegment.includes(".setAppState")
+      ) {
+        return "thin-client native toggle path no longer shares the native Fast fallback";
+      }
+
+      const localJsxPattern =
+        /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?"Toggle gateway priority tier":`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?!1:!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",get immediate\(\)\{return ([A-Za-z_$][\w$]*)\(\)\},requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
+      const localPattern =
+        /([A-Za-z_$][\w$]*)=\{type:"local",name:"fast",supportsNonInteractive:!0,get description\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?"Toggle gateway priority tier":`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},argumentHint:"\[on\|off\]",isEnabled:\(\)=>process\.env\.REMORA_ACTIVE==="1"\|\|([A-Za-z_$][\w$]*)\(\),get isHidden\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?!1:!([A-Za-z_$][\w$]*)\(\)\}/g;
+      const localJsxMatches = [...content.matchAll(localJsxPattern)];
+      const localMatches = [...content.matchAll(localPattern)];
+      if (localJsxMatches.length !== 1 || localMatches.length !== 1) {
+        return "gateway-aware Fast command registrations are missing or duplicated";
+      }
+      if (
+        localJsxMatches[0][2] !== localMatches[0][2] ||
+        localJsxMatches[0][3] !== interactive[5] ||
+        localMatches[0][3] !== localMatches[0][4]
+      ) {
+        return "Fast registrations changed native description or visibility gate ownership";
+      }
+
+      const builderPattern = new RegExp(
+        `function (${identifier})\\((${identifier})\\)\\{let (${identifier})=process\\.env\\.CLAUDE_CODE_EXTRA_BODY,(${identifier})=\\{\\};`,
+        "g"
+      );
+      const builderMatches = [...content.matchAll(builderPattern)];
+      if (builderMatches.length !== 1) {
+        return `expected one request extra-body builder, found ${builderMatches.length}`;
+      }
+      const builder = builderMatches[0];
+      const builderStart = builder.index ?? -1;
+      const builderEndCandidate = content.indexOf("function ", builderStart + builder[0].length);
+      const builderEnd = builderEndCandidate === -1 ? content.length : builderEndCandidate;
+      const builderSegment = content.slice(builderStart, builderEnd);
+      const applyNeedle = `${builder[4]}=__calicoGatewayFastApply(${builder[4]});`;
+      const betaNeedle = `if(${builder[2]}&&${builder[2]}.length>0){`;
+      const parseErrorIndex = builderSegment.indexOf(
+        "Error parsing CLAUDE_CODE_EXTRA_BODY:"
+      );
+      const parseCompletionNeedle = ',{level:"error"})}';
+      const parseCompletionIndex = builderSegment.indexOf(
+        parseCompletionNeedle,
+        parseErrorIndex
+      );
+      const applyIndex = builderSegment.indexOf(applyNeedle);
+      const betaIndex = builderSegment.indexOf(betaNeedle);
+      if (
+        countOccurrences(builderSegment, applyNeedle) !== 1 ||
+        countOccurrences(builderSegment, betaNeedle) !== 1 ||
+        parseErrorIndex === -1 ||
+        parseCompletionIndex === -1 ||
+        applyIndex !== parseCompletionIndex + parseCompletionNeedle.length ||
+        applyIndex > betaIndex ||
+        builderSegment.includes('speed:"fast"') ||
+        builderSegment.includes('.speed="fast"') ||
+        !builderSegment.includes("CLAUDE_CODE_EXTRA_BODY env var must be a JSON object") ||
+        !builderSegment.includes(`return ${builder[4]}}`)
+      ) {
+        return "request-time mode application is not between native parsing and beta merge";
+      }
+
+      const workerPattern = new RegExp(
+        `\\.\\.\\.(${identifier})\\.CLAUDE_CODE_EXTRA_BODY&&\\{CLAUDE_CODE_EXTRA_BODY:\\1\\.CLAUDE_CODE_EXTRA_BODY\\},\\.\\.\\.\\1\\.CALICO_GATEWAY_FAST_STATE_FILE&&\\{CALICO_GATEWAY_FAST_STATE_FILE:\\1\\.CALICO_GATEWAY_FAST_STATE_FILE\\},\\.\\.\\.\\1\\.PATH&&\\{PATH:\\1\\.PATH\\}`,
+        "g"
+      );
+      const workerMatches = [...content.matchAll(workerPattern)];
+      if (workerMatches.length !== 1) {
+        return "worker dispatch does not propagate exactly one shared-state locator";
+      }
+      const worker = workerMatches[0];
+      const workerIndex = worker.index ?? -1;
+      const workerStart = content.lastIndexOf("async function ", workerIndex);
+      const workerEndCandidate = content.indexOf(
+        "async function ",
+        workerIndex + worker[0].length
+      );
+      const workerEnd = workerEndCandidate === -1 ? content.length : workerEndCandidate;
+      const workerSegment = content.slice(workerStart, workerEnd);
+      const workerLocalIndex = workerIndex - workerStart;
+      const respawnIndex = workerSegment.lastIndexOf(
+        "respawnFlags:",
+        workerLocalIndex
+      );
+      const envIndex = workerSegment.lastIndexOf("env:", workerLocalIndex);
+      const dispatchIndex = workerSegment.indexOf(
+        "uea(",
+        workerLocalIndex + worker[0].length
+      );
+      if (
+        workerStart === -1 ||
+        respawnIndex === -1 ||
+        envIndex < respawnIndex ||
+        envIndex > workerLocalIndex ||
+        dispatchIndex === -1
+      ) {
+        return "shared locator is detached from the worker/respawn dispatch record";
+      }
+
+      return null;
+    },
+  },
+  {
     id: "active-turn-prompt-id",
     kind: "custom",
     describe: "remora-scoped prompt identity header with per-agent frozen turn id",

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -1,0 +1,405 @@
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const { patchGatewayFastMode } = require("../patch-claude-display.ts");
+
+const fixture = `
+var nativeAvailable=!1,nativeReason="Fast mode is not available",nativeCalls=[],pickerCalls=0,logs=[];
+function sl(){return nativeAvailable}
+function IDe(){return nativeReason}
+async function Ujt(){}
+async function jTo(e,t,r,n,o,i=!0){nativeCalls.push({enabled:e,source:n,persist:i});return e?"Native Fast mode ON":"Native Fast mode OFF"}
+function M(){pickerCalls++}
+var ug={jsx:(component,props)=>({component,props})},Gun=function Gun(){};
+function R9(){return"claude-opus-4-8"}
+function usr(){return!0}
+function pn(){return nativeAvailable}
+function rwd(){}
+function twd(){}
+async function Wj_(e,t,r){if(!sl())return e(IDe()??"Fast mode is not available"),null;await Ujt();let n=r?.trim().toLowerCase();if(n==="on"||n==="off"){let i=await jTo(n==="on",t.getAppState,t.setAppState,"shortcut",t.onQueryEvent);return e(i),null}let o=IDe();return M("tengu_fast_mode_picker_shown",{unavailable_reason:o??""}),ug.jsx(Gun,{onDone:e,unavailableReason:o})}
+async function VPy(e,t){if(!sl())return{type:"text",value:IDe()??"Fast mode is not available"};await Ujt();let r=e.trim().toLowerCase(),n;if(r==="on")n=!0;else if(r==="off")n=!1;else if(r==="")n=!t.options.fastMode;else return{type:"text",value:\`Unknown argument "\${r}". Use: /fast [on|off]\`};return{type:"text",value:await jTo(n,t.getAppState,t.setAppState,"bridge",t.onQueryEvent,!t.options.isNonInteractiveSession)}}
+var zPy={type:"local-jsx",name:"fast",get description(){return\`Toggle fast mode (\${R9()})\`},get isHidden(){return!sl()},argumentHint:"[on|off]",get immediate(){return usr()},requires:{ink:!0},thinClientDispatch:"control-request"};
+var wSs={type:"local",name:"fast",supportsNonInteractive:!0,get description(){return\`Toggle fast mode (\${R9()})\`},argumentHint:"[on|off]",isEnabled:()=>pn(),get isHidden(){return!pn()},load:()=>Promise.resolve().then(() => (rwd(),twd))};
+function Ol(e){return JSON.parse(e)}
+function C(e,t){logs.push({message:e,options:t})}
+function uL(e){return e}
+function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};if(t)try{let n=Ol(t);if(n&&typeof n==="object"&&!Array.isArray(n))r={...n};else C(\`CLAUDE_CODE_EXTRA_BODY env var must be a JSON object, but was given \${t}\`,{level:"error"})}catch(n){C(\`Error parsing CLAUDE_CODE_EXTRA_BODY: \${n.message}\`,{level:"error"})}if(e&&e.length>0){let n=uL(e);if(r.anthropic_beta&&Array.isArray(r.anthropic_beta)){let o=r.anthropic_beta,i=n.filter((s)=>!o.includes(s));r.anthropic_beta=[...o,...i]}else r.anthropic_beta=n}return r}
+async function uea(e){return e}
+async function BF_(e,t,r,n,o,i){let I=t,ye=r,w=["--resume"],U={respawnFlags:w,env:{...I,...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.PATH&&{PATH:ye.PATH}}};return uea(U)}
+`;
+
+let nextPid = 41000;
+
+function createFsFacade() {
+  const facade = Object.create(fs);
+  facade.failRename = false;
+  facade.renameSync = (...args) => {
+    if (facade.failRename) {
+      throw new Error("rename failed");
+    }
+    return fs.renameSync(...args);
+  };
+  return facade;
+}
+
+function runtime(t, { env = {}, source = fixture, fsFacade = createFsFacade() } = {}) {
+  const result = patchGatewayFastMode(source);
+  assert.equal(result.candidates, 6);
+  assert.equal(result.patched, 6);
+
+  const modules = { fs: fsFacade, path, os, crypto };
+  const fakeProcess = {
+    env: { ...env },
+    pid: nextPid++,
+    getBuiltinModule(name) {
+      return modules[name];
+    },
+    once() {},
+  };
+  const context = { console, process: fakeProcess };
+  vm.createContext(context);
+  vm.runInContext(result.content, context);
+
+  const locator = context.process.env.CALICO_GATEWAY_FAST_STATE_FILE;
+  if (locator && !env.CALICO_GATEWAY_FAST_STATE_FILE) {
+    t.after(() => fs.rmSync(path.dirname(locator), { recursive: true, force: true }));
+  }
+  return { context, result, fsFacade };
+}
+
+function appState(options = {}) {
+  return {
+    getAppState() {
+      return {};
+    },
+    setAppState() {},
+    onQueryEvent() {},
+    options: { fastMode: false, isNonInteractiveSession: false, ...options },
+  };
+}
+
+function readMode(context) {
+  return fs.readFileSync(context.process.env.CALICO_GATEWAY_FAST_STATE_FILE, "utf8");
+}
+
+function parsedEnv(context) {
+  return JSON.parse(context.process.env.CLAUDE_CODE_EXTRA_BODY);
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function renameToken(source, from, to) {
+  const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return source.replace(
+    new RegExp(`(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`, "g"),
+    to
+  );
+}
+
+test("remora interactive and thin commands toggle gateway priority without native Fast", async (t) => {
+  const { context } = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: '{"keep":1}' },
+  });
+  let message;
+
+  assert.equal(await context.Wj_((value) => (message = value), appState(), "on"), null);
+  assert.match(message, /priority mode ON/);
+  assert.deepEqual(parsedEnv(context), { keep: 1, service_tier: "priority" });
+  assert.equal(readMode(context), "on");
+  assert.deepEqual(plain(context.nativeCalls), []);
+  assert.equal(context.pickerCalls, 0);
+
+  const requestBody = plain(context.tHt(["beta-a"]));
+  assert.deepEqual(requestBody, {
+    keep: 1,
+    service_tier: "priority",
+    anthropic_beta: ["beta-a"],
+  });
+  assert.equal("speed" in requestBody, false);
+
+  const off = await context.VPy("off", appState());
+  assert.deepEqual(plain(off), {
+    type: "text",
+    value: "Gateway priority mode OFF (this session only)",
+  });
+  assert.deepEqual(parsedEnv(context), { keep: 1 });
+  assert.equal(readMode(context), "off");
+
+  await context.VPy("", appState());
+  assert.equal(readMode(context), "on");
+  await context.Wj_((value) => (message = value), appState(), "");
+  assert.match(message, /priority mode OFF/);
+  assert.equal(readMode(context), "off");
+  assert.equal(context.pickerCalls, 0);
+
+  const beforeEnv = context.process.env.CLAUDE_CODE_EXTRA_BODY;
+  const beforeMode = readMode(context);
+  const unknown = await context.VPy("later", appState());
+  assert.match(unknown.value, /Unknown argument "later"/);
+  assert.equal(context.process.env.CLAUDE_CODE_EXTRA_BODY, beforeEnv);
+  assert.equal(readMode(context), beforeMode);
+});
+
+test("non-remora sessions preserve native gates, actions, picker, and registrations", async (t) => {
+  const { context } = runtime(t);
+  let message;
+
+  await context.Wj_((value) => (message = value), appState(), "on");
+  assert.equal(message, "Fast mode is not available");
+  assert.deepEqual(plain(context.nativeCalls), []);
+  assert.equal(context.zPy.isHidden, true);
+  assert.equal(context.wSs.isEnabled(), false);
+  assert.equal(context.wSs.isHidden, true);
+  assert.equal(context.zPy.description, "Toggle fast mode (claude-opus-4-8)");
+
+  context.nativeAvailable = true;
+  await context.Wj_((value) => (message = value), appState(), "on");
+  assert.equal(message, "Native Fast mode ON");
+  assert.equal(context.nativeCalls.at(-1).source, "shortcut");
+
+  const picker = await context.Wj_(() => undefined, appState(), "");
+  assert.equal(picker.component, context.Gun);
+  assert.equal(context.pickerCalls, 1);
+
+  const thin = await context.VPy("", appState({ fastMode: true }));
+  assert.equal(thin.value, "Native Fast mode OFF");
+  assert.equal(context.nativeCalls.at(-1).source, "bridge");
+  assert.equal(context.zPy.isHidden, false);
+  assert.equal(context.wSs.isEnabled(), true);
+  assert.equal(context.wSs.isHidden, false);
+});
+
+test("remora registrations stay visible and describe the gateway tier", (t) => {
+  const { context } = runtime(t, { env: { REMORA_ACTIVE: "1" } });
+  assert.equal(context.zPy.isHidden, false);
+  assert.equal(context.wSs.isEnabled(), true);
+  assert.equal(context.wSs.isHidden, false);
+  assert.equal(context.zPy.description, "Toggle gateway priority tier");
+  assert.equal(context.wSs.description, "Toggle gateway priority tier");
+  assert.equal(context.zPy.thinClientDispatch, "control-request");
+});
+
+test("strict JSON handling preserves fields and enforces tier semantics", async (t) => {
+  const accepted = runtime(t, {
+    env: {
+      REMORA_ACTIVE: "1",
+      CLAUDE_CODE_EXTRA_BODY: String.raw`{"nested":{"ok":true},"service_tier":"fast"}`,
+    },
+  }).context;
+  await accepted.VPy("on", appState());
+  assert.deepEqual(parsedEnv(accepted), {
+    nested: { ok: true },
+    service_tier: "priority",
+  });
+
+  const literalEscape = runtime(t, {
+    env: {
+      REMORA_ACTIVE: "1",
+      CLAUDE_CODE_EXTRA_BODY: String.raw`{"a":1,"\\u0061":2}`,
+    },
+  }).context;
+  const literalResult = await literalEscape.VPy("on", appState());
+  assert.match(literalResult.value, /priority mode ON/);
+  assert.equal(parsedEnv(literalEscape).a, 1);
+  assert.equal(parsedEnv(literalEscape)["\\u0061"], 2);
+
+  const conflictingOff = runtime(t, {
+    env: {
+      REMORA_ACTIVE: "1",
+      CLAUDE_CODE_EXTRA_BODY:
+        '{"keep":{"service_tier":"nested"},"service_tier":"standard"}',
+    },
+  }).context;
+  await conflictingOff.VPy("off", appState());
+  assert.deepEqual(parsedEnv(conflictingOff), {
+    keep: { service_tier: "nested" },
+  });
+
+  const blank = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: "   " },
+  }).context;
+  await blank.VPy("on", appState());
+  assert.deepEqual(parsedEnv(blank), { service_tier: "priority" });
+});
+
+test("invalid JSON, duplicate keys, non-finite values, and conflicting on are atomic", async (t) => {
+  const cases = [
+    ['{"a":', /JSON|unexpected|unterminated/i],
+    ["[]", /must be a JSON object/],
+    [
+      '{"outer":{"a":1,"' + String.fromCharCode(92) + 'u0061":2}}',
+      /duplicate JSON key/,
+    ],
+    ['{"value":NaN}', /JSON|unexpected/i],
+    ['{"value":Infinity}', /JSON|unexpected/i],
+    ['{"value":-Infinity}', /JSON|unexpected/i],
+    ['{"value":1e9999}', /non-finite/],
+    ['{"service_tier":"standard","keep":1}', /service_tier/],
+  ];
+
+  for (const [body, errorPattern] of cases) {
+    const { context } = runtime(t, {
+      env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: body },
+    });
+    const beforeMode = readMode(context);
+    const result = await context.VPy("on", appState());
+    assert.match(result.value, errorPattern, body);
+    assert.equal(context.process.env.CLAUDE_CODE_EXTRA_BODY, body, body);
+    assert.equal(readMode(context), beforeMode, body);
+  }
+});
+
+test("bare inherit derives current state from the strict body", async (t) => {
+  const inheritedOn = runtime(t, {
+    env: {
+      REMORA_ACTIVE: "1",
+      CLAUDE_CODE_EXTRA_BODY: '{"keep":1,"service_tier":"priority"}',
+    },
+  }).context;
+  assert.equal(readMode(inheritedOn), "inherit");
+  assert.equal(plain(inheritedOn.tHt([])).service_tier, "priority");
+  await inheritedOn.VPy("", appState());
+  assert.equal(readMode(inheritedOn), "off");
+  assert.deepEqual(parsedEnv(inheritedOn), { keep: 1 });
+
+  const inheritedOff = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: '{"keep":2}' },
+  }).context;
+  await inheritedOff.VPy("", appState());
+  assert.equal(readMode(inheritedOff), "on");
+  assert.deepEqual(parsedEnv(inheritedOff), { keep: 2, service_tier: "priority" });
+});
+
+test("existing, new, and respawned workers read the shared mode on every request", async (t) => {
+  const main = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: '{"main":1}' },
+  }).context;
+  const locator = main.process.env.CALICO_GATEWAY_FAST_STATE_FILE;
+  const workerEnv = {
+    REMORA_ACTIVE: "1",
+    CALICO_GATEWAY_FAST_STATE_FILE: locator,
+    CLAUDE_CODE_EXTRA_BODY: '{"worker":1,"service_tier":"stale"}',
+  };
+  const existingWorker = runtime(t, { env: workerEnv }).context;
+
+  await main.VPy("on", appState());
+  assert.deepEqual(plain(existingWorker.tHt([])), {
+    worker: 1,
+    service_tier: "priority",
+  });
+
+  const dispatch = await main.BF_(null, { BASE: "1" }, main.process.env);
+  assert.equal(dispatch.env.CALICO_GATEWAY_FAST_STATE_FILE, locator);
+  const newWorker = runtime(t, {
+    env: { ...workerEnv, ...dispatch.env, CLAUDE_CODE_EXTRA_BODY: '{"new":1}' },
+  }).context;
+  assert.equal(plain(newWorker.tHt([])).service_tier, "priority");
+
+  await main.VPy("off", appState());
+  assert.deepEqual(plain(existingWorker.tHt([])), { worker: 1 });
+  assert.deepEqual(plain(newWorker.tHt([])), { new: 1 });
+
+  const respawned = runtime(t, {
+    env: {
+      ...workerEnv,
+      CALICO_GATEWAY_FAST_STATE_FILE: dispatch.env.CALICO_GATEWAY_FAST_STATE_FILE,
+      CLAUDE_CODE_EXTRA_BODY: '{"respawn":1,"service_tier":"old"}',
+    },
+  }).context;
+  assert.deepEqual(plain(respawned.tHt([])), { respawn: 1 });
+});
+
+test("state read failures abort request-time body construction", async (t) => {
+  const { context } = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: '{"service_tier":"priority"}' },
+  });
+  const locator = context.process.env.CALICO_GATEWAY_FAST_STATE_FILE;
+
+  fs.writeFileSync(locator, "invalid", "utf8");
+  assert.throws(() => context.tHt([]), /state is invalid/);
+
+  fs.unlinkSync(locator);
+  assert.throws(() => context.tHt([]), /ENOENT/);
+
+  const unreadablePath = path.dirname(locator);
+  const unreadable = runtime(t, {
+    env: {
+      REMORA_ACTIVE: "1",
+      CALICO_GATEWAY_FAST_STATE_FILE: unreadablePath,
+      CLAUDE_CODE_EXTRA_BODY: '{"service_tier":"priority"}',
+    },
+  }).context;
+  assert.throws(() => unreadable.tHt([]), /EISDIR|illegal operation|directory/i);
+});
+
+test("rename failure restores the exact env string and old mode", async (t) => {
+  const fsFacade = createFsFacade();
+  const originalBody = '{ "keep" : 1 }';
+  const { context } = runtime(t, {
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: originalBody },
+    fsFacade,
+  });
+  const locator = context.process.env.CALICO_GATEWAY_FAST_STATE_FILE;
+  fsFacade.failRename = true;
+
+  const result = await context.VPy("on", appState());
+  assert.match(result.value, /rename failed/);
+  assert.equal(context.process.env.CLAUDE_CODE_EXTRA_BODY, originalBody);
+  assert.equal(readMode(context), "inherit");
+  assert.deepEqual(fs.readdirSync(path.dirname(locator)), ["mode"]);
+});
+
+test("matches renamed identifiers", async (t) => {
+  const renamed = [
+    ["Wj_", "Qj_"],
+    ["VPy", "KPy"],
+    ["zPy", "aPy"],
+    ["wSs", "bSs"],
+    ["tHt", "qHt"],
+    ["BF_", "RF_"],
+    ["sl", "gate"],
+    ["IDe", "reason"],
+    ["jTo", "nativeSet"],
+    ["R9", "modelLabel"],
+    ["e", "argE"],
+    ["t", "ctxT"],
+    ["r", "argR"],
+  ].reduce((source, [from, to]) => renameToken(source, from, to), fixture);
+  const { context } = runtime(t, {
+    source: renamed,
+    env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: "{}" },
+  });
+
+  const result = await context.KPy("on", appState());
+  assert.match(result.value, /priority mode ON/);
+  assert.equal(plain(context.qHt([])).service_tier, "priority");
+});
+
+test("fails atomically when a required anchor is missing or duplicated", () => {
+  const brokenFixtures = [
+    fixture.replace("async function Wj_", "async function_changed Wj_"),
+    fixture.replace("async function VPy", "async function_changed VPy"),
+    fixture.replace('type:"local-jsx",name:"fast"', 'type:"local-jsx",name:"slow"'),
+    fixture.replace('type:"local",name:"fast"', 'type:"local",name:"slow"'),
+    fixture.replace("process.env.CLAUDE_CODE_EXTRA_BODY,r={}", "process.env.EXTRA_BODY,r={}"),
+    fixture.replace(
+      "...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY}",
+      "...ye.EXTRA_BODY&&{EXTRA_BODY:ye.EXTRA_BODY}"
+    ),
+    fixture + fixture,
+  ];
+
+  for (const broken of brokenFixtures) {
+    const result = patchGatewayFastMode(broken);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, broken);
+    assert.equal(result.content.includes("__calicoGatewayFastEnsure"), false);
+  }
+});

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -7,6 +7,9 @@ const test = require("node:test");
 const vm = require("node:vm");
 
 const { patchGatewayFastMode } = require("../patch-claude-display.ts");
+const {
+  evaluatePatchModule,
+} = require("../scripts/verify-patched-binary.ts");
 
 const fixture = `
 var nativeAvailable=!1,nativeReason="Fast mode is not available",nativeCalls=[],pickerCalls=0,logs=[];
@@ -401,5 +404,113 @@ test("fails atomically when a required anchor is missing or duplicated", () => {
     assert.equal(result.patched, 0);
     assert.equal(result.content, broken);
     assert.equal(result.content.includes("__calicoGatewayFastEnsure"), false);
+  }
+});
+
+test("binary verifier accepts the complete gateway fast-mode structure", () => {
+  const patched = patchGatewayFastMode(fixture).content;
+  assert.equal(evaluatePatchModule("gateway-fast-mode", patched), null);
+});
+
+test("binary verifier rejects detached helpers and broken gateway ownership", () => {
+  const patched = patchGatewayFastMode(fixture).content;
+  const helperStart = patched.indexOf("var __calicoGatewayFastNode=");
+  const interactiveStart = patched.indexOf("async function Wj_", helperStart);
+  const helperBlock = patched.slice(helperStart, interactiveStart);
+  const applyHelper = helperBlock.match(
+    /function __calicoGatewayFastApply[\s\S]*$/
+  )?.[0];
+  const builderStart = patched.indexOf("function tHt(");
+  const builderEnd = patched.indexOf("async function uea", builderStart);
+  assert.ok(applyHelper);
+  assert.notEqual(builderStart, -1);
+  assert.ok(builderEnd > builderStart);
+  const builderBlock = patched.slice(builderStart, builderEnd);
+
+  const commentOnlyHelpers =
+    patched.slice(0, helperStart) +
+    `/*${helperBlock}*/` +
+    patched.slice(interactiveStart);
+  const alternateApply = patched.replace(
+    applyHelper,
+    `var __calicoGatewayFastApply=()=>{};/*${applyHelper}*/`
+  );
+  const withoutThinBranch = patched.replace(
+    'if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(e);',
+    ""
+  );
+  const withoutNativeAction = patched.replace('"shortcut"', '"shortcut-broken"');
+  const applyAfterBetaMerge = patched.replace(
+    builderBlock,
+    builderBlock
+      .replace("r=__calicoGatewayFastApply(r);", "")
+      .replace("return r}", "r=__calicoGatewayFastApply(r);return r}")
+  );
+  const applyBeforeNativeParse = patched
+    .replace(
+      "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
+      "if(e&&e.length>0){"
+    )
+    .replace(
+      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};",
+      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};r=__calicoGatewayFastApply(r);"
+    );
+  const applyInsideNativeCatch = patched.replace(
+    ',{level:"error"})}r=__calicoGatewayFastApply(r);',
+    ',{level:"error"});r=__calicoGatewayFastApply(r)}'
+  );
+  const withoutWorkerLocator = patched.replace(
+    ",...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE}",
+    ""
+  );
+  const nativeOnlyRegistration = patched.replace(
+    'process.env.REMORA_ACTIVE==="1"?"Toggle gateway priority tier":',
+    ""
+  );
+  const wrongVisibilityOwner = patched.replace(
+    'process.env.REMORA_ACTIVE==="1"?!1:!sl()',
+    'process.env.REMORA_ACTIVE==="1"?!1:!pn()'
+  );
+  const injectedAnthropicSpeed = patched.replace(
+    "function __calicoGatewayFastApply",
+    'var __calicoGatewayFastLeak={speed:"fast"};function __calicoGatewayFastApply'
+  );
+  const injectedBuilderSpeed = patched.replace(
+    "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
+    'r=__calicoGatewayFastApply(r);r.speed="fast";if(e&&e.length>0){'
+  );
+  const persistedExtraBody = patched.replace(
+    "writeFileSync(l,e,{encoding:",
+    "writeFileSync(l,t,{encoding:"
+  );
+  const staleThinToggle = patched.replace(".options.fastMode", ".options.fastModeBroken");
+  const workerEnvPair =
+    ",...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE}";
+  const detachedWorkerEnv = patched
+    .replace(workerEnvPair, "")
+    .replace(
+      "}};return uea(U)",
+      `},detachedEnv:{${workerEnvPair.slice(1)}}};return uea(U)`
+    );
+
+  for (const [name, broken] of [
+    ["comment-only helpers", commentOnlyHelpers],
+    ["alternate apply binding", alternateApply],
+    ["missing thin branch", withoutThinBranch],
+    ["missing native action", withoutNativeAction],
+    ["apply after beta merge", applyAfterBetaMerge],
+    ["apply before native parse", applyBeforeNativeParse],
+    ["apply inside native catch", applyInsideNativeCatch],
+    ["missing worker locator", withoutWorkerLocator],
+    ["detached worker env", detachedWorkerEnv],
+    ["native-only registration", nativeOnlyRegistration],
+    ["wrong visibility owner", wrongVisibilityOwner],
+    ["Anthropic helper speed injection", injectedAnthropicSpeed],
+    ["Anthropic builder speed injection", injectedBuilderSpeed],
+    ["persisted extra body", persistedExtraBody],
+    ["stale thin toggle", staleThinToggle],
+  ]) {
+    assert.notEqual(broken, patched, `${name} mutation did not change the fixture`);
+    assert.notEqual(evaluatePatchModule("gateway-fast-mode", broken), null, name);
   }
 });


### PR DESCRIPTION
## Summary

- extend Claude Code's built-in `/fast` command with remora/GPT gateway behavior when `REMORA_ACTIVE=1`
- support `/fast on`, `/fast off`, and bare toggle through both interactive and thin/non-interactive command paths
- apply `service_tier: "priority"` at request time without injecting Anthropic's `speed: "fast"`
- preserve the native Anthropic Fast availability gates, picker, app state, telemetry, model switching, descriptions, and visibility outside remora

## Runtime design

The patch uses `CALICO_GATEWAY_FAST_STATE_FILE` as a private session locator. Its mode file stores only `inherit`, `on`, or `off`; the complete extra body is never persisted.

The command process keeps `CLAUDE_CODE_EXTRA_BODY` as a local mirror, while every request producer rereads the shared mode and applies it to that process's parsed body. This lets already-running workers and respawned workers observe the next successful toggle without relying on stale process environments.

Publishing a mode uses an owner-only same-directory temporary file, synchronous local-env update, and atomic rename. Write or rename failure restores the exact prior environment and leaves the previous published mode authoritative. Missing, unreadable, or invalid shared state aborts request construction rather than falling back to stale worker data.

## Command semantics

- blank extra body is treated as `{}`
- the top level must be a non-array object
- duplicate decoded keys are rejected recursively, including Unicode-escape aliases
- non-finite numbers and numeric overflow are rejected
- `on` accepts an absent tier or `fast`/`priority`, then normalizes to `priority`
- `off` removes only the outer `service_tier`, preserving unrelated and nested fields
- bare `/fast` derives the effective state under `inherit`, then publishes the opposite explicit mode
- existing `remora --fast` behavior remains priority while the shared mode is `inherit`

## Patch ownership and verification

`gateway-fast-mode` atomically owns six Claude Code 2.1.211 semantic surfaces:

1. interactive `/fast` handler
2. thin/control handler
3. `local-jsx` registration
4. non-interactive `local` registration
5. shared extra-body request builder
6. initial/respawn worker environment dispatch

If any anchor is missing, duplicated, or belongs to the wrong surrounding flow, the module returns the original bundle with `patched: 0`.

The binary verifier checks executable helper ownership, native fallthrough, registration ownership, parse → mode apply → beta merge order, and locator placement beside raw extra-body/PATH worker snapshots. Adversarial fixture mutations cover detached/commented helpers, alternate bindings, missing handlers, native fallback loss, incorrect builder ordering, catch-only application, detached worker env data, full-body persistence, `speed` injection, and stale thin toggles.

## Validation

- `npm test`: **60/60 passed**
- exact Claude Code 2.1.211 patch pipeline with `--assert-all`: `gateway-fast-mode` **6/6**, all selected modules patched
- full patched-binary verifier: **15/15 modules passed**
- patched binary runtime version marker confirmed
- live sanitized gateway capture confirmed:
  - stream on/off/bare tiers: `priority → absent → priority → absent`
  - `remora --fast` inherit then off: `priority → absent`
  - unrelated metadata preserved on every captured request
  - conflicting tier rejected without modifying the inherited body
  - missing, invalid, unreadable, and live-removed state produced an error with no stale POST
  - same existing worker PID observed `absent → priority` on the next request with the same prompt ID
  - new worker while on sent priority
  - new worker while off removed a stale raw priority snapshot
  - forced worker crash respawned under a new PID and still removed the stale raw priority snapshot
  - no captured GPT gateway request contained `speed`
- non-remora interactive `/fast on` retained the native usage-credit availability reason, and bare `/fast` opened the native Fast picker
- fresh-context outcome verifier: **CONFIRMED**

Changing the effective body/tier can produce one expected prompt-cache miss on the following request because the cache key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
