### PR TITLE
fix(thinking): preserve live blocks in main brief mode

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -524,6 +524,7 @@ Sub-fixes currently bundled here:
 - memo removal: disable one memo wrapper around the message-row renderer when its comparator shape references screen/columns/lastThinkingBlockId/streamingToolUseIDs and suppresses updates
 - linger fix: replace the "remain visible for 30 seconds after stream end" path with `isStreaming` only
 - inline extras fix: materialize `streamingThinking.messages` in the transcript extras list, ordered alongside streaming tool-use blocks by content-block index
+- brief-filter fix: preserve thinking and redacted-thinking entries when the main session applies its brief transcript filter
 - bottom-row suppressor: remove the separate live-thinking row that sits outside the main message flow so streaming thinking only renders inline once
 - reducer/event fix: update the stream event handler so `stream_request_start`, `thinking`, `thinking_delta`, `text`, `message_delta`, and `message_stop` keep per-block streaming thinking state in sync without relying on footer-row rendering
 - duplicate-index fix: keep only one virtual streaming-thinking message per content-block index so repeated block-start handling cannot create two live blocks that receive the same later deltas
@@ -543,6 +544,7 @@ Old bundle shapes we match:
 - 2.1.168-style UI reducers can run `displayTransform?.finalize()` inside the `message_stop` branch before switching to `"tool-use"`, and can use a block-form `case"message_delta":{...}`. The reducer patch must preserve those existing side effects while adding streaming-thinking cleanup before the stream transitions to normal response state.
 - 2.1.183-style UI reducers can keep `onStreamingThinking:<setter>` on the outer event dispatcher while moving the stream-event switch into a separate inner handler that destructures `onSetStreamMode`, `onStreamingToolUses`, `onStreamingText`, and `displayTransform`, but not `onStreamingThinking`. In that shape, inject `onStreamingThinking` into the inner handler destructuring, then patch `stream_request_start`, thinking/redacted-thinking block start, `thinking_delta`, text/message transitions, and `message_stop` there.
 - 2.1.199-style live thinking can still use the same `onStreamingThinking` state but may surface duplicate virtual entries if a thinking content-block start is handled more than once for the same index. Treat `streamingThinking.messages` as keyed by content-block index, not append-only.
+- 2.1.216-style main sessions can filter normalized transcript entries in brief mode, retaining text and selected tool-use blocks while dropping thinking. Preserve thinking and redacted-thinking in that filter; subagents do not take this `isBriefOnly` path, so they can appear healthy while the main session stays blank until another block lands.
 - the duplicate live-thinking suppressor should match the semantic row shape around `param:{type:"thinking",thinking:<var>.thinking}` and the surrounding `marginTop:1` wrapper, not a specific wrapper component identifier
 
 Why this exists:

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -808,6 +808,27 @@ function patchThinkingStreaming(content) {
     patched += inlineThinkingPatched;
   }
 
