### PR TITLE
fix(release): identify Calico patch suite

### DIFF
--- a/.github/workflows/patch-claude.yml
+++ b/.github/workflows/patch-claude.yml
@@ -358,7 +358,7 @@ jobs:
             printf 'Patched native Claude build for source version %s.\n' "$VERSION" > "$NOTES_PATH"
           fi
 
-          printf '\n---\n\n- Platform: %s\n- Source version: %s\n- Patcher: tweakcc %s\n' \
+          printf '\n---\n\n- Platform: %s\n- Source version: %s\n- Patcher: Calico patch suite + tweakcc %s\n' \
             "${{ matrix.platform_label }}" \
             "$VERSION" \
             "$TWEAKCC_VERSION" >> "$NOTES_PATH"


### PR DESCRIPTION
## Summary

- change the generated Release footer from `Patcher: tweakcc <version>` to `Patcher: Calico patch suite + tweakcc <version>`
- retain the workflow-derived `TWEAKCC_VERSION` as the dependency-version source of truth
- leave platform, source version, assets, checksums, metadata, attestations, and publication behavior unchanged

The five existing 2.1.212 platform Releases have already been updated to use the same label.

## Verification

- workflow YAML parsed successfully
- `git diff --cached --check` passed
- actionlint output is unchanged from `origin/main`: only the same three pre-existing shellcheck findings remain, with no new findings from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
