### PR TITLE
fix: support Claude Code 2.1.212 patch variants

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -180,8 +180,15 @@ Atomicity and verification:
 - tracker construction, assistant accounting, registry progress, and completion anchors are matched
   by semantic bundle shape rather than platform-varying minified function names; each must occur
   exactly once or the module returns `patched: 0`
+- Claude Code 2.1.211 finalizes with `finalize(result, owner, options, {suppressTelemetry})`;
+  2.1.212 uses `finalize(result, owner, optionsWithModelsUsed, {suppressTelemetry})`, where the third
+  argument is exactly `{...options, modelsUsed:modelSet}`. These are two syntax variants of one
+  completion role: their result, status, owner, and transcript locals are normalized, and both variants
+  present together are rejected
+- the injected refresh is appended after the matched native completion, so `modelsUsed` and telemetry
+  metadata are not rebuilt or dropped
 - `scripts/verify-patched-binary.ts` requires both helpers, the response-ID map, terminal stream
-  support, and both transcript refresh seams
+  support, both transcript refresh seams, and exactly one owned completion variant
 - regression tests cover provisional `0/0`, native message-start input, terminal GPT usage,
   repeated frames, late wrapper mutation, direct completed wrappers, and multi-turn totals
 
@@ -203,6 +210,9 @@ Source of truth:
 
 - the canonical query-stream assistant wrapper is created provisionally with a shared object cell:
   `__calicoUsageState:{committed:!1,usage:null}`
+- Claude Code 2.1.212 appends `...effortLocal!==void 0&&{effort:effortLocal}` after the existing
+  advisor metadata; the cell is inserted immediately after the native `...!1` marker so both metadata
+  spreads remain byte-for-byte intact
 - production app state shallow-copies the wrapper before the terminal event; the shared object cell
   survives that copy, unlike the old primitive top-level boolean which remained stale `false`
 - the normal terminal `message_delta` mutation loop is the only path that can set `committed:!0`
@@ -257,11 +267,15 @@ Atomicity and verification:
 - the wrapper, canonical `case"message_delta"` aggregation, terminal loop, both clone
   registrations, clone-sync loop, and status-line selector are matched by semantic bundle shape
   rather than platform-varying minified locals; each anchor must occur exactly once
+- legacy advisor-only and 2.1.212 advisor-plus-effort tails are syntax variants of one wrapper role;
+  the effort condition and property must use the same local, and both variants present together fail
 - if any required anchor is missing or repeated, the module returns the original bundle with
   `patched: 0`
 - `scripts/verify-patched-binary.ts` checks commit-cell/helper/selector occurrence counts, confirms
   downstream clones synchronize wrapper ownership, and rejects snapshot assignments that escape
   the canonical terminal loop or appear in message-stop/UI reducer paths
+- an owned background `modelsUsed` completion is the 2.1.212 bundle signal; when present, the verifier
+  requires the effort-bearing wrapper instead of treating the effort tail as optional
 
 Likely break signs:
 
@@ -309,7 +323,7 @@ Atomic publish:
 - write or rename failure restores the exact prior env presence/value and removes the temporary file;
   the previously published mode remains authoritative
 
-Claude Code 2.1.211 semantic anchors:
+Claude Code 2.1.211–2.1.212 semantic anchors:
 
 - the interactive handler is identified by the native availability reason, `"shortcut"` Fast action,
   picker telemetry, JSX picker fallback, and app-state access
@@ -319,8 +333,10 @@ Claude Code 2.1.211 semantic anchors:
   owns non-interactive support; both retain the same native model-description getter
 - the request-body builder parses `CLAUDE_CODE_EXTRA_BODY`, validates that the native result is an
   object, merges `anthropic_beta`, and returns the resulting body
-- the worker dispatch record owns `respawnFlags`, the raw extra-body/PATH env snapshots, and the
-  `uea(...)` launch call used by initial and respawned workers
+- the worker dispatch record owns `proto`, `short`, `sessionId`, `respawnFlags`, and the raw
+  extra-body/PATH env snapshots. The same record must be passed exactly once to a direct dispatch call
+  inside awaited `Promise.all`; the dispatch function's minified symbol is not an anchor (`uea(U)` in
+  2.1.211 and `Jia(J)` in 2.1.212 are examples, not fixed names)
 - all six surfaces must be discovered exactly once before any replacement is applied; otherwise the
   module returns the original bundle with `patched: 0`
 
@@ -356,8 +372,9 @@ Atomicity and verification:
   preserved native fallbacks, registration ownership, parse-then-apply-then-beta order, and the
   locator beside raw extra-body/PATH snapshots in the worker respawn dispatch record
 - verifier mutations cover commented/rebound helpers, missing command surfaces, parse/beta drift,
-  catch-only application, detached worker env data, registration drift, full-body persistence,
-  Anthropic speed injection, and stale thin toggles
+  catch-only application, detached worker env data, wrong-record/outside-`Promise.all`/callback-deferred
+  or duplicate dispatch, registration drift, full-body persistence, Anthropic speed injection, and
+  stale thin toggles
 - fixture tests model shared request-time state, but they do not replace live proof with a real
   existing worker process, thin client, request-capture gateway, and respawn
 
