### PR TITLE
feat(statusline): forward Fable 5 and usage-credit rate-limit windows

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -285,6 +285,57 @@ Likely break signs:
 - a valid partial-zero response is discarded
 - the module reports `0` candidates or the verifier reports an occurrence mismatch
 
+### `statusline-rate-limit-windows`
+
+Intent:
+
+- forward every rate-limit window Claude Code already holds into the status line JSON, not just
+  the two it currently projects
+
+Source of truth:
+
+- the header parser builds the internal `rawUtilization` state from four abbreviated headers:
+  `anthropic-ratelimit-unified-5h-*` (`five_hour`), `-7d-*` (`seven_day`), `-7d_oi-*`
+  (`seven_day_overage_included`), and `-overage-*` (`overage`)
+- upstream's own label map names `seven_day_overage_included` the "Fable 5 limit" and `overage`
+  the "usage credit limit"; both are first-class `rateLimitType` cases in the limit-message paths
+- the status line payload builder reads that same state object and projects only `five_hour` and
+  `seven_day`, so the other two windows are dropped after they have already been parsed
+- this is a projection widening, not a new data source: no extra request, no extra work per render
+
+Old bundle shape we match:
+
+- the two-window projection object literal, matched by shape with the state local captured:
+  `{...L.five_hour&&{five_hour:{used_percentage:L.five_hour.utilization*100,resets_at:L.five_hour.resets_at}},...L.seven_day&&{...}}`
+- the payload guard that admits the object only when one of those two windows exists:
+  `...P.five_hour||P.seven_day)&&{rate_limits:P}`
+- both anchors must occur exactly once; anything else returns the original bundle with `patched: 0`
+
+What we rewrite:
+
+- append `seven_day_overage_included` and `overage` spreads in the same shape as the existing two
+- widen the guard to `...Object.keys(P).length>0&&{rate_limits:P}` so a payload carrying only a
+  Fable or credit window still emits `rate_limits`
+
+Why this exists:
+
+- coralline (and any other status line) can only render what the payload carries; Fable usage is
+  visible on claude.ai but absent from the status line JSON, tracked as coralline issue 43
+- upstream key names are preserved verbatim, so if Anthropic ever forwards these windows itself,
+  the field names already match and this module simply stops applying
+
+Likely break signs:
+
+- the module reports `0` candidates after an upstream refactor of the payload builder
+- upstream renames the window keys or moves the projection off `rawUtilization`
+- upstream widens the projection itself, at which point the first anchor no longer matches and
+  this module should be retired rather than repaired
+
+Caveat:
+
+- the `7d_oi` headers are only present when the server emits them for that account; the patch
+  forwards the window when it exists and changes nothing when it does not
+
 ### `gateway-fast-mode`
 
 Intent:

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2343,9 +2343,13 @@ function patchStatuslineRateLimitWindows(content) {
     guardIndex === -1 ? -1 : content.lastIndexOf("function ", guardIndex);
   const sharesPayloadBuilder =
     projectionFunctionStart !== -1 && projectionFunctionStart === guardFunctionStart;
+  // `.` is excluded from the boundary class deliberately: without it,
+  // `x.A={...projection...}` reads as an assignment to a local named `A`, and
+  // the windows would be added to a property while an unrelated local drives
+  // the guard. Same boundary as the occurrence test below.
   const projectionAssignsGuardLocal =
     projectionIndex !== -1 &&
-    new RegExp(`(?:^|[^\\w$])${guardLocal}=$`).test(
+    new RegExp(`(?:^|[^\\w$.])${guardLocal}=$`).test(
       content.slice(Math.max(0, projectionIndex - 40), projectionIndex)
     );
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2376,22 +2376,27 @@ function patchStatuslineRateLimitWindows(content) {
     }
   }
 
-  // The depth walk still permits the inverse nesting: the projection initializes
-  // an outer `A` and a deeper block declares its own `A` around the guard, which
-  // only increases depth. Rather than resolve bindings (this patcher has no
-  // AST), require that nothing reassigns the guard's local between the two
-  // anchors. A shadowing declaration is one such write, and so is a plain
-  // reassignment — both mean the guard does not read this projection.
+  // Every way the guard's local can stop referring to this projection —
+  // reassignment, a shadowing `let` in a deeper block, an arrow parameter, a
+  // destructuring or catch binding — is a distinct syntactic form, and matching
+  // them one at a time only invites the next one. This patcher has no AST to
+  // resolve bindings with, so it asks for something stricter and complete
+  // instead: the name must not occur between the two anchors at all. If it
+  // never appears, it cannot have been rebound or shadowed by any form.
+  //
+  // Property accesses are excluded, since `x.A` binds nothing. In the bundles
+  // this targets the span between the anchors is the remainder of the payload
+  // object literal and does not mention the local at all.
   const between = projectionEnd === -1 ? "" : content.slice(projectionEnd, guardIndex);
-  const guardLocalIsRebound = new RegExp(
-    `[^\\w$.!<>=+\\-*/%&|^]${guardLocal}=(?!=)`
+  const guardLocalOccursBetween = new RegExp(
+    `(?:^|[^\\w$.])${guardLocal}(?![\\w$])`
   ).test(between);
 
   if (
     !sharesPayloadBuilder ||
     !projectionAssignsGuardLocal ||
     leftProjectionScope ||
-    guardLocalIsRebound
+    guardLocalOccursBetween
   ) {
     return { content: original, candidates, patched: 0 };
   }

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2294,6 +2294,62 @@ function patchStatuslineCommittedUsage(content) {
   return { content: output, candidates, patched: 6 };
 }
 
+// Claude Code's statusline payload builder reads the header-derived rate-limit
+// state (five_hour, seven_day, seven_day_overage_included, overage) but projects
+// only the first two into the JSON handed to the status line command. The other
+// two windows are already parsed from response headers on the same object, so
+// forwarding them costs nothing at render time. Upstream labels
+// seven_day_overage_included "Fable 5 limit"; overage is the usage-credit window.
+// Both keep their upstream key names so a future upstream projection is a
+// drop-in replacement for this patch.
+function patchStatuslineRateLimitWindows(content) {
+  const original = content;
+  const identifier = "[A-Za-z_$][\\w$]*";
+  const window = (local, key) =>
+    `...${local}.${key}&&{${key}:{used_percentage:${local}.${key}.utilization*100,resets_at:${local}.${key}.resets_at}}`;
+
+  const projectionPattern = new RegExp(
+    `\\{\\.\\.\\.(${identifier})\\.five_hour&&\\{five_hour:\\{used_percentage:\\1\\.five_hour\\.utilization\\*100,resets_at:\\1\\.five_hour\\.resets_at\\}\\},\\.\\.\\.\\1\\.seven_day&&\\{seven_day:\\{used_percentage:\\1\\.seven_day\\.utilization\\*100,resets_at:\\1\\.seven_day\\.resets_at\\}\\}\\}`,
+    "g"
+  );
+  const guardPattern = new RegExp(
+    `\\.\\.\\.\\((${identifier})\\.five_hour\\|\\|\\1\\.seven_day\\)&&\\{rate_limits:\\1\\}`,
+    "g"
+  );
+
+  const projectionMatches = [...content.matchAll(projectionPattern)];
+  const guardMatches = [...content.matchAll(guardPattern)];
+  const candidates = projectionMatches.length + guardMatches.length;
+
+  if (projectionMatches.length !== 1 || guardMatches.length !== 1) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  const projectionLocal = projectionMatches[0][1];
+  const guardLocal = guardMatches[0][1];
+  const projectionReplacement = `{${[
+    "five_hour",
+    "seven_day",
+    "seven_day_overage_included",
+    "overage",
+  ]
+    .map((key) => window(projectionLocal, key))
+    .join(",")}}`;
+  const guardReplacement = `...Object.keys(${guardLocal}).length>0&&{rate_limits:${guardLocal}}`;
+
+  let output = original.replace(projectionPattern, projectionReplacement);
+  output = output.replace(guardPattern, guardReplacement);
+
+  if (
+    output.split(projectionReplacement).length - 1 !== 1 ||
+    output.split(guardReplacement).length - 1 !== 1
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  return { content: output, candidates, patched: 2 };
+}
+
 function patchGatewayFastMode(content) {
   const original = content;
   const identifier = "[A-Za-z_$][\\w$]*";
@@ -2959,6 +3015,11 @@ const PATCH_MODULES = [
     apply: patchStatuslineCommittedUsage,
   },
   {
+    id: "statusline-rate-limit-windows",
+    description: "Forward Fable 5 and usage-credit rate-limit windows to statusline payloads",
+    apply: patchStatuslineRateLimitWindows,
+  },
+  {
     id: "custom-context-window",
     description: "Allow exact opt-in custom model context windows",
     apply: patchCustomContextWindows,
@@ -3178,6 +3239,7 @@ module.exports = {
   patchCompactBodyPolicy,
   patchBackgroundAgentUsage,
   patchStatuslineCommittedUsage,
+  patchStatuslineRateLimitWindows,
   patchCustomContextWindows,
 };
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2349,7 +2349,34 @@ function patchStatuslineRateLimitWindows(content) {
       content.slice(Math.max(0, projectionIndex - 40), projectionIndex)
     );
 
-  if (!sharesPayloadBuilder || !projectionAssignsGuardLocal) {
+  // `function ` does not bound a lexical scope on its own. An arrow callback can
+  // hold the projection while the guard sits in the enclosing function with a
+  // shadowed local of the same name:
+  //   items.map(()=>{let A={...projection...}}); let A=other; return {...guard...}
+  // Both lastIndexOf calls land on the enclosing function and the initializer
+  // test sees the callback's `A=`, so neither check above rejects it. Walk the
+  // text between the anchors instead and require that reaching the guard never
+  // closes a bracket it did not open — that is, the guard is reached without
+  // leaving the block the projection lives in.
+  const projectionEnd =
+    projectionIndex === -1 ? -1 : projectionIndex + projectionMatches[0][0].length;
+  let leftProjectionScope = projectionEnd === -1 || guardIndex < projectionEnd;
+  if (!leftProjectionScope) {
+    let depth = 0;
+    for (const ch of content.slice(projectionEnd, guardIndex)) {
+      if (ch === "{" || ch === "(" || ch === "[") {
+        depth += 1;
+      } else if (ch === "}" || ch === ")" || ch === "]") {
+        depth -= 1;
+        if (depth < 0) {
+          leftProjectionScope = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!sharesPayloadBuilder || !projectionAssignsGuardLocal || leftProjectionScope) {
     return { content: original, candidates, patched: 0 };
   }
   const projectionReplacement = `{${[

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2327,6 +2327,31 @@ function patchStatuslineRateLimitWindows(content) {
 
   const projectionLocal = projectionMatches[0][1];
   const guardLocal = guardMatches[0][1];
+
+  // Global counts alone do not prove the two anchors belong to each other: an
+  // upstream bundle could carry each shape once in unrelated functions, and
+  // rewriting both would widen a guard that never sees the added windows.
+  // Two independent ownership proofs, because a minified local name like `P`
+  // recurs across functions:
+  //   1. both anchors sit inside the same function
+  //   2. the projection literal is the initializer of the very local the guard reads
+  const projectionIndex = projectionMatches[0].index ?? -1;
+  const guardIndex = guardMatches[0].index ?? -1;
+  const projectionFunctionStart =
+    projectionIndex === -1 ? -1 : content.lastIndexOf("function ", projectionIndex);
+  const guardFunctionStart =
+    guardIndex === -1 ? -1 : content.lastIndexOf("function ", guardIndex);
+  const sharesPayloadBuilder =
+    projectionFunctionStart !== -1 && projectionFunctionStart === guardFunctionStart;
+  const projectionAssignsGuardLocal =
+    projectionIndex !== -1 &&
+    new RegExp(`(?:^|[^\\w$])${guardLocal}=$`).test(
+      content.slice(Math.max(0, projectionIndex - 40), projectionIndex)
+    );
+
+  if (!sharesPayloadBuilder || !projectionAssignsGuardLocal) {
+    return { content: original, candidates, patched: 0 };
+  }
   const projectionReplacement = `{${[
     "five_hour",
     "seven_day",

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2376,7 +2376,23 @@ function patchStatuslineRateLimitWindows(content) {
     }
   }
 
-  if (!sharesPayloadBuilder || !projectionAssignsGuardLocal || leftProjectionScope) {
+  // The depth walk still permits the inverse nesting: the projection initializes
+  // an outer `A` and a deeper block declares its own `A` around the guard, which
+  // only increases depth. Rather than resolve bindings (this patcher has no
+  // AST), require that nothing reassigns the guard's local between the two
+  // anchors. A shadowing declaration is one such write, and so is a plain
+  // reassignment — both mean the guard does not read this projection.
+  const between = projectionEnd === -1 ? "" : content.slice(projectionEnd, guardIndex);
+  const guardLocalIsRebound = new RegExp(
+    `[^\\w$.!<>=+\\-*/%&|^]${guardLocal}=(?!=)`
+  ).test(between);
+
+  if (
+    !sharesPayloadBuilder ||
+    !projectionAssignsGuardLocal ||
+    leftProjectionScope ||
+    guardLocalIsRebound
+  ) {
     return { content: original, candidates, patched: 0 };
   }
   const projectionReplacement = `{${[

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -997,6 +997,39 @@ const CHECKS: Check[] = [
     },
   },
   {
+    id: "statusline-rate-limit-windows",
+    kind: "custom",
+    describe:
+      "Fable 5 and usage-credit windows forwarded, two-window rate_limits guard replaced",
+    disabledMarker: /\.\.\.Object\.keys\([A-Za-z_$][\w$]*\)\.length>0&&\{rate_limits:/,
+    run: (content: string): string | null => {
+      const identifier = "[A-Za-z_$][\\w$]*";
+      const windowMarker = (key: string) =>
+        new RegExp(
+          `\\.\\.\\.(${identifier})\\.${key}&&\\{${key}:\\{used_percentage:\\1\\.${key}\\.utilization\\*100,resets_at:\\1\\.${key}\\.resets_at\\}\\}`
+        );
+      const missing = ["five_hour", "seven_day", "seven_day_overage_included", "overage"].filter(
+        (key) => !windowMarker(key).test(content)
+      );
+      if (missing.length > 0) {
+        return `missing forwarded rate-limit window(s): ${missing.join(", ")}`;
+      }
+      const widenedGuard = new RegExp(
+        `\\.\\.\\.Object\\.keys\\((${identifier})\\)\\.length>0&&\\{rate_limits:\\1\\}`
+      );
+      if (!widenedGuard.test(content)) {
+        return "rate_limits payload guard was not widened to all windows";
+      }
+      const originalGuard = new RegExp(
+        `\\.\\.\\.\\((${identifier})\\.five_hour\\|\\|\\1\\.seven_day\\)&&\\{rate_limits:\\1\\}`
+      );
+      if (originalGuard.test(content)) {
+        return "original two-window rate_limits guard is still present";
+      }
+      return null;
+    },
+  },
+  {
     id: "custom-context-window",
     kind: "custom",
     describe: "validated opt-in context resolver and effective status-line window",

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -166,3 +166,22 @@ function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five
   assert.equal(result.candidates, 2);
   assert.equal(result.patched, 0);
 });
+
+// The binding forms below are all distinct syntax. They are covered by one
+// condition — the guard's local must not occur between the anchors — rather
+// than by a matcher per form, which is what kept admitting the next variant.
+for (const [name, middle] of [
+  ["an arrow parameter", `items.map((A)=>({...(A.five_hour||A.seven_day)&&{rate_limits:A}}));`],
+  ["a destructured parameter", `items.map(({A})=>({...(A.five_hour||A.seven_day)&&{rate_limits:A}}));`],
+  ["a catch binding", `try{x()}catch(A){log(A)};`],
+  ["a for-loop binding", `for(let A of xs){use(A)};`],
+]) {
+  test(`rejects a guard shadowed by ${name}`, () => {
+    const source = `
+function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};${middle}return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+    const result = patchStatuslineRateLimitWindows(source);
+    assert.equal(result.patched, 0, "the guard may not be rewritten");
+    assert.equal(result.content, source);
+  });
+}

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -1,0 +1,94 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const { patchStatuslineRateLimitWindows } = require("../patch-claude-display.ts");
+
+// Mirrors the upstream statusline payload builder: the header-derived state is
+// read once, projected into a two-window object, and spread into the payload
+// behind a guard that only knows about those same two windows.
+const fixture = `
+var state={};
+function setState(next){state=next}
+function tLn(){return state}
+function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A},thinking:{enabled:!0}}}
+`;
+
+function runPatched(content) {
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(content, context);
+  return context;
+}
+
+function windowState(utilization, resetsAt) {
+  return { utilization, resets_at: resetsAt };
+}
+
+test("forwards all four header-derived rate-limit windows", () => {
+  const result = patchStatuslineRateLimitWindows(fixture);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 2);
+
+  const context = runPatched(result.content);
+  context.setState({
+    five_hour: windowState(0.125, 1),
+    seven_day: windowState(0.25, 2),
+    seven_day_overage_included: windowState(0.5, 3),
+    overage: windowState(0.75, 4),
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.hqw().rate_limits)), {
+    five_hour: { used_percentage: 12.5, resets_at: 1 },
+    seven_day: { used_percentage: 25, resets_at: 2 },
+    seven_day_overage_included: { used_percentage: 50, resets_at: 3 },
+    overage: { used_percentage: 75, resets_at: 4 },
+  });
+});
+
+test("keeps the existing two-window payload byte-identical when only those exist", () => {
+  const context = runPatched(patchStatuslineRateLimitWindows(fixture).content);
+  const baseline = runPatched(fixture);
+  const state = { five_hour: windowState(0.9, 11), seven_day: windowState(0.5, 22) };
+
+  context.setState(state);
+  baseline.setState(state);
+  assert.equal(JSON.stringify(context.hqw()), JSON.stringify(baseline.hqw()));
+});
+
+test("emits rate_limits when only a Fable window is present", () => {
+  const context = runPatched(patchStatuslineRateLimitWindows(fixture).content);
+  const baseline = runPatched(fixture);
+  const state = { seven_day_overage_included: windowState(0.5, 7) };
+
+  context.setState(state);
+  baseline.setState(state);
+  // The upstream guard drops the whole object here, which is what the patch fixes.
+  assert.equal(baseline.hqw().rate_limits, undefined);
+  assert.deepEqual(JSON.parse(JSON.stringify(context.hqw().rate_limits)), {
+    seven_day_overage_included: { used_percentage: 50, resets_at: 7 },
+  });
+});
+
+test("omits rate_limits entirely when no window is known", () => {
+  const context = runPatched(patchStatuslineRateLimitWindows(fixture).content);
+  context.setState({});
+  assert.equal("rate_limits" in context.hqw(), false);
+});
+
+test("leaves content untouched when either anchor is missing", () => {
+  const guardOnly = fixture.replace(
+    /let k=tLn\(\),A=\{[^;]*\};/,
+    "let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization}}};"
+  );
+  const result = patchStatuslineRateLimitWindows(guardOnly);
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, guardOnly);
+});
+
+test("is inert on already-patched content", () => {
+  const once = patchStatuslineRateLimitWindows(fixture);
+  const twice = patchStatuslineRateLimitWindows(once.content);
+  assert.equal(twice.patched, 0);
+  assert.equal(twice.content, once.content);
+});

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -142,3 +142,27 @@ function hqw(){let k=tLn(),A=prior();let out={model:{id:"sonnet"},...(A.five_hou
   assert.equal(result.candidates, 2);
   assert.equal(result.patched, 0);
 });
+
+test("rejects a guard whose local was re-declared in a deeper block", () => {
+  // The inverse nesting raised on #8 round 3: the projection initializes the
+  // outer `A`, then a deeper block declares its own `A` around the guard. The
+  // bracket depth never goes negative, so the scope walk alone accepts it.
+  const shadowedInner = `
+function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};if(cond){let A=somethingElse();return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}return A}
+`;
+  const result = patchStatuslineRateLimitWindows(shadowedInner);
+  assert.equal(result.candidates, 2, "both shapes are still found");
+  assert.equal(result.patched, 0, "but the windows and the guard belong to different objects");
+  assert.equal(result.content, shadowedInner);
+});
+
+test("rejects a guard whose local was reassigned after the projection", () => {
+  // Not shadowing, but the same consequence: the projection's result is
+  // discarded before the guard reads the local.
+  const reassigned = `
+function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};A=recompute(A);return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+  const result = patchStatuslineRateLimitWindows(reassigned);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 0);
+});

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -119,3 +119,26 @@ function hqw(){let k=tLn(),B={...k.five_hour&&{five_hour:{used_percentage:k.five
   assert.equal(result.patched, 0);
   assert.equal(result.content, unrelated);
 });
+
+test("rejects a projection trapped inside an arrow callback", () => {
+  // The shape Codex raised on #8: same enclosing function, and the guard's local
+  // name is even initialized by a projection — but that projection belongs to a
+  // callback scope and a shadowed binding, so widening the guard would not see
+  // the added windows. `lastIndexOf("function ")` cannot tell these apart.
+  const shadowed = `
+function hqw(){let k=tLn();items.map(()=>{let A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};return A});let A=somethingElse();return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+  const result = patchStatuslineRateLimitWindows(shadowed);
+  assert.equal(result.candidates, 2, "both shapes are still found");
+  assert.equal(result.patched, 0, "but the guard must not be widened");
+  assert.equal(result.content, shadowed);
+});
+
+test("rejects a guard that precedes the projection it would have to consume", () => {
+  const reversed = `
+function hqw(){let k=tLn(),A=prior();let out={model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}};A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};return out}
+`;
+  const result = patchStatuslineRateLimitWindows(reversed);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 0);
+});

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -185,3 +185,13 @@ function hqw(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five
     assert.equal(result.content, source);
   });
 }
+
+test("rejects a projection assigned to a property rather than the guard's local", () => {
+  const propertyAssigned = `
+function hqw(){let k=tLn(),A=elsewhere();x.A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+  const result = patchStatuslineRateLimitWindows(propertyAssigned);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, propertyAssigned);
+});

--- a/tests/statusline-rate-limit-windows.test.js
+++ b/tests/statusline-rate-limit-windows.test.js
@@ -92,3 +92,30 @@ test("is inert on already-patched content", () => {
   assert.equal(twice.patched, 0);
   assert.equal(twice.content, once.content);
 });
+
+// Global match counts alone do not prove the two anchors belong to each other.
+// Both of the following carry each shape exactly once, so the counts look
+// identical to the healthy fixture — only an ownership proof separates them.
+
+test("rejects anchors that live in different payload builders", () => {
+  const split = `
+function projectOnly(){let k=tLn(),A={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}};return A}
+function guardOnly(){let A=somethingElse();return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+  const result = patchStatuslineRateLimitWindows(split);
+  assert.equal(result.candidates, 2, "both shapes are still found");
+  assert.equal(result.patched, 0, "but they must not be rewritten");
+  assert.equal(result.content, split);
+});
+
+test("rejects a projection that does not initialize the local the guard reads", () => {
+  // Same function, and the guard's local `A` even exists — but the projection
+  // is assigned to `B`, so widening the guard would not see the added windows.
+  const unrelated = `
+function hqw(){let k=tLn(),B={...k.five_hour&&{five_hour:{used_percentage:k.five_hour.utilization*100,resets_at:k.five_hour.resets_at}},...k.seven_day&&{seven_day:{used_percentage:k.seven_day.utilization*100,resets_at:k.seven_day.resets_at}}},A=somethingElse(B);return{model:{id:"sonnet"},...(A.five_hour||A.seven_day)&&{rate_limits:A}}}
+`;
+  const result = patchStatuslineRateLimitWindows(unrelated);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, unrelated);
+});


### PR DESCRIPTION
Stacked on #7. Review that one first; this PR's diff is the single commit `bad901f`.

## Problem

Claude Code parses four rate-limit windows from response headers into one internal utilization state object, then projects only two of them into the status line payload. The other two are dropped *after* they have already been parsed, so a status line cannot render Fable usage even though the number is in memory by the time the payload is built.

| Window | Upstream key | Stock | With this patch |
|---|---|---|---|
| Session | `five_hour` | projected | projected |
| Weekly | `seven_day` | projected | projected |
| "Fable 5 limit" | `seven_day_overage_included` | parsed, dropped | **projected** |
| Usage credit | `overage` | parsed, dropped | **projected** |

Both dropped keys are already first-class `rateLimitType` cases in upstream's own limit-message paths, and upstream's label map is what names them "Fable 5 limit" and "usage credit limit".

## What the module does

Adds `statusline-rate-limit-windows` (`patchStatuslineRateLimitWindows`), registered between `statusline-committed-usage` and `custom-context-window`.

Two anchors must each occur exactly once, matched by shape with the state local captured by backreference:

- the two-window projection object literal
- the payload guard `...(P.five_hour||P.seven_day)&&{rate_limits:P}`

It appends `seven_day_overage_included` and `overage` spreads in the same shape as the existing two, and widens the guard to `...Object.keys(P).length>0&&{rate_limits:P}` so a payload carrying only a Fable or credit window still emits `rate_limits`. Anything other than exactly one occurrence of each anchor returns the bundle unchanged with `patched: 0`, failing the release build under `--assert-all`.

This is a projection widening, not a new data source: no extra request, no extra work per render.

## Compatibility

Upstream key names are preserved verbatim, so a status line written against this patch keeps working if Anthropic later forwards the same windows itself. Windows appear only when the server sends the corresponding headers for that account; otherwise the payload is byte-identical to stock.

## Verification

`scripts/verify-patched-binary.ts` gains a matching custom check requiring all four forwarded windows, the widened guard, and the *absence* of the original two-window guard, plus a `disabledMarker` so a disabled build is confirmed to lack the widened guard rather than merely not asserting it.

`tests/statusline-rate-limit-windows.test.js` drives the real patch function over a fixture mirroring the upstream payload builder and executes the result in a `vm` context: all four windows forwarded, a two-window payload staying byte-identical, `rate_limits` emitted for a Fable-only payload, omitted when no window is known, content untouched when either anchor is missing, and inert on already-patched content.

Also verified against a real 2.1.237 bundle: `candidates: 2, patched: 2`. The 2.1.236 upstream refactor that broke `statusline-committed-usage` (see #7) does not affect these anchors — that change is in the assistant wrapper, this one is in the payload builder.

Motivated by coralline issue 43 (Fable usage visible on claude.ai but absent from the status line JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeGTwEV8Xdgj9ngxHPjptK