+  // Main-session brief mode filters the normalized transcript after the live
+  // thinking extras are appended. Keep thinking entries there; subagents skip
+  // this filter, which otherwise makes the bug appear main-session-only.
+  let briefThinkingCandidates = 0;
+  let briefThinkingPatched = 0;
+  const briefThinkingFilterPattern =
+    /if\(([A-Za-z_$][\w$]*)\.type==="assistant"\)\{if\(\1\.isApiErrorMessage\)return!0;(if\(([A-Za-z_$][\w$]*)\?\.type==="tool_use"[\s\S]{0,600}?if\(([A-Za-z_$][\w$]*)\?\.type==="text"[\s\S]{0,300}?return!0;return!1\})/g;
+  output = output.replace(
+    briefThinkingFilterPattern,
+    (full, entryVar, remainingFilter, contentVar, textContentVar) => {
+      if (contentVar !== textContentVar) {
+        return full;
+      }
+      briefThinkingCandidates += 1;
+      briefThinkingPatched += 1;
+      return `if(${entryVar}.type==="assistant"){if(${entryVar}.isApiErrorMessage)return!0;if(${contentVar}?.type==="thinking"||${contentVar}?.type==="redacted_thinking")return!0;${remainingFilter}`;
+    }
+  );
+  candidates += briefThinkingCandidates;
+  patched += briefThinkingPatched;
+
   // The dedicated live thinking row sits outside the message flow, so when the
   // inline transcript extras are active it becomes a duplicate copy pinned at
   // the bottom. Suppress that extra row and keep streamed thinking inline.

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1041,9 +1041,21 @@ const CHECKS: Check[] = [
   },
   {
     id: "thinking-streaming",
-    kind: "presence",
-    marker: "__cc_streamingThinking",
-    describe: "injected __cc_streamingThinking live-streaming plumbing",
+    kind: "custom",
+    describe: "live-streaming plumbing and main-session brief-filter preservation",
+    run: (content) => {
+      if (!content.includes("__cc_streamingThinking")) {
+        return "expected __cc_streamingThinking live-streaming plumbing";
+      }
+      if (
+        !/if\(([A-Za-z_$][\w$]*)\?\.type==="thinking"\|\|\1\?\.type==="redacted_thinking"\)return!0;if\(\1\?\.type==="tool_use"/.test(
+          content
+        )
+      ) {
+        return "expected main-session brief filter to preserve thinking entries";
+      }
+      return null;
+    },
   },
   {
     id: "subagent-prompt",

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1058,11 +1058,13 @@ const CHECKS: Check[] = [
         /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
       );
       const version = versionMatch?.slice(1).map(Number);
+      if (version === undefined) {
+        return "expected parseable Claude Code VERSION metadata";
+      }
       const requiresBriefFilter =
-        version !== undefined &&
-        (version[0] > 2 ||
-          (version[0] === 2 &&
-            (version[1] > 1 || (version[1] === 1 && version[2] >= 216))));
+        version[0] > 2 ||
+        (version[0] === 2 &&
+          (version[1] > 1 || (version[1] === 1 && version[2] >= 216)));
       if (
         requiresBriefFilter &&
         !/if\(([A-Za-z_$][\w$]*)\?\.type==="thinking"\|\|\1\?\.type==="redacted_thinking"\)return!0;if\(\1\?\.type==="tool_use"/.test(

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -29,6 +29,8 @@ type Check = {
   kind: "presence" | "absence" | "custom";
   // For presence/absence: a RegExp or a literal string to search for.
   marker?: RegExp | string;
+  // For custom checks: a marker that must be absent when the module is disabled.
+  disabledMarker?: RegExp | string;
   // For custom checks: return null on success, or a failure detail string.
   run?: (content: string) => string | null;
   describe: string;
@@ -49,6 +51,10 @@ function markerPresent(content: string, marker: RegExp | string): boolean {
     return content.includes(marker);
   }
   return marker.test(content);
+}
+
+function disabledMarkerForCheck(check: Check): RegExp | string | undefined {
+  return check.disabledMarker ?? (check.kind === "presence" ? check.marker : undefined);
 }
 
 const CHECKS: Check[] = [
@@ -1042,12 +1048,23 @@ const CHECKS: Check[] = [
   {
     id: "thinking-streaming",
     kind: "custom",
+    disabledMarker: "__cc_streamingThinking",
     describe: "live-streaming plumbing and main-session brief-filter preservation",
     run: (content) => {
       if (!content.includes("__cc_streamingThinking")) {
         return "expected __cc_streamingThinking live-streaming plumbing";
       }
+      const versionMatch = content.match(
+        /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
+      );
+      const version = versionMatch?.slice(1).map(Number);
+      const requiresBriefFilter =
+        version !== undefined &&
+        (version[0] > 2 ||
+          (version[0] === 2 &&
+            (version[1] > 1 || (version[1] === 1 && version[2] >= 216))));
       if (
+        requiresBriefFilter &&
         !/if\(([A-Za-z_$][\w$]*)\?\.type==="thinking"\|\|\1\?\.type==="redacted_thinking"\)return!0;if\(\1\?\.type==="tool_use"/.test(
           content
         )
@@ -1235,11 +1252,12 @@ async function main(): Promise<void> {
   for (const check of CHECKS) {
     if (disableSet.has(check.id)) {
       // This module was intentionally not applied. Skip its normal check, and
-      // for presence-type modules reverse-assert the marker is ABSENT so the
+      // when a disabled marker exists, reverse-assert it is ABSENT so the
       // disable is proven (the patch really isn't in the bundle), not merely
       // ignored.
-      if (check.kind === "presence" && check.marker !== undefined) {
-        if (markerPresent(content, check.marker)) {
+      const disabledMarker = disabledMarkerForCheck(check);
+      if (disabledMarker !== undefined) {
+        if (markerPresent(content, disabledMarker)) {
           console.log(`  FAIL ${check.id}`);
           failures.push({
             id: check.id,
@@ -1290,7 +1308,18 @@ function evaluatePatchModule(id: string, content: string): string | null {
   return check ? evaluateCheck(check, content) : `unknown patch module: ${id}`;
 }
 
-module.exports = { evaluatePatchModule };
+function evaluateDisabledPatchModule(id: string, content: string): string | null {
+  const check = CHECKS.find((candidate) => candidate.id === id);
+  if (!check) {
+    return `unknown patch module: ${id}`;
+  }
+  const disabledMarker = disabledMarkerForCheck(check);
+  return disabledMarker !== undefined && markerPresent(content, disabledMarker)
+    ? `disabled module marker unexpectedly present (${check.describe})`
+    : null;
+}
+
+module.exports = { evaluateDisabledPatchModule, evaluatePatchModule };
 
 if (require.main === module) {
   void main();

--- a/tests/thinking-streaming-verifier.test.js
+++ b/tests/thinking-streaming-verifier.test.js
@@ -29,6 +29,13 @@ test("thinking verifier requires the brief filter from Claude 2.1.216", () => {
   );
 });
 
+test("thinking verifier rejects unparseable Claude version metadata", () => {
+  assert.match(
+    evaluatePatchModule("thinking-streaming", plumbing),
+    /VERSION metadata/
+  );
+});
+
 test("disabled thinking verifier rejects installed streaming plumbing", () => {
   assert.match(
     evaluateDisabledPatchModule("thinking-streaming", plumbing),

--- a/tests/thinking-streaming-verifier.test.js
+++ b/tests/thinking-streaming-verifier.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  evaluateDisabledPatchModule,
+  evaluatePatchModule,
+} = require("../scripts/verify-patched-binary.ts");
+
+const plumbing = "__cc_streamingThinking";
+const briefMarker =
+  'if(a?.type==="thinking"||a?.type==="redacted_thinking")return!0;if(a?.type==="tool_use"';
+
+function bundle(version, extra = "") {
+  return `PACKAGE_URL:"@anthropic-ai/claude-code",VERSION:"${version}" ${plumbing} ${extra}`;
+}
+
+test("thinking verifier skips the brief filter before Claude 2.1.216", () => {
+  assert.equal(evaluatePatchModule("thinking-streaming", bundle("2.1.215")), null);
+});
+
+test("thinking verifier requires the brief filter from Claude 2.1.216", () => {
+  assert.match(
+    evaluatePatchModule("thinking-streaming", bundle("2.1.216")),
+    /brief filter/
+  );
+  assert.equal(
+    evaluatePatchModule("thinking-streaming", bundle("2.1.216", briefMarker)),
+    null
+  );
+});
+
+test("disabled thinking verifier rejects installed streaming plumbing", () => {
+  assert.match(
+    evaluateDisabledPatchModule("thinking-streaming", plumbing),
+    /unexpectedly present/
+  );
+  assert.equal(evaluateDisabledPatchModule("thinking-streaming", ""), null);
+});


### PR DESCRIPTION
## Summary

- preserve `thinking` and `redacted_thinking` blocks while Claude main sessions apply the native brief-only content filter
- keep non-display/transient blocks filtered by the existing native predicate
- verify the executable filter shape and document the Claude 2.1.216+ compatibility requirement

## Root cause

Claude 2.1.216+ introduced a main-session brief-only filter whose accepted block types omitted virtual thinking blocks. Subagents bypassed that path, so their live thinking remained visible while main-session thinking appeared only after later output.

## Validation

- `npm test` — 78 passed
- patched official Claude 2.1.220 verifier — thinking-streaming patch accepted
- `git diff --check origin/main...HEAD`