@@ -726,20 +743,27 @@ node patch-claude-display.ts --file ./content.js --list-patches
 node patch-claude-display.ts --file ./content.js --dry-run
 ```
 
-## CI Caveat
+## CI and Release Caveats
 
-Current CI behavior is not a proof that patching happened.
+The patch workflow now uses `--assert-all`, runs the structural binary verifier, and checks the
+runtime `(patched)` marker on executable runners. Those per-platform checks are necessary, but five
+matrix jobs still create five GitHub Releases independently; publication is not cross-platform atomic.
 
-- the workflow uploads `work/${OUT_BASE}.patched`
-- that file path is created by copying the original binary first
-- if the patcher makes no changes, the job can still succeed
-- runtime `--version` output is printed, but the workflow does not currently assert on `(patched)`
+For a version-wide release:
 
-So when investigating release correctness, treat these as strong signals, in order:
+1. pin the approved merge commit with an immutable provenance tag and dispatch from that tag, not a
+   mutable default branch
+2. pre-create each platform base tag at the same approved commit because `gh release create` without
+   `--target` otherwise creates a missing tag from the current default branch
+3. identify the exact workflow run ID created by each dispatch and verify its `headSha`; do not infer
+   provenance from the latest run
+4. a `force=false` retry can fill a missing platform only when that platform has no GitHub Release.
+   An incomplete Release can already exist after a failed upload and will be skipped on retry; stop and
+   obtain an explicit disposition instead of deleting, force-publishing, or claiming success
+5. download every released binary and `checksums.txt`, verify the digest, then verify the provenance
+   attestation subject, source commit, signer workflow, and run ID against the accepted run
 
-1. nonzero patch counts for the expected modules
-2. runtime `--version` output including `(patched)`
-3. different checksums between original and patched binaries
+Do not report a partial set of platform Releases as a complete version release.
 
 ## Maintenance Notes
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1823,12 +1823,31 @@ function patchBackgroundAgentUsage(content) {
           "g"
         )
       : null;
-  const completionPattern = new RegExp(
+  const legacyCompletionPattern = new RegExp(
     `let (${identifierPattern})=(${identifierPattern})\\((${identifierPattern}),(${identifierPattern}),(${identifierPattern})\\),(${identifierPattern})=(${identifierPattern})\\(\\1,\\4,(${identifierPattern}),\\{suppressTelemetry:(${identifierPattern})\\}\\);`,
     "g"
   );
+  const modelsUsedCompletionPattern = new RegExp(
+    `let (${identifierPattern})=(${identifierPattern})\\((${identifierPattern}),(${identifierPattern}),(${identifierPattern})\\),(${identifierPattern})=(${identifierPattern})\\(\\1,\\4,\\{\\.\\.\\.(${identifierPattern}),modelsUsed:(${identifierPattern})\\},\\{suppressTelemetry:(${identifierPattern})\\}\\);`,
+    "g"
+  );
   const progressMatches = progressPattern ? [...content.matchAll(progressPattern)] : [];
-  const completionMatches = [...content.matchAll(completionPattern)];
+  const completionMatches = [
+    ...[...content.matchAll(legacyCompletionPattern)].map((match) => ({
+      match,
+      result: match[1],
+      status: match[3],
+      owner: match[4],
+      transcript: match[5],
+    })),
+    ...[...content.matchAll(modelsUsedCompletionPattern)].map((match) => ({
+      match,
+      result: match[1],
+      status: match[3],
+      owner: match[4],
+      transcript: match[5],
+    })),
+  ];
   const progressMatch = progressMatches[0];
   const completionMatch = completionMatches[0];
   const progressOwner = progressMatch?.[6];
@@ -1838,11 +1857,11 @@ function patchBackgroundAgentUsage(content) {
     progressIndex === -1 ? -1 : content.lastIndexOf("function ", progressIndex);
   const progressEnd =
     progressIndex === -1 || !progressMatch ? -1 : progressIndex + progressMatch[0].length;
-  const completionResult = completionMatch?.[1];
-  const completionStatus = completionMatch?.[3];
-  const completionOwner = completionMatch?.[4];
-  const completionTranscript = completionMatch?.[5];
-  const completionIndex = completionMatch?.index ?? -1;
+  const completionResult = completionMatch?.result;
+  const completionStatus = completionMatch?.status;
+  const completionOwner = completionMatch?.owner;
+  const completionTranscript = completionMatch?.transcript;
+  const completionIndex = completionMatch?.match.index ?? -1;
   const completionFunctionStart =
     completionIndex === -1 ? -1 : content.lastIndexOf("function ", completionIndex);
   const progressToCompletionSegment =
@@ -1898,7 +1917,10 @@ function patchBackgroundAgentUsage(content) {
   let output = original.replace(trackerPattern, trackerReplacement);
   output = output.replace(accountingPattern, eventReplacement);
   output = output.replace(progressPattern, progressReplacement);
-  output = output.replace(completionPattern, (full) => full + completionRefresh);
+  output = output.replace(
+    completionMatch.match[0],
+    completionMatch.match[0] + completionRefresh
+  );
 
   if (
     output.split("function __calicoTrackAgentUsage").length - 1 !== 1 ||

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2320,10 +2320,88 @@ function patchGatewayFastMode(content) {
   const workerEndCandidate = content.indexOf("async function ", workerIndex + worker[0].length);
   const workerEnd = workerEndCandidate === -1 ? content.length : workerEndCandidate;
   const workerSegment = content.slice(workerStart, workerEnd);
+  const workerLocalIndex = workerIndex - workerStart;
+  function findObjectEnd(source, openIndex) {
+    if (source[openIndex] !== "{") return -1;
+    let depth = 0;
+    let quote = null;
+    let escaped = false;
+    for (let index = openIndex; index < source.length; index += 1) {
+      const character = source[index];
+      if (quote !== null) {
+        if (escaped) escaped = false;
+        else if (character === "\\") escaped = true;
+        else if (character === quote) quote = null;
+        continue;
+      }
+      if (character === '"' || character === "'" || character === "`") {
+        quote = character;
+      } else if (character === "{") {
+        depth += 1;
+      } else if (character === "}") {
+        depth -= 1;
+        if (depth === 0) return index;
+      }
+    }
+    return -1;
+  }
+  const dispatchRecordPattern = new RegExp(
+    "let (" +
+      identifier +
+      ")=\\{proto:" +
+      identifier +
+      ",short:" +
+      identifier +
+      ",sessionId:" +
+      identifier +
+      ",",
+    "g"
+  );
+  const dispatchRecords = [...workerSegment.matchAll(dispatchRecordPattern)]
+    .map((match) => {
+      const recordStart = match.index ?? -1;
+      const recordOpen = recordStart + match[0].indexOf("{");
+      const recordEnd = findObjectEnd(workerSegment, recordOpen);
+      const respawnIndex = workerSegment.indexOf("respawnFlags:", recordStart + match[0].length);
+      const envIndex = workerSegment.indexOf("env:{", respawnIndex);
+      const envEnd = findObjectEnd(workerSegment, envIndex + "env:".length);
+      return { match, recordStart, recordEnd, respawnIndex, envIndex, envEnd };
+    })
+    .filter(
+      ({ recordStart, recordEnd, respawnIndex, envIndex, envEnd }) =>
+        recordStart !== -1 &&
+        recordStart < respawnIndex &&
+        respawnIndex < envIndex &&
+        envIndex < workerLocalIndex &&
+        workerLocalIndex < envEnd &&
+        envEnd < recordEnd
+    );
+  if (dispatchRecords.length !== 1) {
+    return { content: original, candidates, patched: 0 };
+  }
+  const dispatchRecord = dispatchRecords[0];
+  const dispatchRecordLocal = dispatchRecord.match[1];
+  const awaitedDispatchPattern = new RegExp(
+    "\\},\\[,(" +
+      identifier +
+      ")\\]=await Promise\\.all\\(\\[(?:(?!\\]\\))[\\s\\S])*?,(" +
+      identifier +
+      ")\\(" +
+      dispatchRecordLocal +
+      "\\)\\]\\)",
+    "g"
+  );
+  const awaitedDispatches = [...workerSegment.matchAll(awaitedDispatchPattern)];
+  const directDispatchPattern = new RegExp(
+    "(" + identifier + ")\\(" + dispatchRecordLocal + "\\)",
+    "g"
+  );
+  const directDispatches = [...workerSegment.matchAll(directDispatchPattern)];
   if (
-    !workerSegment.includes("env:") ||
-    !workerSegment.includes("respawnFlags:") ||
-    !workerSegment.includes("uea(")
+    awaitedDispatches.length !== 1 ||
+    directDispatches.length !== 1 ||
+    (awaitedDispatches[0].index ?? -1) !== dispatchRecord.recordEnd ||
+    awaitedDispatches[0][2] !== directDispatches[0][1]
   ) {
     return { content: original, candidates, patched: 0 };
   }

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1944,8 +1944,12 @@ function patchStatuslineCommittedUsage(content) {
     `function (${identifierPattern})\\((${identifierPattern})\\)\\{for\\(let (${identifierPattern})=\\2\\.length-1;\\3>=0;\\3--\\)\\{let (${identifierPattern})=\\2\\[\\3\\],(${identifierPattern})=\\4\\?(${identifierPattern})\\(\\4\\):void 0;if\\(\\5\\)return\\{input_tokens:\\5\\.input_tokens,output_tokens:\\5\\.output_tokens,cache_creation_input_tokens:\\5\\.cache_creation_input_tokens\\?\\?0,cache_read_input_tokens:\\5\\.cache_read_input_tokens\\?\\?0\\}\\}return null\\}`,
     "g"
   );
-  const wrapperPattern = new RegExp(
+  const legacyWrapperPattern = new RegExp(
     `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\}\\};`,
+    "g"
+  );
+  const effortWrapperPattern = new RegExp(
+    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
     "g"
   );
   const terminalPattern = new RegExp(
@@ -1964,10 +1968,21 @@ function patchStatuslineCommittedUsage(content) {
         "g"
       )
     : null;
-  const wrapperMatches = [...content.matchAll(wrapperPattern)];
+  const wrapperMatches = [
+    ...[...content.matchAll(legacyWrapperPattern)].map((match) => ({
+      match,
+      effortCondition: null,
+      effortProperty: null,
+    })),
+    ...[...content.matchAll(effortWrapperPattern)].map((match) => ({
+      match,
+      effortCondition: match[11],
+      effortProperty: match[12],
+    })),
+  ];
   const wrapperMatch = wrapperMatches[0];
-  const wrapperIndex = wrapperMatch?.index ?? -1;
-  const wrapperLocal = wrapperMatch?.[1];
+  const wrapperIndex = wrapperMatch?.match.index ?? -1;
+  const wrapperLocal = wrapperMatch?.match[1];
   const wrapperFunctionStart = wrapperIndex === -1 ? -1 : content.lastIndexOf("function ", wrapperIndex);
   const terminalMatches = [...content.matchAll(terminalPattern)];
   const terminalMatch = terminalMatches[0];
@@ -2081,7 +2096,7 @@ function patchStatuslineCommittedUsage(content) {
   const wrapperFunctionEnd =
     wrapperIndex === -1 || !wrapperMatch
       ? -1
-      : content.indexOf("function ", wrapperIndex + wrapperMatch[0].length);
+      : content.indexOf("function ", wrapperIndex + wrapperMatch.match[0].length);
   const wrapperFunctionSegment =
     wrapperFunctionStart === -1
       ? ""
@@ -2107,12 +2122,16 @@ function patchStatuslineCommittedUsage(content) {
   const wrapperOwnsTerminalArray =
     terminalIndex > wrapperIndex &&
     wrapperPushPattern !== null &&
-    wrapperPushPattern.test(content.slice(wrapperIndex + (wrapperMatch?.[0].length ?? 0), terminalIndex));
+    wrapperPushPattern.test(
+      content.slice(wrapperIndex + (wrapperMatch?.match[0].length ?? 0), terminalIndex)
+    );
   const cloneArrayIsDistinctFromTerminal = cloneArray !== terminalArray;
 
   if (
     reducerMatches.length !== 1 ||
     wrapperCount !== 1 ||
+    (wrapperMatch.effortCondition !== null &&
+      wrapperMatch.effortCondition !== wrapperMatch.effortProperty) ||
     terminalCount !== 1 ||
     aggregationCount !== 1 ||
     cloneMatches.length !== 2 ||
@@ -2133,14 +2152,15 @@ function patchStatuslineCommittedUsage(content) {
     'function __calicoUsageHasAccountingSignal(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)}' +
     'function __calicoUsageIsExactAllZero(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)}' +
     'function __calicoStatuslineMessages(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})}';
-  const wrapperTailPattern = new RegExp(
-    `,\\.\\.\\.!1,\\.\\.\\.${identifierPattern}&&\\{advisorModel:${identifierPattern}\\}\\};$`
+  const wrapperStateNeedle = ",...!1,";
+  const wrapperReplacement = wrapperMatch.match[0].replace(
+    wrapperStateNeedle,
+    ",...!1,__calicoUsageState:{committed:!1,usage:null},"
   );
-  const wrapperReplacement = wrapperMatch[0].replace(
-    wrapperTailPattern,
-    `,...!1,__calicoUsageState:{committed:!1,usage:null},...${wrapperMatch[10]}&&{advisorModel:${wrapperMatch[10]}}};`
-  );
-  if (wrapperReplacement === wrapperMatch[0]) {
+  if (
+    wrapperMatch.match[0].split(wrapperStateNeedle).length - 1 !== 1 ||
+    wrapperReplacement === wrapperMatch.match[0]
+  ) {
     return { content: original, candidates, patched: 0 };
   }
   const terminalReplacement = `for(let ${terminalItem} of ${terminalArray})${terminalItem}.message.usage=${terminalUsage},${terminalItem}.message.stop_reason=${terminalStop},${terminalItem}.message.stop_details=${terminalRawEvent}.delta.stop_details??null,${terminalStop}!=null&&!__calicoUsageIsExactAllZero(${terminalRawEvent}.usage)&&__calicoUsageHasAccountingSignal(${terminalUsage})&&(${terminalItem}.__calicoUsageState.committed=!0,${terminalItem}.__calicoUsageState.usage=${terminalUsage});`;
@@ -2153,7 +2173,7 @@ function patchStatuslineCommittedUsage(content) {
   const selectorMatch = selectorMatches[0];
   const selectorReplacement = `${selectorMatch[1]}=${reducerName}(__calicoStatuslineMessages(${selectorMatch[2]})),${selectorMatch[3]}=${selectorMatch[4]}(${selectorMatch[5]},${selectorMatch[6]}())`;
 
-  let output = original.replace(wrapperPattern, wrapperReplacement);
+  let output = original.replace(wrapperMatch.match[0], wrapperReplacement);
   output = output.replace(terminalPattern, terminalReplacement);
   let cloneIndex = 0;
   output = output.replace(cloneRegistrationPattern, () => cloneReplacements[cloneIndex++]);

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -506,17 +506,48 @@ const CHECKS: Check[] = [
         return "background progress refresh calls a different event-accounting function";
       }
 
-      const completionPattern = new RegExp(
+      const legacyCompletionPattern = new RegExp(
         `let (${identifier})=(${identifier})\\((${identifier}),(${identifier}),(${identifier})\\),(${identifier})=(${identifier})\\(\\1,\\4,(${identifier}),\\{suppressTelemetry:(${identifier})\\}\\);__calicoRefreshAgentUsage\\((${identifier}),\\1\\),(${identifier})\\((${identifier}),(${identifier})\\((${identifier})\\),(${identifier})\\);`,
         "g"
       );
-      const completionMatches = [...content.matchAll(completionPattern)];
+      const modelsUsedCompletionPattern = new RegExp(
+        `let (${identifier})=(${identifier})\\((${identifier}),(${identifier}),(${identifier})\\),(${identifier})=(${identifier})\\(\\1,\\4,\\{\\.\\.\\.(${identifier}),modelsUsed:(${identifier})\\},\\{suppressTelemetry:(${identifier})\\}\\);__calicoRefreshAgentUsage\\((${identifier}),\\1\\),(${identifier})\\((${identifier}),(${identifier})\\((${identifier})\\),(${identifier})\\);`,
+        "g"
+      );
+      const completionMatches = [
+        ...[...content.matchAll(legacyCompletionPattern)].map((match) => ({
+          match,
+          result: match[1],
+          status: match[3],
+          owner: match[4],
+          transcript: match[5],
+          refreshTracker: match[10],
+          refreshFunction: match[11],
+          refreshOwner: match[12],
+          summaryFunction: match[13],
+          summaryTracker: match[14],
+          refreshStatus: match[15],
+        })),
+        ...[...content.matchAll(modelsUsedCompletionPattern)].map((match) => ({
+          match,
+          result: match[1],
+          status: match[3],
+          owner: match[4],
+          transcript: match[5],
+          refreshTracker: match[11],
+          refreshFunction: match[12],
+          refreshOwner: match[13],
+          summaryFunction: match[14],
+          summaryTracker: match[15],
+          refreshStatus: match[16],
+        })),
+      ];
       if (completionMatches.length !== 1) {
         return `expected 1 semantic background completion refresh, found ${completionMatches.length}`;
       }
       const completion = completionMatches[0];
       const progressIndex = progress.index ?? -1;
-      const completionIndex = completion.index ?? -1;
+      const completionIndex = completion.match.index ?? -1;
       const progressEnd =
         progressIndex === -1 ? -1 : progressIndex + progress[0].length;
       const progressFunctionStart = content.lastIndexOf("function ", progressIndex);
@@ -531,15 +562,15 @@ const CHECKS: Check[] = [
         completionIndex < progressEnd ||
         progressToCompletionSegment.includes("=>") ||
         progressToCompletionSegment.includes("function ") ||
-        completion[10] !== progress[2] ||
-        completion[12] !== completion[4] ||
-        completion[14] !== progress[2] ||
-        completion[15] !== completion[3] ||
-        progress[6] !== completion[5] ||
-        progress[7] !== completion[11] ||
-        progress[8] !== completion[4] ||
-        progress[9] !== completion[13] ||
-        progress[10] !== completion[3]
+        completion.refreshTracker !== progress[2] ||
+        completion.refreshOwner !== completion.owner ||
+        completion.summaryTracker !== progress[2] ||
+        completion.refreshStatus !== completion.status ||
+        progress[6] !== completion.transcript ||
+        progress[7] !== completion.refreshFunction ||
+        progress[8] !== completion.owner ||
+        progress[9] !== completion.summaryFunction ||
+        progress[10] !== completion.status
       ) {
         return "background progress/completion refresh seams do not share tracker ownership";
       }

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -303,23 +303,78 @@ const CHECKS: Check[] = [
       const workerEnd = workerEndCandidate === -1 ? content.length : workerEndCandidate;
       const workerSegment = content.slice(workerStart, workerEnd);
       const workerLocalIndex = workerIndex - workerStart;
-      const respawnIndex = workerSegment.lastIndexOf(
-        "respawnFlags:",
-        workerLocalIndex
+      function findObjectEnd(source: string, openIndex: number): number {
+        if (source[openIndex] !== "{") return -1;
+        let depth = 0;
+        let quote: string | null = null;
+        let escaped = false;
+        for (let index = openIndex; index < source.length; index += 1) {
+          const character = source[index];
+          if (quote !== null) {
+            if (escaped) escaped = false;
+            else if (character === "\\") escaped = true;
+            else if (character === quote) quote = null;
+            continue;
+          }
+          if (character === '"' || character === "'" || character === "`") {
+            quote = character;
+          } else if (character === "{") {
+            depth += 1;
+          } else if (character === "}") {
+            depth -= 1;
+            if (depth === 0) return index;
+          }
+        }
+        return -1;
+      }
+      const dispatchRecordPattern = new RegExp(
+        `let (${identifier})=\\{proto:${identifier},short:${identifier},sessionId:${identifier},`,
+        "g"
       );
-      const envIndex = workerSegment.lastIndexOf("env:", workerLocalIndex);
-      const dispatchIndex = workerSegment.indexOf(
-        "uea(",
-        workerLocalIndex + worker[0].length
-      );
-      if (
-        workerStart === -1 ||
-        respawnIndex === -1 ||
-        envIndex < respawnIndex ||
-        envIndex > workerLocalIndex ||
-        dispatchIndex === -1
-      ) {
+      const dispatchRecords = [...workerSegment.matchAll(dispatchRecordPattern)]
+        .map((match) => {
+          const recordStart = match.index ?? -1;
+          const recordOpen = recordStart + match[0].indexOf("{");
+          const recordEnd = findObjectEnd(workerSegment, recordOpen);
+          const respawnIndex = workerSegment.indexOf(
+            "respawnFlags:",
+            recordStart + match[0].length
+          );
+          const envIndex = workerSegment.indexOf("env:{", respawnIndex);
+          const envEnd = findObjectEnd(workerSegment, envIndex + "env:".length);
+          return { match, recordStart, recordEnd, respawnIndex, envIndex, envEnd };
+        })
+        .filter(
+          ({ recordStart, recordEnd, respawnIndex, envIndex, envEnd }) =>
+            recordStart !== -1 &&
+            recordStart < respawnIndex &&
+            respawnIndex < envIndex &&
+            envIndex < workerLocalIndex &&
+            workerLocalIndex < envEnd &&
+            envEnd < recordEnd
+        );
+      if (workerStart === -1 || dispatchRecords.length !== 1) {
         return "shared locator is detached from the worker/respawn dispatch record";
+      }
+      const dispatchRecord = dispatchRecords[0];
+      const dispatchRecordLocal = dispatchRecord.match[1];
+      const awaitedDispatchPattern = new RegExp(
+        `\\},\\[,(${identifier})\\]=await Promise\\.all\\(\\[(?:(?!\\]\\))[\\s\\S])*?,(${identifier})\\(${dispatchRecordLocal}\\)\\]\\)`,
+        "g"
+      );
+      const awaitedDispatches = [...workerSegment.matchAll(awaitedDispatchPattern)];
+      const directDispatchPattern = new RegExp(
+        `(${identifier})\\(${dispatchRecordLocal}\\)`,
+        "g"
+      );
+      const directDispatches = [...workerSegment.matchAll(directDispatchPattern)];
+      if (
+        awaitedDispatches.length !== 1 ||
+        directDispatches.length !== 1 ||
+        (awaitedDispatches[0].index ?? -1) !== dispatchRecord.recordEnd ||
+        awaitedDispatches[0][2] !== directDispatches[0][1]
+      ) {
+        return "worker record is not directly dispatched once through awaited Promise.all";
       }
 
       return null;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -642,17 +642,59 @@ const CHECKS: Check[] = [
         }
       }
 
-      const wrapperPattern = new RegExp(
+      const legacyWrapperPattern = new RegExp(
         `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\}\\};`,
         "g"
       );
-      const wrapperMatches = [...content.matchAll(wrapperPattern)];
+      const effortWrapperPattern = new RegExp(
+        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        "g"
+      );
+      const wrapperMatches = [
+        ...[...content.matchAll(legacyWrapperPattern)].map((match) => ({
+          match,
+          effortCondition: null,
+          effortProperty: null,
+        })),
+        ...[...content.matchAll(effortWrapperPattern)].map((match) => ({
+          match,
+          effortCondition: match[11],
+          effortProperty: match[12],
+        })),
+      ];
       if (wrapperMatches.length !== 1) {
         return `expected 1 canonical wrapper-owned usage cell, found ${wrapperMatches.length}`;
       }
       const wrapper = wrapperMatches[0];
-      const wrapperLocal = wrapper[1];
-      const wrapperIndex = wrapper.index ?? -1;
+      if (
+        wrapper.effortCondition !== null &&
+        wrapper.effortCondition !== wrapper.effortProperty
+      ) {
+        return "statusline effort condition and property use different locals";
+      }
+      const modelsUsedCompletionSignalPattern = new RegExp(
+        `let (${identifier})=(${identifier})\\((${identifier}),(${identifier}),(${identifier})\\),(${identifier})=(${identifier})\\(\\1,\\4,\\{\\.\\.\\.(${identifier}),modelsUsed:(${identifier})\\},\\{suppressTelemetry:(${identifier})\\}\\);__calicoRefreshAgentUsage\\((${identifier}),\\1\\),(${identifier})\\((${identifier}),(${identifier})\\((${identifier})\\),(${identifier})\\);`,
+        "g"
+      );
+      const modelsUsedCompletionSignals = [
+        ...content.matchAll(modelsUsedCompletionSignalPattern),
+      ].filter(
+        (match) =>
+          match[13] === match[4] &&
+          match[15] === match[11] &&
+          match[16] === match[3]
+      );
+      if (modelsUsedCompletionSignals.length > 1) {
+        return "ambiguous 2.1.212 background modelsUsed completion signal";
+      }
+      if (
+        modelsUsedCompletionSignals.length === 1 &&
+        wrapper.effortCondition === null
+      ) {
+        return "2.1.212 modelsUsed completion requires an effort-bearing statusline wrapper";
+      }
+      const wrapperLocal = wrapper.match[1];
+      const wrapperIndex = wrapper.match.index ?? -1;
       const wrapperFunctionStart = content.lastIndexOf("function ", wrapperIndex);
 
       const terminalPattern = new RegExp(

--- a/tests/background-agent-usage.test.js
+++ b/tests/background-agent-usage.test.js
@@ -25,6 +25,13 @@ function renameToken(source, from, to) {
   );
 }
 
+function modelsUsedFixture(source = fixture) {
+  return source.replace(
+    "let oe=RTy(s,e,g),de=fCs(oe,e,n,{suppressTelemetry:ee});",
+    "let oe=RTy(s,e,g),de=fCs(oe,e,{...n,modelsUsed:_},{suppressTelemetry:ee});"
+  );
+}
+
 function renamedFixture() {
   const renames = [
     ["fQn", "uQn"],
@@ -251,6 +258,56 @@ test("matches renamed function, parameter, and seam locals", () => {
   const tracker = context.uQn();
   context.pQn(tracker, assistant("renamed", { input_tokens: 17, output_tokens: 4 }));
   assert.equal(context.dQn(tracker), 21);
+});
+
+test("accepts the 2.1.212 modelsUsed completion variant without changing metadata", () => {
+  const source = modelsUsedFixture();
+  const result = patchBackgroundAgentUsage(source);
+
+  assert.equal(result.candidates, 4);
+  assert.equal(result.patched, 4);
+  assert.match(
+    result.content,
+    /de=fCs\(oe,e,\{\.\.\.n,modelsUsed:_\},\{suppressTelemetry:ee\}\);__calicoRefreshAgentUsage\(re,oe\),Z0u\(e,a9r\(re\),s\);/
+  );
+  assert.equal(evaluatePatchModule("background-agent-usage", result.content), null);
+  const wrongTranscriptRefresh = result.content.replace(
+    "__calicoRefreshAgentUsage(re,g)",
+    "__calicoRefreshAgentUsage(re,otherTranscript)"
+  );
+  assert.notEqual(wrongTranscriptRefresh, result.content);
+  assert.notEqual(
+    evaluatePatchModule("background-agent-usage", wrongTranscriptRefresh),
+    null
+  );
+});
+
+test("modelsUsed completion keeps one owner, status, transcript, and semantic role", () => {
+  const source = modelsUsedFixture();
+  const progress = "hQn(re,_e,ie,i.options.tools),Z0u(e,a9r(re),s);";
+  const completion =
+    "let oe=RTy(s,e,g),de=fCs(oe,e,{...n,modelsUsed:_},{suppressTelemetry:ee});";
+  const splitFunctions = source.replace(
+    `function asyncLoopFixture(){${progress}${completion}if(tRu(de,s))return}`,
+    `function progressFixture(){${progress}}function completionFixture(){${completion}if(tRu(de,s))return}`
+  );
+  const brokenFixtures = [
+    source.replace("RTy(s,e,g)", "RTy(otherStatus,e,g)"),
+    source.replace("RTy(s,e,g)", "RTy(s,otherOwner,g)"),
+    source.replace(completion, `queueMicrotask(()=>{${completion}});`),
+    source.replace(
+      completion,
+      `${completion}let ox=RTy(s,e,g),dx=fCs(ox,e,n,{suppressTelemetry:ee});`
+    ),
+    splitFunctions,
+  ];
+
+  for (const broken of brokenFixtures) {
+    const result = patchBackgroundAgentUsage(broken);
+    assert.notEqual(broken, source);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, broken);
+  }
 });
 
 test("binary verifier rejects empty helpers hidden behind dead exact markers", () => {

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -33,7 +33,7 @@ function C(e,t){logs.push({message:e,options:t})}
 function uL(e){return e}
 function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};if(t)try{let n=Ol(t);if(n&&typeof n==="object"&&!Array.isArray(n))r={...n};else C(\`CLAUDE_CODE_EXTRA_BODY env var must be a JSON object, but was given \${t}\`,{level:"error"})}catch(n){C(\`Error parsing CLAUDE_CODE_EXTRA_BODY: \${n.message}\`,{level:"error"})}if(e&&e.length>0){let n=uL(e);if(r.anthropic_beta&&Array.isArray(r.anthropic_beta)){let o=r.anthropic_beta,i=n.filter((s)=>!o.includes(s));r.anthropic_beta=[...o,...i]}else r.anthropic_beta=n}return r}
 async function uea(e){return e}
-async function BF_(e,t,r,n,o,i){let I=t,ye=r,w=["--resume"],U={respawnFlags:w,env:{...I,...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.PATH&&{PATH:ye.PATH}}};return uea(U)}
+async function BF_(e,t,r,n,o,i){let nm="proto",a="short",s="session",I=t,ye=r,w=["--resume"];let U={proto:nm,short:a,sessionId:s,respawnFlags:w,env:{...I,...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.PATH&&{PATH:ye.PATH}},reattachEnv:o},[,Q]=await Promise.all([Promise.resolve(),uea(U)]);return Q}
 `;
 
 let nextPid = 41000;
@@ -104,6 +104,16 @@ function renameToken(source, from, to) {
     new RegExp(`(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`, "g"),
     to
   );
+}
+
+function fixture212() {
+  return [
+    ["uea", "Jia"],
+    ["BF_", "GWy"],
+    ["nm", "bm"],
+    ["U", "J"],
+    ["Q", "ne"],
+  ].reduce((source, [from, to]) => renameToken(source, from, to), fixture);
 }
 
 test("remora interactive and thin commands toggle gateway priority without native Fast", async (t) => {
@@ -385,6 +395,54 @@ test("matches renamed identifiers", async (t) => {
   assert.equal(plain(context.qHt([])).service_tier, "priority");
 });
 
+test("accepts 2.1.211 and 2.1.212 worker dispatch symbols through record ownership", async (t) => {
+  for (const [source, functionName] of [
+    [fixture, "BF_"],
+    [fixture212(), "GWy"],
+  ]) {
+    const { context } = runtime(t, {
+      source,
+      env: { REMORA_ACTIVE: "1", CLAUDE_CODE_EXTRA_BODY: "{}" },
+    });
+    const dispatch = await context[functionName](null, { BASE: "1" }, context.process.env);
+    assert.equal(
+      dispatch.env.CALICO_GATEWAY_FAST_STATE_FILE,
+      context.process.env.CALICO_GATEWAY_FAST_STATE_FILE
+    );
+  }
+});
+
+test("rejects detached, indirect, wrong-record, and duplicate worker dispatches", () => {
+  const workerEnv =
+    "...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.PATH&&{PATH:ye.PATH}";
+  const brokenFixtures = [
+    fixture.replace("uea(U)", "uea(J)"),
+    fixture.replace(
+      "},[,Q]=await Promise.all([Promise.resolve(),uea(U)]);return Q",
+      "};let Q=await uea(U);return Q"
+    ),
+    fixture.replace(
+      "uea(U)",
+      "Promise.resolve().then(()=>uea(U))"
+    ),
+    fixture.replace(
+      `env:{...I,${workerEnv}},reattachEnv:o`,
+      `env:{...I},detachedEnv:{${workerEnv}},reattachEnv:o`
+    ),
+    fixture.replace(
+      "return Q}",
+      "await uea(U);return Q}"
+    ),
+  ];
+
+  for (const broken of brokenFixtures) {
+    const result = patchGatewayFastMode(broken);
+    assert.notEqual(broken, fixture);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, broken);
+  }
+});
+
 test("fails atomically when a required anchor is missing or duplicated", () => {
   const brokenFixtures = [
     fixture.replace("async function Wj_", "async function_changed Wj_"),
@@ -485,13 +543,21 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
   );
   const staleThinToggle = patched.replace(".options.fastMode", ".options.fastModeBroken");
   const workerEnvPair =
-    ",...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE}";
-  const detachedWorkerEnv = patched
-    .replace(workerEnvPair, "")
-    .replace(
-      "}};return uea(U)",
-      `},detachedEnv:{${workerEnvPair.slice(1)}}};return uea(U)`
-    );
+    ",...ye.CLAUDE_CODE_EXTRA_BODY&&{CLAUDE_CODE_EXTRA_BODY:ye.CLAUDE_CODE_EXTRA_BODY},...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE},...ye.PATH&&{PATH:ye.PATH}";
+  const detachedWorkerEnv = patched.replace(
+    `env:{...I${workerEnvPair}},reattachEnv:o`,
+    `env:{...I},detachedEnv:{${workerEnvPair.slice(1)}},reattachEnv:o`
+  );
+  const wrongDispatchRecord = patched.replace("uea(U)", "uea(J)");
+  const dispatchOutsidePromiseAll = patched.replace(
+    "},[,Q]=await Promise.all([Promise.resolve(),uea(U)]);return Q",
+    "};let Q=await uea(U);return Q"
+  );
+  const callbackDeferredDispatch = patched.replace(
+    "uea(U)",
+    "Promise.resolve().then(()=>uea(U))"
+  );
+  const duplicateDispatch = patched.replace("return Q}", "await uea(U);return Q}");
 
   for (const [name, broken] of [
     ["comment-only helpers", commentOnlyHelpers],
@@ -503,6 +569,10 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     ["apply inside native catch", applyInsideNativeCatch],
     ["missing worker locator", withoutWorkerLocator],
     ["detached worker env", detachedWorkerEnv],
+    ["wrong dispatch record", wrongDispatchRecord],
+    ["dispatch outside Promise.all", dispatchOutsidePromiseAll],
+    ["callback-deferred dispatch", callbackDeferredDispatch],
+    ["duplicate dispatch", duplicateDispatch],
     ["native-only registration", nativeOnlyRegistration],
     ["wrong visibility owner", wrongVisibilityOwner],
     ["Anthropic helper speed injection", injectedAnthropicSpeed],

--- a/tests/statusline-committed-usage.test.js
+++ b/tests/statusline-committed-usage.test.js
@@ -33,6 +33,18 @@ function renameToken(source, from, to) {
   );
 }
 
+function effortCommittedUsageFixture(source = committedUsageFixture) {
+  return source
+    .replace("ge=null,_=null;let Kn=", 'ge=null,_=null,Ie="high";let Kn=')
+    .replace(
+      "..._&&{advisorModel:_}};",
+      "..._&&{advisorModel:_},...Ie!==void 0&&{effort:Ie}};"
+    );
+}
+
+const modelsUsedCompletionSignal =
+  "function backgroundCompletionSignal(){let ie=BBg(s,e,g),de=Yns(ie,e,{...n,modelsUsed:_},{suppressTelemetry:re});__calicoRefreshAgentUsage(re,ie),Z0u(e,a9r(re),s);return de}";
+
 function renamedCommittedUsageFixture() {
   const renames = [
     ["ZJr", "buildContent"],
@@ -347,6 +359,65 @@ test("matches renamed wrapper, terminal, selector, and clone locals", () => {
   assert.match(result.content, /selectedUsage=usageReducer\(__calicoStatuslineMessages\(messageEntries\)\),windowSize=contextWindow\(modelContext,windowOptions\(\)\)/);
   assert.equal(completed[0].__calicoUsageState.committed, true);
   assert.deepEqual(readStatuslineUsage(context, completed), usage(333, 44));
+});
+
+test("preserves the 2.1.212 effort metadata wrapper", () => {
+  const source = effortCommittedUsageFixture();
+  const { context, result } = loadCommittedFixture(source);
+  const completed = context.query(usage(210, 31), "end_turn");
+
+  assert.match(
+    result.content,
+    /__calicoUsageState:\{committed:!1,usage:null\},\.\.\._&&\{advisorModel:_\},\.\.\.Ie!==void 0&&\{effort:Ie\}/
+  );
+  assert.equal(completed[0].effort, "high");
+  assert.deepEqual(readStatuslineUsage(context, completed), usage(210, 31));
+  assert.equal(
+    evaluatePatchModule(
+      "statusline-committed-usage",
+      result.content + modelsUsedCompletionSignal
+    ),
+    null
+  );
+});
+
+test("2.1.212 wrapper ownership rejects lost, mismatched, and duplicate effort variants", () => {
+  const source = effortCommittedUsageFixture();
+  const mismatchedEffort = source.replace("{effort:Ie}", "{effort:otherEffort}");
+  const duplicateLegacy =
+    source +
+    'let Other={message:{...wo,content:ZJr([Zr],n,i.agentId,{requestId:ge??void 0,messageId:wo.id})},requestId:ge??void 0,...OG(i.querySource,i.spawnedBySkill,i.activeSkill,i.activeMcpServer,i.activeMcpTool),type:"assistant",uuid:sar.randomUUID(),timestamp:new Date().toISOString(),...!1,..._&&{advisorModel:_}};';
+
+  for (const broken of [mismatchedEffort, duplicateLegacy]) {
+    const result = patchStatuslineCommittedUsage(broken);
+    assert.notEqual(broken, source);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, broken);
+  }
+
+  const patchedEffort = patchStatuslineCommittedUsage(source).content;
+  const lostEffort = patchedEffort.replace(
+    ",...Ie!==void 0&&{effort:Ie}",
+    ""
+  );
+  assert.notEqual(lostEffort, patchedEffort);
+  assert.notEqual(
+    evaluatePatchModule(
+      "statusline-committed-usage",
+      lostEffort + modelsUsedCompletionSignal
+    ),
+    null
+  );
+
+  const patchedLegacy = patchStatuslineCommittedUsage(committedUsageFixture).content;
+  assert.equal(evaluatePatchModule("statusline-committed-usage", patchedLegacy), null);
+  assert.notEqual(
+    evaluatePatchModule(
+      "statusline-committed-usage",
+      patchedLegacy + modelsUsedCompletionSignal
+    ),
+    null
+  );
 });
 
 test("statusline selector is bound to the discovered usage reducer", () => {


### PR DESCRIPTION
## Summary

- generalize gateway worker dispatch ownership so the patch follows the `proto` / `short` / `sessionId` / `respawnFlags` / `env` record into its unique direct `Promise.all` dispatch instead of depending on a minified function name
- accept the Claude Code 2.1.212 background completion shape that adds `modelsUsed`, while preserving native completion metadata and the existing same-owner/direct-seam checks
- preserve the 2.1.212 statusline `effort` spread while injecting committed usage state, with version-aware verifier coverage
- document the 2.1.211–2.1.212 compatibility variants and release verification gates

## Compatibility constraints

- syntax variants still share one semantic-role count; duplicate legacy/new variants fail closed
- gateway Fast continues to use only top-level `service_tier: "priority"`; the GPT gateway path never emits Anthropic native `speed: "fast"`
- existing, new, and respawned workers read the shared Fast state at request time
- non-remora `/fast` continues through the native Claude Code handler and its provider/model/organization/subscription/usage-credit gates

## Verification

- `npm test`: 66/66 passed
- exact Claude Code 2.1.211 regression: full patch pipeline and binary verifier passed
- exact Claude Code 2.1.212 release candidate:
  - `gateway-fast-mode`: 6/6
  - `background-agent-usage`: 4/4
  - `statusline-committed-usage`: 6/6
  - `active-turn-prompt-id`: 2/2
  - `custom-context-window`: 4/4
  - binary verifier: 14 modules verified, 1 disabled/skipped
  - ad-hoc codesign and strict signature verification passed
  - version output includes `(patched)`
- live sanitized gateway E2E:
  - thin/main: `priority → absent → priority → absent`
  - `remora --fast`: `priority → absent`
  - interactive: `priority → absent`
  - existing worker, same PID/session: `absent → priority`
  - new worker on/off and stale raw priority cases passed
  - active worker crash produced a new daemon-managed PID and retried the same prompt identity with shared `off`
  - missing, invalid, directory, and live-removed state files failed before any gateway POST
  - every captured gateway request omitted `speed`
  - non-remora `/fast on` reached the native organization/model gate and bare `/fast` opened the native picker
- release-candidate SHA-256 remained unchanged before/after E2E: `56c121e0639a098e9b2116215fca03c93101f556ddaaf57c98e243bf332413c2`
- fresh-context outcome verifier: `CONFIRMED`
- official TypeScript LSP smoke check passed for document symbols, references, and go-to-definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
