### PR TITLE
docs: restructure README and add a local auto-update example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ claude.display.backup
 original*
 node_modules
 work/
+.DS_Store
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -3,88 +3,350 @@
 > **Calico Claude** is a self-hosted, verifiable supply chain for patched native Claude Code binaries.
 > It is a fork of [`a-connoisseur/patch-claude-code`](https://github.com/a-connoisseur/patch-claude-code)
 > (reviewed at upstream commit `729494e`). The display patches are unchanged in intent; this fork adds
-> its own branding ("Calico Claude"), patch-integrity assertions, dependency pinning, and a CI pipeline
-> that publishes sha256 checksums plus build provenance attestations. Releases live at
+> its own branding, patch-integrity assertions, dependency pinning, and a CI pipeline that publishes
+> SHA-256 checksums plus build provenance attestations. Releases live at
 > [`Nanako0129/calico-claude`](https://github.com/Nanako0129/calico-claude).
+
+## Contents
+
+- [What this does](#what-this-does)
+- [Install](#install)
+- [Keeping it updated](#keeping-it-updated)
+- [Trust and security](#trust-and-security)
+- [Verify the installed binary](#verify-the-installed-binary)
+- [Patch modules in detail](#patch-modules-in-detail)
+- [Questions and answers](#questions-and-answers)
+
+---
 
 ## What this does
 
-This repo publishes patched native Claude binaries that make output more transparent without verbose mode.
-Here is an exhaustive list of things it changes:
+This repo publishes patched native Claude binaries that make output more transparent without verbose
+mode, and adds a set of adapters that stay completely dormant unless a launcher such as
+[remora](https://github.com/Nanako0129/remora-cc) turns them on. Every change is a local patch to the
+binary's own rendering and request-building code; nothing is proxied, and no protocol is modified.
 
-- Shows detailed tool calls instead of collapsed summaries.
-- Hard disables spinner tips.
-- Streams thinking live in the UI. This is helpful for instances where Claude thinks for over 10 minutes and you want to know if it's actually still doing something.
-- Shows subagent `Prompt:` blocks in the non-verbose UI.
-- Renames the startup header to `Calico Claude v...` (this makes it easy to identify when Claude has auto updated and lost the patch).
-- Adds a dormant, opt-in custom-model context adapter. It changes nothing unless
-  `CALICO_MODEL_CONTEXT_WINDOWS` is supplied by a launcher such as remora.
-- Adds a dormant active-turn identity adapter for remora. It changes nothing
-  unless the launcher sets `REMORA_ACTIVE=1`.
-- Refreshes background GPT agent accounting after terminal stream usage or late wrapper
-  mutation, so the agent row shows finalized token usage alongside elapsed time.
-- Exposes only committed terminal assistant usage to the status line, so provisional
-  thinking/responding wrappers and synthetic all-zero fallbacks cannot erase the last
-  completed snapshot.
+### Display patches (always active)
+
+| Module | Effect |
+|---|---|
+| `thinking-inline` | Renders thinking blocks inline instead of hiding them behind transcript mode |
+| `thinking-streaming` | Streams thinking live, so a 10-minute think shows progress instead of a silent spinner |
+| `redacted-thinking-inline` | Renders redacted thinking summaries inline as thinking text |
+| `subagent-prompt` | Shows subagent `Prompt:` blocks outside transcript mode |
+| `tool-call-verbose` | Forces verbose rendering of collapsed read/search tool calls |
+| `create-diff-colors` | Renders created files through the diff component with `+` lines |
+| `word-diff-line-bg` | Keeps the muted `+`/`-` line background in word-diff mode |
+| `disable-spinner-tips` | Disables spinner tips regardless of settings |
+| `background-agent-usage` | Accounts terminal stream usage in the background agent progress row |
+| `statusline-committed-usage` | Exposes only committed terminal assistant usage to status-line payloads |
+| `statusline-rate-limit-windows` | Forwards the Fable 5 and usage-credit rate-limit windows to status-line payloads |
+| `version-output` | Appends `(patched)` to plain `--version` output |
+| `welcome-badge` | Renames the startup and help titles to `Calico Claude` |
+
+> **Note:** `tool-call-verbose` is **disabled in published releases** (thinking-only expansion, by
+> maintainer preference). The CI workflow and the verifier read the same `DISABLED_MODULES` value, so
+> the two never drift apart.
+
+### Opt-in adapters (dormant by default)
+
+Each of these changes nothing at all unless its trigger is present in the process environment.
+
+| Module | Trigger | Effect |
+|---|---|---|
+| `custom-context-window` | `CALICO_MODEL_CONTEXT_WINDOWS` | Uses an exact model-to-window map instead of the stock 200K assumption |
+| `active-turn-prompt-id` | `REMORA_ACTIVE=1` | Exposes Claude's own prompt UUID to a compatible gateway as `x-calico-prompt-id` |
+| `compact-request-source` | `REMORA_ACTIVE=1` + `compact` query source | Sends `x-calico-request-source: compact` so a gateway can apply class-level stream guards |
+| `compact-body-policy` | `REMORA_ACTIVE=1` + `CALICO_COMPACT_*` | Rewrites the full outbound compact JSON body before it leaves the process |
+| `gateway-fast-mode` | `REMORA_ACTIVE=1` | Applies `service_tier: "priority"` from remora's shared request-time worker state |
+
+> The startup banner reflects the **branding** patch only. An older build can print `Calico Claude`
+> while lacking a newer adapter entirely — see [Verify the installed binary](#verify-the-installed-binary).
+
+---
+
+## Install
+
+### Prerequisite
+
+Calico patches the **native** build. If Claude Code came from npm, replace it first:
+
+```bash
+npm uninstall -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
+claude --version
+```
+
+### Automatic
+
+The installer detects OS and CPU architecture and downloads the matching patched release for that
+version and platform. When an immutable rebuild such as `-2` exists, it selects the highest published
+rebuild suffix rather than overwriting or silently using the older artifact.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/calico-claude/main/install-patched-claude.sh | bash
+```
+
+```powershell
+irm https://raw.githubusercontent.com/Nanako0129/calico-claude/main/install-patched-claude.ps1 | iex
+```
+
+> **Prefer not to pipe a script from the internet?** Use the manual path below. The binaries are built
+> in GitHub Actions and the patcher is readable and modifiable, so convenience is the only reason to
+> trust this repo's release builds over your own.
+
+### Manual, from releases
+
+| Platform | Release tag suffix | Asset |
+|---|---|---|
+| macOS arm64 | `macos-arm64` | `claude.native.macos.patched` |
+| Linux x64 | `linux-x64` | `claude.native.patched` |
+| Linux arm64 | `linux-arm64` | `claude.native.patched` |
+| Windows x64 | `win32-x64` | `claude.native.windows.patched.exe` |
+| Windows arm64 | `win32-arm64` | `claude.native.windows.patched.exe` |
+
+Download the asset from the release matching your installed Claude version, then:
+
+```bash
+# Linux
+chmod +x ./claude.native.patched
+sudo mv ./claude.native.patched "$(which claude)"
+claude --version
+```
+
+```bash
+# macOS
+chmod +x ./claude.native.macos.patched
+sudo mv ./claude.native.macos.patched "$(which claude)"
+xattr -dr com.apple.quarantine "$(which claude)"
+claude --version
+```
+
+```powershell
+# Windows
+$target = (Get-Command claude).Source
+Copy-Item .\claude.native.windows.patched.exe $target -Force
+claude --version
+```
+
+### Side by side with official Claude
+
+Installing under a separate name avoids updater contention and makes rollback explicit:
+
+```bash
+install -m 0755 ./claude.native.patched ~/.local/bin/calico-claude
+~/.local/bin/calico-claude --version
+```
+
+```toml
+[runtime]
+claude_binary = "/absolute/path/to/.local/bin/calico-claude"
+```
+
+Leave `~/.local/bin/claude` under Anthropic's updater. Anthropic's updater does not touch a
+differently named binary, which is exactly why the Calico one never moves on its own.
+
+---
+
+## Keeping it updated
+
+The official updater can install a new version and repoint the `claude` symlink at an unpatched
+binary. The renamed Calico binary is immune to that, but it also stops receiving updates.
+
+[`examples/local-auto-update/`](./examples/local-auto-update/) closes that gap: a SessionStart hook
+that checks at most hourly, verifies checksum and build attestation **before** installing, rolls the
+symlink back if the new binary fails its post-install check, and reinstalls the patched build if the
+official updater ever overwrites it.
+
+---
+
+## Trust and security
+
+Calico replaces the native Claude Code executable, so installing it is a supply-chain decision rather
+than a normal configuration change. Every release passes the same gates:
+
+```mermaid
+flowchart TD
+    INST["Anthropic native installer
+claude.ai/install.sh"] --> PATCH["Patch suite + pinned tweakcc
+run with --assert-all"]
+    PATCH --> VERIFY["Structural verifier
+every enabled module must match"]
+    VERIFY --> SMOKE["PTY / Windows smoke test
+banner and --version"]
+    SMOKE --> SIGN["SHA-256 checksums
++ build provenance attestation"]
+    SIGN --> REL["Per-platform GitHub release"]
+    PATCH -.->|"anchor no longer matches"| FAIL["Build fails"]
+    VERIFY -.->|"module missing"| FAIL
+    SMOKE -.->|"binary does not start"| FAIL
+```
+
+| Gate | What it guarantees |
+|---|---|
+| `--assert-all` during patching | A patch whose upstream anchor no longer matches fails the build instead of silently applying nothing |
+| Structural verifier | Every enabled module is present in the produced binary, by symbol and shape |
+| PTY / Windows smoke test | The patched binary actually starts and renders the expected banner |
+| Pinned dependencies | The patcher version is fixed per build and recorded in the release metadata |
+| SHA-256 + attestation | The published asset matches its checksum and provably came out of this repo's CI |
+
+> ⚠️ **Before installing:** review the workflow and patch source, verify the release checksum and
+> attestation, and keep a reinstall path for the official Claude binary. remora's approval-gated
+> installer deliberately does not install Calico on your behalf.
+
+The context adapter is dormant by default. It never contacts a server and never reads credentials; it
+only accepts a child-process environment map. Exact model matching, bounded integer validation,
+malformed-input fallback, and remora's binary capability check together prevent a broad or silent
+context increase.
+
+---
+
+## Verify the installed binary
+
+Check the release SHA-256 and the GitHub attestation first. Then, from a source checkout, run the
+structural verifier against the exact binary you intend to use:
+
+```bash
+node scripts/verify-patched-binary.ts \
+  --input "$(command -v calico-claude)" \
+  --disable tool-call-verbose
+```
+
+> **A `(patched)` version label alone is not sufficient.** The banner comes from one module; the
+> adapters are separate ones. Treat the verifier's per-module report as the capability check —
+> `active-turn-prompt-id`, `background-agent-usage`, `statusline-committed-usage` and
+> `custom-context-window` must all report `ok`.
+
+remora users can run `remora doctor --online` instead.
+
+### Live thinking in the UI
+
+Streaming thinking also needs one Claude setting, in `~/.claude/settings.json`,
+`.claude/settings.json`, or `.claude/settings.local.json`:
+
+```json
+"showThinkingSummaries": true
+```
+
+---
+
+## Patch modules in detail
 
 ### Background-agent token usage
 
-Claude Code's native background tracker normally samples assistant usage as stream messages
-arrive. OpenAI-compatible gateways can create the assistant wrapper with provisional `0/0`
-usage, then deliver authoritative accounting in a terminal `message_delta` or mutate that same
-wrapper after the tracker sampled it. The foreground summary reads the finalized wrapper later,
-but without this patch the live background row can show elapsed time without any token count.
+Claude Code's native background tracker samples assistant usage as stream messages arrive.
+OpenAI-compatible gateways can create the assistant wrapper with provisional `0/0` usage and then
+deliver authoritative accounting later — in a terminal `message_delta`, or by mutating that same
+wrapper after the tracker already sampled it. The foreground summary reads the finalized wrapper
+eventually, but the live background row would show elapsed time with no token count.
 
-Calico tracks usage by response ID across `message_start`, terminal `message_delta`, and completed
-assistant wrappers. It refreshes from the mutated transcript at both progress and completion seams,
-while deduplicating output tokens seen through more than one path. The displayed total preserves
-Claude Code's native semantics: the latest response input and cache tokens plus cumulative output
-across the background agent's turns. This changes only local accounting; it does not modify the
-Claude or OpenAI-compatible gateway protocol.
+Calico tracks usage by response ID across three sources and refreshes at both the progress and the
+completion seam, deduplicating output tokens seen through more than one path.
 
-The structural verifier requires `__calicoTrackAgentUsage`, `__calicoRefreshAgentUsage`, the
-response-output deduplication map, and both refresh seams. Regression tests cover provisional
-`0/0`, terminal accounting, late mutation, repeated deltas, direct completed wrappers, and
-multi-turn totals.
+| Source | Role |
+|---|---|
+| `message_start` | Opens the response record, usually provisional |
+| Terminal `message_delta` | Authoritative accounting for the response |
+| Completed assistant wrapper | Covers gateways that mutate the wrapper in place |
+
+The displayed total preserves Claude Code's native semantics: latest response input and cache tokens,
+plus cumulative output across the background agent's turns. This changes local accounting only.
+
+| Verifier requires | Regression tests cover |
+|---|---|
+| `__calicoTrackAgentUsage` | Provisional `0/0` |
+| `__calicoRefreshAgentUsage` | Terminal accounting |
+| Response-output deduplication map | Late wrapper mutation |
+| Both refresh seams | Repeated deltas, direct completed wrappers, multi-turn totals |
 
 ### Committed status-line usage
 
-The status-line usage display is sourced from Calico's patched Claude Code message stream.
-The canonical query-stream assistant wrapper starts with a shared mutable commit cell,
-`__calicoUsageState: { committed: false, usage: null }`. The object cell is intentional:
-Claude Code shallow-copies the provisional wrapper into app state before the terminal event, so
-a primitive top-level boolean would remain stale even after the canonical wrapper commits. The
-shallow copies retain the cell reference. A trusted terminal `message_delta` stores both
-`committed: true` and the exact aggregated usage snapshot in that cell. Downstream tool-input and
-fallback transforms synchronize the same cell alongside usage and stop fields, and the status-line
-selector projects the saved snapshot instead of trusting later mutations to the provisional
-message usage.
+The canonical query-stream assistant wrapper starts with a shared mutable commit cell:
 
-A terminal event is trusted only when its raw usage is not the exact all-zero sentinel and the
-aggregated usage contains a non-zero accounting field (`input_tokens`, `output_tokens`, cache
-creation, or cache read). The sentinel requires explicit numeric `input_tokens: 0` and
-`output_tokens: 0`; flat cache creation/read fields may be omitted or zero, and nested
-`cache_creation.ephemeral_1h_input_tokens` and
-`cache_creation.ephemeral_5m_input_tokens` may also be omitted or zero. Any non-zero flat or
-nested cache field makes it non-sentinel. A raw event with only `output_tokens: 0` is not
-classified as the fallback because its input field is missing. The raw guard is required because
-Claude's `xAe` aggregation can retain positive message-start or previous-turn values when a
-synthetic terminal event reports all zeros. The saved snapshot is monotonic: a later untrusted
-all-zero delta cannot erase it. Valid partial-zero responses such as `input_tokens > 0` and
-`output_tokens = 0` are still committed.
+```js
+__calicoUsageState: { committed: false, usage: null }
+```
 
-Wrappers created at `message_start` or content-block cleanup remain provisional. UI-only
-thinking/responding virtual messages, `message_stop` cleanup, direct stream-error synthesized
-stop reasons, and the exact all-zero `[DONE]` fallback are therefore ignored by the status-line
-selector. Before the first committed response the display is unknown; while a later turn is
-still provisional it keeps the previous committed usage. The selector only projects committed
-snapshots from the already-sliced message array supplied by Claude Code, so compaction boundaries
-remain owned by the existing `kb()` slice and are never searched across by the new helper.
+> **Why an object rather than a boolean:** Claude Code shallow-copies the provisional wrapper into app
+> state before the terminal event arrives. A primitive top-level flag would stay stale in those copies
+> even after the canonical wrapper commits; the shallow copies retain the *cell reference*.
 
-The structural verifier checks the shared commit cell, terminal snapshot mutation, downstream
-clone synchronization, selector replacement, and absence of message-stop/UI-reducer commits. Run it
-against the exact binary you intend to use;
-a `(patched)` version label alone is not sufficient.
+A trusted terminal `message_delta` writes both `committed: true` and the exact aggregated usage
+snapshot into that cell. Downstream tool-input and fallback transforms synchronize the same cell, and
+the status-line selector projects the saved snapshot instead of trusting later mutations.
+
+**When is a terminal event trusted?** Both conditions must hold:
+
+| Condition | Requirement |
+|---|---|
+| Raw usage is not the all-zero sentinel | See the sentinel table below |
+| Aggregated usage has real accounting | Any non-zero `input_tokens`, `output_tokens`, cache creation, or cache read |
+
+**What counts as the all-zero sentinel:**
+
+| Field | Sentinel requirement |
+|---|---|
+| `input_tokens` | Explicit numeric `0` — a *missing* field disqualifies |
+| `output_tokens` | Explicit numeric `0` — a *missing* field disqualifies |
+| Flat cache creation / read | May be omitted or zero |
+| `cache_creation.ephemeral_1h_input_tokens` | May be omitted or zero |
+| `cache_creation.ephemeral_5m_input_tokens` | May be omitted or zero |
+| Any of the above non-zero | Not a sentinel |
+
+The raw guard is required because Claude's `xAe` aggregation can retain positive message-start or
+previous-turn values when a synthetic terminal event reports all zeros.
+
+**How each wrapper is classified:**
+
+| Wrapper origin | Classification |
+|---|---|
+| Terminal `message_delta`, trusted | **Committed** — projected to the status line |
+| `message_start` | Provisional |
+| Content-block cleanup | Provisional |
+| UI-only thinking / responding virtual message | Ignored |
+| `message_stop` cleanup | Ignored |
+| Direct stream-error synthesized stop reason | Ignored |
+| Exact all-zero `[DONE]` fallback | Ignored |
+
+**What the status line shows:**
+
+| State | Display |
+|---|---|
+| Before the first committed response | Unknown |
+| A later turn still provisional | Previous committed usage |
+| A later untrusted all-zero delta arrives | Previous committed usage — the snapshot is monotonic |
+| Partial-zero but valid (`input > 0`, `output = 0`) | Committed normally |
+
+The selector only projects committed snapshots from the already-sliced message array Claude Code
+supplies, so compaction boundaries stay owned by the existing `kb()` slice and are never searched
+across by the new helper.
+
+The verifier checks the shared commit cell, terminal snapshot mutation, downstream clone
+synchronization, selector replacement, and the *absence* of message-stop and UI-reducer commits.
+
+### Fable 5 and usage-credit rate-limit windows
+
+Claude Code parses four rate-limit windows from response headers into one internal state object, then
+projects only two of them into the status-line payload:
+
+| Window | Upstream key | Stock Claude Code | With this patch |
+|---|---|---|---|
+| Session | `five_hour` | Projected | Projected |
+| Weekly | `seven_day` | Projected | Projected |
+| "Fable 5 limit" | `seven_day_overage_included` | Parsed, then dropped | Projected |
+| Usage credit | `overage` | Parsed, then dropped | Projected |
+
+The patch appends the two missing windows in the same shape and under their upstream key names, and
+widens the payload guard so a payload carrying only a Fable or credit window still emits
+`rate_limits`. There is no extra request and no extra per-render work — the data is already parsed by
+the time the payload is built.
+
+Windows appear only when the server sends the corresponding headers for that account; otherwise the
+payload is unchanged. Because upstream key names are preserved, a status line written against this
+patch keeps working if Anthropic later forwards the same windows itself.
+
+The verifier requires all four forwarded windows, the widened `rate_limits` guard, and the absence of
+the original two-window guard.
 
 ### Optional custom-model context windows
 
@@ -99,189 +361,106 @@ export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=90
 claude --model gpt-5.6-sol
 ```
 
-The map is parsed locally, accepts only exact model ids and integer windows from 100K through 1M, and
-falls back to Claude Code's stock behavior on malformed input. The display percentage only affects the
-status-line denominator. In this opt-in mode Calico also bypasses Claude's separate output-reserve and
-precompute-buffer deductions, so the compact percentage is applied once to the raw mapped window. With
-the values above, status-line consumers see 353.4K usable tokens and compaction starts at 334.8K.
+| Property | Behavior |
+|---|---|
+| Parsing | Local; no network |
+| Accepted keys | Exact model ids only |
+| Accepted values | Integer windows from 100K through 1M |
+| Malformed input | Falls back to stock Claude Code behavior |
+| `CALICO_CONTEXT_DISPLAY_PERCENT` | Affects the status-line denominator only |
+| Output reserve / precompute buffer | Bypassed in this mode, so the compact percentage applies once to the raw mapped window |
 
-remora users should select its `calico` context mode instead of exporting these variables manually.
-The default remora `stock` mode does not require Calico and remains capped at Claude Code's native 200K.
+With the values above, status-line consumers see 353.4K usable tokens and compaction starts at 334.8K.
+
+> **remora users:** select its `calico` context mode instead of exporting these manually. The default
+> remora `stock` mode does not require Calico and stays capped at Claude Code's native 200K.
 
 ### Optional active-turn identity
 
-Claude Code already maintains a prompt UUID across the initial model request and
-its tool-result continuations. When `REMORA_ACTIVE=1`, Calico exposes that value
-to a compatible gateway as `x-calico-prompt-id` and sends
-`x-calico-active-turn-version: 1`. Spawned agents freeze the prompt UUID in
-their async context, and nested agents inherit the frozen parent value, so a
-background agent keeps its original turn identity if the main session accepts a
-later user prompt.
+Claude Code already maintains a prompt UUID across the initial model request and its tool-result
+continuations. With `REMORA_ACTIVE=1`, Calico exposes it to a compatible gateway:
 
-Only Claude's own `main` and `subagent` query-source classes receive these
-headers. Quota checks, token counting, compaction, side queries, and other
-auxiliary requests are excluded so they cannot read or overwrite agentic turn
-state. Calico-owned header values are written after custom headers and therefore
-cannot be replaced through `ANTHROPIC_CUSTOM_HEADERS`.
+| Header | Value |
+|---|---|
+| `x-calico-prompt-id` | Claude's own prompt UUID for the active turn |
+| `x-calico-active-turn-version` | `1` |
 
-The adapter marker is `calico-active-turn-adapter:v1`. The patch gate requires
-both the AsyncLocalStorage capture and HTTP header anchors; if either upstream
-shape changes, the module applies nothing and the release build fails. The
-adapter does not store or forward Codex backend state. A compatible gateway
-must still capture and replay the server-issued `x-codex-turn-state`; the Calico
-header only provides the Claude-side turn boundary. Plain Calico launches do
-not emit either header.
+| Query source | Receives the headers? |
+|---|---|
+| `main` | Yes |
+| `subagent` | Yes |
+| Quota checks | No |
+| Token counting | No |
+| Compaction | No |
+| Side queries | No |
+
+Excluding auxiliary traffic is deliberate: those requests must not read or overwrite agentic turn
+state. Spawned agents freeze the prompt UUID in their async context and nested agents inherit the
+frozen parent value, so a background agent keeps its original turn identity even if the main session
+accepts a later user prompt.
+
+| Property | Behavior |
+|---|---|
+| Adapter marker | `calico-active-turn-adapter:v1` |
+| Patch gate | Requires **both** the AsyncLocalStorage capture and the HTTP header anchors |
+| If either upstream shape changes | The module applies nothing and the release build fails |
+| `ANTHROPIC_CUSTOM_HEADERS` override | Impossible — Calico values are written after custom headers |
+| Codex backend state | Not stored, not forwarded |
+| Plain Calico launch (no `REMORA_ACTIVE`) | Neither header is emitted |
+
+A compatible gateway must still capture and replay the server-issued `x-codex-turn-state`; the Calico
+header only provides the Claude-side turn boundary.
 
 ### Optional remora compact policy
 
-When `REMORA_ACTIVE=1` and Claude's query source is `compact`, Calico:
+When `REMORA_ACTIVE=1` and Claude's query source is `compact`, Calico sends
+`x-calico-request-source: compact` so a gateway can apply class-level stream guards (absolute
+duration, no retry) without rewriting product fields, and wraps the Anthropic client `fetchOverride`
+so the **full** outbound JSON body is rewritten before the request leaves the process.
 
-1. Sends `x-calico-request-source: compact` so a compatible gateway can apply
-   class-level stream guards (absolute duration / no retry) without rewriting
-   product fields.
-2. Wraps the Anthropic client `fetchOverride` so the **full** outbound JSON body
-   is rewritten before the request leaves the process.
-
-Body policy is controlled by the remora child process environment (not by the
-gateway):
+Body policy comes from the remora child process environment, not from the gateway:
 
 | Variable | Default | Effect |
-|----------|---------|--------|
+|---|---|---|
 | `CALICO_COMPACT_EFFORT` | `medium` | Sets `output_config.effort` and top-level `effort` when present |
-| `CALICO_COMPACT_MODEL` | empty | When non-empty, overrides top-level `model`; empty keeps session model |
-| `CALICO_COMPACT_DISABLE_THINKING` | off | Set `1` to force `thinking: { "type": "disabled" }` when present; unset leaves session thinking |
+| `CALICO_COMPACT_MODEL` | empty | When non-empty, overrides top-level `model`; empty keeps the session model |
+| `CALICO_COMPACT_DISABLE_THINKING` | off | Set `1` to force `thinking: { "type": "disabled" }` when present; unset keeps session thinking |
 
-Main / subagent / quota / side-query traffic is not rewritten. Plain Calico
-launches without `REMORA_ACTIVE=1` keep stock compact behavior.
+Main, subagent, quota and side-query traffic is never rewritten. Plain Calico launches without
+`REMORA_ACTIVE=1` keep stock compact behavior.
 
-## Trust and security
-
-Calico replaces the native Claude Code executable, so installing it is a supply-chain decision rather than a normal remora configuration change. Releases are built in GitHub Actions from Anthropic's native installer, use pinned patch dependencies, fail when a selected patch no longer matches the upstream bundle, and publish SHA-256 checksums plus GitHub provenance attestations.
-
-The context adapter is dormant by default. It never contacts a server or reads credentials; it only accepts a child-process environment map. Exact model matching, bounded integer validation, malformed-input fallback, and remora's binary capability check prevent a broad or silent context increase. Plain Claude Code launches without those variables retain stock context behavior.
-
-Before installation, review the workflow and patch source, verify the release checksum and attestation, and keep a copy or reinstall path for the official Claude binary. remora's approval-gated installer deliberately does not install Calico on the user's behalf.
-
-#### Thinking note:
-
-- If you want thinking to stream live in the UI without verbose mode, add this to your Claude settings:
-
-```json
-"showThinkingSummaries": true
-```
-- Settings can come from `~/.claude/settings.json`, `.claude/settings.json`, or `.claude/settings.local.json`.
+---
 
 ## Questions and answers
 
 ### Does Calico send prompts or credentials anywhere?
 
-No. Calico is a patched native Claude Code executable, not a gateway or hosted service. The build pipeline downloads Anthropic's native binary, applies reviewable local patches, and publishes the result. Claude Code still sends data to whichever provider or gateway its runtime configuration selects.
+No. Calico is a patched native Claude Code executable, not a gateway or hosted service. The build
+pipeline downloads Anthropic's native binary, applies reviewable local patches, and publishes the
+result. Claude Code still sends data to whichever provider or gateway its runtime configuration
+selects.
 
 ### Does Calico itself route Claude Code to OpenAI models?
 
-No. The OpenAI routing comes from a launcher such as remora plus an Anthropic-compatible gateway. Calico contributes UI transparency, optional custom-model context handling, and a stable prompt identity for compatible active-turn bridges.
+No. OpenAI routing comes from a launcher such as remora plus an Anthropic-compatible gateway. Calico
+contributes UI transparency, optional custom-model context handling, and a stable prompt identity for
+compatible active-turn bridges.
 
 ### Will Claude Code updates remove the patches?
 
-Yes. The official updater can install a new version and move the `claude` symlink to that unpatched binary. Re-run the Calico installer after every Claude Code update, then verify the new release before relying on it.
+Yes, if Calico is installed over `claude` itself — the official updater installs a new version and
+repoints the symlink at the unpatched binary. Either re-run the Calico installer after every update,
+or use a [side-by-side install](#side-by-side-with-official-claude) plus
+[`examples/local-auto-update/`](./examples/local-auto-update/).
 
 ### Why can the startup banner say Calico while a newer adapter is missing?
 
-The branding patch and functional adapters are separate modules. An older Calico build may still print the patched banner but lack a later `custom-context-window` or `active-turn-prompt-id` module. Use the binary verifier, or `remora doctor --online` when using remora, instead of treating the banner as a complete capability check.
-
-### Can I keep official Claude and Calico side by side?
-
-Yes. This avoids updater contention and makes rollback explicit. Download and verify the patched release, install it under a separate name, and point remora at that path:
-
-```bash
-install -m 0755 ./claude.native.patched ~/.local/bin/calico-claude
-~/.local/bin/calico-claude --version
-```
-
-```toml
-[runtime]
-claude_binary = "/absolute/path/to/.local/bin/calico-claude"
-```
-
-Leave the official `~/.local/bin/claude` symlink under Anthropic's updater. A separately named Calico binary does not update automatically; replace it only after verifying a matching newer release.
+The branding patch and the functional adapters are separate modules. An older Calico build can still
+print the patched banner while lacking a later `custom-context-window` or `active-turn-prompt-id`
+module. Use the [verifier](#verify-the-installed-binary), not the banner.
 
 ### Does the active-turn adapter bypass Codex quota limits?
 
-No. It only exposes Claude's existing prompt boundary to a compatible gateway. The gateway must preserve the server-issued Codex state, and OpenAI still decides whether a recognized turn may continue under fair-use policy.
-
-### How do I verify the installed binary?
-
-Check the release SHA-256 and GitHub attestation first. From a source checkout, the structural verifier confirms every enabled patch module:
-
-```bash
-node scripts/verify-patched-binary.ts \
-  --input "$(command -v calico-claude)" \
-  --disable tool-call-verbose
-```
-
-The verifier must report `active-turn-prompt-id`, `background-agent-usage`, `statusline-committed-usage`, and `custom-context-window` as `ok`; a patched version label alone is insufficient.
-
-## Quick Start
-
-### Prerequisite
-
-If you installed Claude Code via npm, remove it and install the native build first:
-
-```bash
-npm uninstall -g @anthropic-ai/claude-code
-curl -fsSL https://claude.ai/install.sh | bash
-claude --version
-```
-
-### Automatic Install
-
-This installer detects your OS and CPU architecture and downloads the matching patched release for that version and platform. If an immutable rebuild such as `-2` exists, it selects the highest published rebuild suffix instead of overwriting or silently using the older artifact.
-```bash
-curl -fsSL https://raw.githubusercontent.com/Nanako0129/calico-claude/main/install-patched-claude.sh | bash
-```
-
-On Windows, use PowerShell:
-```powershell
-irm https://raw.githubusercontent.com/Nanako0129/calico-claude/main/install-patched-claude.ps1 | iex
-```
-
-If you'd rather avoid blindly running scripts from the internet, you can do it the manual way below.
-That said, the binaries are built on Github Actions and the patcher is also free for you to see and modify, so there's no reason to trust this repo or the release builds other than convenience.
-
-### Manual Install (From Releases, native only)
-
-1. Pick the release tag for your platform:
-   - macOS arm64: `macos-arm64`
-   - Linux x64: `linux-x64`
-   - Linux arm64: `linux-arm64`
-   - Windows x64: `win32-x64`
-   - Windows arm64: `win32-arm64`
-
-2. In that release, download the regular patched binary for your platform.
-
-3. Follow the install instructions for your platform below.
-
-### Install (Linux)
-
-```bash
-chmod +x ./claude.native.patched
-sudo mv ./claude.native.patched "$(which claude)"
-claude --version
-```
-
-### Install (macOS)
-
-```bash
-chmod +x ./claude.native.macos.patched
-sudo mv ./claude.native.macos.patched "$(which claude)"
-xattr -dr com.apple.quarantine "$(which claude)"
-claude --version
-```
-
-### Install (Windows)
-
-```powershell
-$target = (Get-Command claude).Source
-Copy-Item .\claude.native.windows.patched.exe $target -Force
-claude --version
-```
+No. It only exposes Claude's existing prompt boundary to a compatible gateway. The gateway must
+preserve the server-issued Codex state, and OpenAI still decides whether a recognized turn may
+continue under fair-use policy.

--- a/README.md
+++ b/README.md
@@ -154,9 +154,13 @@ The official updater can install a new version and repoint the `claude` symlink 
 binary. The renamed Calico binary is immune to that, but it also stops receiving updates.
 
 [`examples/local-auto-update/`](./examples/local-auto-update/) closes that gap: a SessionStart hook
-that checks at most hourly, verifies checksum and build attestation **before** installing, rolls the
-symlink back if the new binary fails its post-install check, and reinstalls the patched build if the
-official updater ever overwrites it.
+that checks at most hourly and never blocks startup. Before anything is installed it verifies the
+release checksum, and — when an authenticated `gh` is available — the build provenance attestation;
+without `gh` it logs a warning and proceeds on the checksum alone, so provenance is not a guarantee
+in that configuration. The downloaded build is then run and must report the exact expected version
+plus `(patched)`; only after that does the launcher symlink move. A build that fails leaves the
+launcher untouched, so there is nothing to roll back. It also reinstalls the patched build if the
+official updater ever replaces it.
 
 ---
 

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -25,10 +25,14 @@ SessionStart hook ──► update.sh --hook ──► throttled? ──► exit
                                                      │
    run the downloaded file in place: exact version + `(patched)` (fail-hard)
                                                      │
-   install versions/<X.Y.Z> ─► atomic symlink swap ─► re-check through the link
+   install versions/<X.Y.Z> — or a unique sibling <X.Y.Z>.<pid> when that path
+   already exists; an install NEVER writes over an existing file
                                                      │
-                              mismatch ─► restore the previous target, or remove
-                                          the link when there is no previous one
+   atomic symlink swap ─► re-check through the link
+                                                     │
+                              mismatch ─► point the link back at the previous
+                                          target (never touched), or remove it
+                                          when there is no previous one
                                                      │
                                             prune to the newest 3 versions
 ```
@@ -39,10 +43,10 @@ a script and not a one-line `curl | bash` in a cron job:
 | Property | Why |
 | --- | --- |
 | Verification happens **before** install | A failed checksum, attestation, or version check must never reach `versions/`, let alone the symlink. |
-| The artifact is run **where it was downloaded** | `--force` and the self-heal path both write to a destination that already exists. Checking only after that write would destroy the very build the rollback needs to restore. |
-| Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. |
-| Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. |
-| A lock records its **owner pid** | A run killed by SIGKILL or a reboot leaves the lock behind. Without a liveness check, every later run would treat that corpse as contention and exit 0 forever, silently ending all updates. A lock with no owner *yet* is treated as a run still starting up, not as a corpse — deleting it would let two installers proceed at once. |
+| Installs **never overwrite** | If the destination exists (`--force`, the self-heal, a same-version rebuild), the new build goes to a unique sibling `<X.Y.Z>.<pid>` instead. No intermediate state where the working binary is gone can exist, so no preserve/restore/recover machinery is needed — rollback is only ever a symlink swap back to a file that was never touched. |
+| Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
+| Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. The failed build stays in `versions/` and is pruned like any other old one. |
+| The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
 | Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
 
 It also self-heals one specific failure: if the installed version already matches
@@ -141,21 +145,24 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-52 assertions, offline: platform detection, the checksum gate (tampered, absent,
+63 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
-throttling, lock ownership across live / stale / not-yet-written owners, log
-rotation, release selection, and end-to-end `--run` cases driven through stubbed
-`curl` and `gh`:
+throttling, lock behaviour (a young lock blocks; an aged one is ignored but
+never removed), log rotation, release selection, and end-to-end `--run` cases
+driven through stubbed `curl` and `gh`:
 
 | Case | Expected |
 |---|---|
 | A good artifact | Installs; symlink points at it |
-| A bad artifact under `--force` | Run fails; the existing same-version build survives byte-for-byte |
+| A bad artifact under `--force` | Run fails before install; the existing same-version build survives byte-for-byte |
+| A `--force` reinstall over an existing build | New build lands on a **new suffixed path**; the existing file is byte-identical afterwards |
+| Passes pre-install, fails once installed | Run fails; symlink returns to the untouched previous target |
 | A version that merely *contains* the expected one | Rejected; nothing installed |
 | Passes pre-install, fails afterwards, no previous target | Run fails; no symlink left behind |
 | A `-2` rebuild of the installed version | Installed; the tag is recorded |
 | A rebuild already installed, or no tag recorded | Left alone |
+| A suffixed symlink target | Reads as its bare version; pruning never deletes it |
 
 Two of those cases run under `/bin/bash` specifically rather than whatever `bash`
 is on `PATH`. Stock macOS ships bash 3.2, where `"${empty_array[@]}"` is an

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -23,10 +23,12 @@ SessionStart hook ──► update.sh --hook ──► throttled? ──► exit
                                                      │
    download ─► checksums.txt (fail-hard) ─► gh attestation verify (fail-hard)
                                                      │
-   install versions/<X.Y.Z> ─► atomic symlink swap ─► `--version` must show
-                                                      the new version AND
-                                                      `(patched)`, else roll the
-                                                      symlink back
+   run the downloaded file in place: exact version + `(patched)` (fail-hard)
+                                                     │
+   install versions/<X.Y.Z> ─► atomic symlink swap ─► re-check through the link
+                                                     │
+                              mismatch ─► restore the previous target, or remove
+                                          the link when there is no previous one
                                                      │
                                             prune to the newest 3 versions
 ```
@@ -36,8 +38,11 @@ a script and not a one-line `curl | bash` in a cron job:
 
 | Property | Why |
 | --- | --- |
-| Verification happens **before** install | A failed checksum or attestation must never reach `versions/`, let alone the symlink. |
-| Post-install verify can **roll back** | If the new binary does not report both the expected version and `(patched)`, the symlink returns to the previous target and the run exits non-zero. |
+| Verification happens **before** install | A failed checksum, attestation, or version check must never reach `versions/`, let alone the symlink. |
+| The artifact is run **where it was downloaded** | `--force` and the self-heal path both write to a destination that already exists. Checking only after that write would destroy the very build the rollback needs to restore. |
+| Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. |
+| Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. |
+| A lock records its **owner pid** | A run killed by SIGKILL or a reboot leaves the lock behind. Without a liveness check, every later run would treat that corpse as contention and exit 0 forever, silently ending all updates. |
 
 It also self-heals one specific failure: if the installed version already matches
 the latest release but `--version` no longer prints `(patched)`, the official
@@ -135,10 +140,14 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-An offline self-check: platform detection, the checksum gate (including tampered,
-absent, and empty `checksums.txt`), pruning (including the rollback shape where
-the symlink points at an older build), hook throttling, lock contention, log
-rotation, and release selection against a stubbed `curl`.
+46 assertions, offline: platform detection, the checksum gate (tampered, absent,
+empty, and a decoy that only matches through an unescaped dot), pruning
+(including the rollback shape where the symlink points at an older build), hook
+throttling, live vs. stale lock ownership, log rotation, release selection, and
+a set of end-to-end `--run` cases driven through stubbed `curl` and `gh`: a good
+artifact installs; a bad artifact leaves an existing same-version build intact;
+a version that merely *contains* the expected one is rejected; and a binary that
+passes its pre-install check but fails afterwards leaves no symlink behind.
 
 Two of those cases run under `/bin/bash` specifically rather than whatever `bash`
 is on `PATH`. Stock macOS ships bash 3.2, where `"${empty_array[@]}"` is an

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -50,6 +50,7 @@ a script and not a one-line `curl | bash` in a cron job:
 | The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
 | A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
 | Pruning is gated by **age**, not by the lock | An entry younger than `PRUNE_MIN_AGE_SECONDS` may belong to a run that has not swapped its link yet, so it is left alone. Gating on the lock instead would have been worse: an abandoned lock is never removed, so pruning would stop for good. |
+| An expired commit lock is **not reclaimed** | Every delete-and-reacquire protocol tried here let two runs enter the section the lock serializes. Unlike the run lock, this one spans two syscalls and cannot be stranded by an ordinary kill, so a stranded one means something needs a human — and stopping is the safe direction. The message names the directory to remove. |
 | The launcher update is **serialized** | Downloading and installing need no exclusion because they are append-only, but reading the current target, deciding, and swapping is a read-modify-write on shared state. A short commit lock covers only those steps; failing to take it leaves the launcher unchanged and the build in place for a later run. |
 | Downgrades compare the **whole release identity** | Version alone would treat a base tag and its `-2` rebuild as equal and let a stale run replace the newer one. |
 | The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
@@ -151,7 +152,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-87 assertions, offline: platform detection, the checksum gate (tampered, absent,
+89 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -46,6 +46,7 @@ a script and not a one-line `curl | bash` in a cron job:
 | Installs **never overwrite** | If the destination exists (`--force`, the self-heal, a same-version rebuild), the new build goes to a unique sibling `<X.Y.Z>.<pid>` instead. No intermediate state where the working binary is gone can exist, so no preserve/restore/recover machinery is needed — rollback is only ever a symlink swap back to a file that was never touched. |
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
 | Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. The failed build stays in `versions/` and is pruned like any other old one. |
+| Pruning only runs while **holding the lock** | An ignored lock lets runs overlap by design, and an overlapping run may have installed a destination without swapping its symlink yet. Deleting it would strand that run, so a run without the lock skips the cleanup pass. |
 | The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
 | Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
 
@@ -145,7 +146,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-63 assertions, offline: platform detection, the checksum gate (tampered, absent,
+68 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -33,10 +33,10 @@ SessionStart hook ──► update.sh --hook ──► throttled? ──► exit
                               mismatch ─► leave the launcher untouched and exit;
                                           the rejected build is pruned later
                                                      │
-   atomic symlink swap, unless the launcher already points at a newer version
+              write the tag record, then atomic symlink swap; a failed write
+                                     leaves the launcher unchanged
                                                      │
-                                            prune, skipping builds young enough
-                                            to belong to an overlapping run
+                                                  prune
 ```
 
 Two properties are worth stating explicitly, because they are the reason this is
@@ -49,13 +49,7 @@ a script and not a one-line `curl | bash` in a cron job:
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
 | The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
 | A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
-| Pruning runs **inside the commit lock** | Pruning snapshots the current target and then deletes. If another run swaps in between, the snapshot names a build that is no longer current and the live one can be deleted, leaving the launcher dangling. Inside the lock the target cannot move. |
-| The tag record and the launcher **advance together** | They describe one fact between them. The record is written to a temporary file before the swap, so a failure is caught while the launcher is still untouched; what remains after the swap is a rename. |
-| The destination is **re-checked under the commit lock** | Age-based in-flight protection assumes a run reaches the swap soon after installing; a suspended machine breaks that. One stat inside the lock is the only point where the answer cannot change underneath. |
-| Pruning is gated by **age**, not by the lock | An entry younger than `PRUNE_MIN_AGE_SECONDS` may belong to a run that has not swapped its link yet, so it is left alone. Gating on the lock instead would have been worse: an abandoned lock is never removed, so pruning would stop for good. |
-| An expired commit lock is **not reclaimed** | Every delete-and-reacquire protocol tried here let two runs enter the section the lock serializes. Unlike the run lock, this one spans two syscalls and cannot be stranded by an ordinary kill, so a stranded one means something needs a human — and stopping is the safe direction. The message names the directory to remove. |
-| The launcher update is **serialized** | Downloading and installing need no exclusion because they are append-only, but reading the current target, deciding, and swapping is a read-modify-write on shared state. A short commit lock covers only those steps; failing to take it leaves the launcher unchanged and the build in place for a later run. |
-| Downgrades compare the **whole release identity** | Version alone would treat a base tag and its `-2` rebuild as equal and let a stale run replace the newer one. |
+| The tag record and the launcher **advance together** | They describe one fact between them. The record is written before the swap, so a failure to write it is caught while the launcher is still untouched. |
 | The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
 | Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
 
@@ -63,6 +57,10 @@ It also self-heals one specific failure: if the installed version already matche
 the latest release but `--version` no longer prints `(patched)`, the official
 updater (or a manual `claude install`) has overwritten the patched build, and the
 script reinstalls it.
+
+Concurrent updaters are outside this example's scope: normal use is one hook, on
+one machine, at most once an hour, and the behavior of two overlapping runs is
+not defined.
 
 ## Install
 
@@ -155,7 +153,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-95 assertions, offline: platform detection, the checksum gate (tampered, absent,
+79 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but
@@ -173,6 +171,7 @@ driven through stubbed `curl` and `gh`:
 | A `-2` rebuild of the installed version | Installed; the tag is recorded |
 | A rebuild already installed, or no tag recorded | Left alone |
 | A suffixed symlink target | Reads as its bare version; pruning never deletes it |
+| The tag record can't be written | Run exits 0; launcher and record both stay unchanged |
 
 Two of those cases run under `/bin/bash` specifically rather than whatever `bash`
 is on `PATH`. Stock macOS ships bash 3.2, where `"${empty_array[@]}"` is an

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -49,6 +49,8 @@ a script and not a one-line `curl | bash` in a cron job:
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
 | The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
 | A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
+| Pruning runs **inside the commit lock** | Pruning snapshots the current target and then deletes. If another run swaps in between, the snapshot names a build that is no longer current and the live one can be deleted, leaving the launcher dangling. Inside the lock the target cannot move. |
+| The tag record and the launcher **advance together** | They describe one fact between them. The record is written to a temporary file before the swap, so a failure is caught while the launcher is still untouched; what remains after the swap is a rename. |
 | The destination is **re-checked under the commit lock** | Age-based in-flight protection assumes a run reaches the swap soon after installing; a suspended machine breaks that. One stat inside the lock is the only point where the answer cannot change underneath. |
 | Pruning is gated by **age**, not by the lock | An entry younger than `PRUNE_MIN_AGE_SECONDS` may belong to a run that has not swapped its link yet, so it is left alone. Gating on the lock instead would have been worse: an abandoned lock is never removed, so pruning would stop for good. |
 | An expired commit lock is **not reclaimed** | Every delete-and-reacquire protocol tried here let two runs enter the section the lock serializes. Unlike the run lock, this one spans two syscalls and cannot be stranded by an ordinary kill, so a stranded one means something needs a human — and stopping is the safe direction. The message names the directory to remove. |
@@ -153,7 +155,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-92 assertions, offline: platform detection, the checksum gate (tampered, absent,
+95 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -1,0 +1,158 @@
+# Local auto-update
+
+Keeps a locally installed patched Claude binary current with this repo's releases,
+without letting it fight Anthropic's own updater.
+
+The design is deliberately side-by-side:
+
+> `~/.local/bin/claude` stays a symlink managed by the official installer.
+> `~/.local/bin/calico-claude` is a **separately named** symlink managed by `update.sh`.
+> Neither updater ever writes the other's path.
+
+Point your launcher (remora's `runtime.claude_binary`, a shell alias, an editor
+setting) at the Calico name; leave `claude` alone.
+
+## What it does
+
+```
+SessionStart hook ──► update.sh --hook ──► throttled? ──► exit 0
+                                            │
+                                            └─ spawn detached `--run`, exit 0
+                                                     │
+   GitHub releases API ── highest v<X.Y.Z>-<platform>[-<rebuild>] with our asset
+                                                     │
+   download ─► checksums.txt (fail-hard) ─► gh attestation verify (fail-hard)
+                                                     │
+   install versions/<X.Y.Z> ─► atomic symlink swap ─► `--version` must show
+                                                      the new version AND
+                                                      `(patched)`, else roll the
+                                                      symlink back
+                                                     │
+                                            prune to the newest 3 versions
+```
+
+Two properties are worth stating explicitly, because they are the reason this is
+a script and not a one-line `curl | bash` in a cron job:
+
+| Property | Why |
+| --- | --- |
+| Verification happens **before** install | A failed checksum or attestation must never reach `versions/`, let alone the symlink. |
+| Post-install verify can **roll back** | If the new binary does not report both the expected version and `(patched)`, the symlink returns to the previous target and the run exits non-zero. |
+
+It also self-heals one specific failure: if the installed version already matches
+the latest release but `--version` no longer prints `(patched)`, the official
+updater (or a manual `claude install`) has overwritten the patched build, and the
+script reinstalls it.
+
+## Install
+
+**1. Put the script somewhere stable.**
+
+```bash
+mkdir -p ~/.claude/calico
+cp examples/local-auto-update/update.sh ~/.claude/calico/update.sh
+chmod +x ~/.claude/calico/update.sh
+```
+
+**2. Do the first install by hand and look at the output.**
+
+```bash
+~/.claude/calico/update.sh --check   # read-only: installed vs latest
+~/.claude/calico/update.sh --run
+~/.local/bin/calico-claude --version # expect: <version> (Claude Code) (patched)
+```
+
+Running `--run` once manually matters: it is the only time you will see the
+checksum and attestation lines on your terminal instead of in a log file.
+
+**3. Wire the SessionStart hook** in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/calico/update.sh --hook",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`--hook` reads its throttle file, spawns a detached `--run` at most once an hour,
+and returns immediately; it never blocks session startup and ignores the hook's
+stdin payload. `async: true` plus the short timeout are belt and braces.
+
+An updated binary is picked up by the **next** session, not the running one.
+
+## Modes
+
+| Mode | Effect |
+| --- | --- |
+| `--hook` | Throttled entry point. Exits 0 immediately inside the window; otherwise stamps `last-check`, rotates the log, spawns a detached `--run`, exits 0. |
+| `--run` | Update if a newer verified release exists. |
+| `--force` | Reinstall even when already up to date — skips *only* the version gate. Checksum, attestation and post-verify still run. Use after a rebuilt release at the same version. |
+| `--check` | Report installed vs latest. Changes nothing, downloads nothing. |
+
+## Configuration
+
+Every path and policy knob is an environment variable with a sane default, so the
+script itself needs no editing:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CALICO_REPO` | `Nanako0129/calico-claude` | Release repo to track. |
+| `CALICO_PLATFORM` | auto-detected | Force a platform suffix (`linux-x64`, `linux-arm64`, `macos-arm64`, `win32-x64`, `win32-arm64`). |
+| `CALICO_BIN_LINK` | `~/.local/bin/calico-claude` | The managed symlink. |
+| `CALICO_VERSIONS_DIR` | `~/.local/share/calico-claude/versions` | Where builds are kept. |
+| `CALICO_STATE_DIR` | `~/.claude/calico` | Lock, throttle stamp, and `update.log`. |
+| `CALICO_KEEP_VERSIONS` | `3` | Newest builds to keep. `0` disables pruning. The current symlink target is always kept — after a rollback it survives on top of the newest N. |
+| `CALICO_THROTTLE_SECONDS` | `3600` | Minimum gap between `--hook` checks. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | unset | Bearer token for the releases API, if you hit the anonymous rate limit. |
+
+Pruning is not cosmetic. Each build is roughly 300 MB, so an unattended updater
+left alone for a few months will quietly consume several gigabytes.
+
+## Requirements
+
+`bash` 3.2+, `curl`, `python3`, and `shasum` (macOS) or `sha256sum` (Linux).
+
+`gh` is optional but strongly recommended: without an authenticated `gh`, build
+provenance attestation cannot be checked and the script logs a warning and
+proceeds on the checksum alone. The checksum proves the file matches the release
+asset; the attestation proves the release asset came out of this repo's CI.
+
+## Verify it works
+
+```bash
+bash examples/local-auto-update/test-update.sh
+```
+
+An offline self-check: platform detection, the checksum gate (including tampered,
+absent, and empty `checksums.txt`), pruning (including the rollback shape where
+the symlink points at an older build), hook throttling, lock contention, log
+rotation, and release selection against a stubbed `curl`.
+
+Two of those cases run under `/bin/bash` specifically rather than whatever `bash`
+is on `PATH`. Stock macOS ships bash 3.2, where `"${empty_array[@]}"` is an
+unbound variable under `set -u`; a Homebrew bash 5.x on `PATH` hides that entire
+class of bug, and it hid a real one here — the releases API call aborted before
+its first request for anyone without `GH_TOKEN` set.
+
+The suite runs entirely in a sandbox: no network, no writes to real install paths.
+
+## Uninstall
+
+```bash
+# Remove the hook entry from ~/.claude/settings.json, then:
+rm -rf ~/.claude/calico
+rm -f ~/.local/bin/calico-claude
+rm -rf ~/.local/share/calico-claude
+```

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -42,7 +42,8 @@ a script and not a one-line `curl | bash` in a cron job:
 | The artifact is run **where it was downloaded** | `--force` and the self-heal path both write to a destination that already exists. Checking only after that write would destroy the very build the rollback needs to restore. |
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. |
 | Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. |
-| A lock records its **owner pid** | A run killed by SIGKILL or a reboot leaves the lock behind. Without a liveness check, every later run would treat that corpse as contention and exit 0 forever, silently ending all updates. |
+| A lock records its **owner pid** | A run killed by SIGKILL or a reboot leaves the lock behind. Without a liveness check, every later run would treat that corpse as contention and exit 0 forever, silently ending all updates. A lock with no owner *yet* is treated as a run still starting up, not as a corpse — deleting it would let two installers proceed at once. |
+| Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
 
 It also self-heals one specific failure: if the installed version already matches
 the latest release but `--version` no longer prints `(patched)`, the official
@@ -117,7 +118,7 @@ script itself needs no editing:
 | `CALICO_PLATFORM` | auto-detected | Force a platform suffix (`linux-x64`, `linux-arm64`, `macos-arm64`, `win32-x64`, `win32-arm64`). |
 | `CALICO_BIN_LINK` | `~/.local/bin/calico-claude` | The managed symlink. |
 | `CALICO_VERSIONS_DIR` | `~/.local/share/calico-claude/versions` | Where builds are kept. |
-| `CALICO_STATE_DIR` | `~/.claude/calico` | Lock, throttle stamp, and `update.log`. |
+| `CALICO_STATE_DIR` | `~/.claude/calico` | Lock, throttle stamp, installed release tag, and `update.log`. |
 | `CALICO_KEEP_VERSIONS` | `3` | Newest builds to keep. `0` disables pruning. The current symlink target is always kept — after a rollback it survives on top of the newest N. |
 | `CALICO_THROTTLE_SECONDS` | `3600` | Minimum gap between `--hook` checks. |
 | `GH_TOKEN` / `GITHUB_TOKEN` | unset | Bearer token for the releases API, if you hit the anonymous rate limit. |
@@ -140,14 +141,21 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-46 assertions, offline: platform detection, the checksum gate (tampered, absent,
+52 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
-throttling, live vs. stale lock ownership, log rotation, release selection, and
-a set of end-to-end `--run` cases driven through stubbed `curl` and `gh`: a good
-artifact installs; a bad artifact leaves an existing same-version build intact;
-a version that merely *contains* the expected one is rejected; and a binary that
-passes its pre-install check but fails afterwards leaves no symlink behind.
+throttling, lock ownership across live / stale / not-yet-written owners, log
+rotation, release selection, and end-to-end `--run` cases driven through stubbed
+`curl` and `gh`:
+
+| Case | Expected |
+|---|---|
+| A good artifact | Installs; symlink points at it |
+| A bad artifact under `--force` | Run fails; the existing same-version build survives byte-for-byte |
+| A version that merely *contains* the expected one | Rejected; nothing installed |
+| Passes pre-install, fails afterwards, no previous target | Run fails; no symlink left behind |
+| A `-2` rebuild of the installed version | Installed; the tag is recorded |
+| A rebuild already installed, or no tag recorded | Left alone |
 
 Two of those cases run under `/bin/bash` specifically rather than whatever `bash`
 is on `PATH`. Stock macOS ships bash 3.2, where `"${empty_array[@]}"` is an

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -45,7 +45,8 @@ a script and not a one-line `curl | bash` in a cron job:
 | Verification happens **before** install | A failed checksum, attestation, or version check must never reach `versions/`, let alone the symlink. |
 | Installs **never overwrite** | If the destination exists (`--force`, the self-heal, a same-version rebuild), the new build goes to a unique sibling `<X.Y.Z>.<pid>` instead. No intermediate state where the working binary is gone can exist, so no preserve/restore/recover machinery is needed — rollback is only ever a symlink swap back to a file that was never touched. |
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
-| Post-install verify can **roll back** | If the installed binary does not report both the expected version and `(patched)`, the symlink returns to its previous target — or is removed outright when this was a first install, since a link to a binary that just failed its check is worse than no link. The failed build stays in `versions/` and is pruned like any other old one. |
+| The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
+| A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
 | Pruning only runs while **holding the lock** | An ignored lock lets runs overlap by design, and an overlapping run may have installed a destination without swapping its symlink yet. Deleting it would strand that run, so a run without the lock skips the cleanup pass. |
 | The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
 | Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
@@ -146,7 +147,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-70 assertions, offline: platform detection, the checksum gate (tampered, absent,
+77 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -25,16 +25,18 @@ SessionStart hook ──► update.sh --hook ──► throttled? ──► exit
                                                      │
    run the downloaded file in place: exact version + `(patched)` (fail-hard)
                                                      │
-   install versions/<X.Y.Z> — or a unique sibling <X.Y.Z>.<pid> when that path
-   already exists; an install NEVER writes over an existing file
+   install versions/<X.Y.Z>, or a uniquely named sibling when that path is
+   taken; the path is reserved exclusively and never written over
                                                      │
-   atomic symlink swap ─► re-check through the link
+   verify the installed file DIRECTLY: exact version + `(patched)` (fail-hard)
                                                      │
-                              mismatch ─► point the link back at the previous
-                                          target (never touched), or remove it
-                                          when there is no previous one
+                              mismatch ─► leave the launcher untouched and exit;
+                                          the rejected build is pruned later
                                                      │
-                                            prune to the newest 3 versions
+   atomic symlink swap, unless the launcher already points at a newer version
+                                                     │
+                                            prune, skipping builds young enough
+                                            to belong to an overlapping run
 ```
 
 Two properties are worth stating explicitly, because they are the reason this is
@@ -147,7 +149,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-77 assertions, offline: platform detection, the checksum gate (tampered, absent,
+80 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -49,7 +49,9 @@ a script and not a one-line `curl | bash` in a cron job:
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
 | The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
 | A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
-| Pruning only runs while **holding the lock** | An ignored lock lets runs overlap by design, and an overlapping run may have installed a destination without swapping its symlink yet. Deleting it would strand that run, so a run without the lock skips the cleanup pass. |
+| Pruning is gated by **age**, not by the lock | An entry younger than `PRUNE_MIN_AGE_SECONDS` may belong to a run that has not swapped its link yet, so it is left alone. Gating on the lock instead would have been worse: an abandoned lock is never removed, so pruning would stop for good. |
+| The launcher update is **serialized** | Downloading and installing need no exclusion because they are append-only, but reading the current target, deciding, and swapping is a read-modify-write on shared state. A short commit lock covers only those steps; failing to take it leaves the launcher unchanged and the build in place for a later run. |
+| Downgrades compare the **whole release identity** | Version alone would treat a base tag and its `-2` rebuild as equal and let a stale run replace the newer one. |
 | The lock is an **efficiency device**, not a correctness one | Because installs never overwrite, two concurrent updaters cost a duplicate download, never a broken install. So the lock has no claim protocol: a lock younger than an hour means another run is working and this one exits; an older (or unmeasurable) one is *ignored* — never deleted, moved, or taken over, and a run that ignored a lock leaves it in place on exit. A run only ever removes a lock it created itself. |
 | Rebuilds are tracked by **release tag**, not version | A corrected build is republished as `-2` at the same version. Comparing versions alone would report "up to date" and no unattended user would ever receive it. |
 
@@ -149,7 +151,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-80 assertions, offline: platform detection, the checksum gate (tampered, absent,
+87 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -49,6 +49,7 @@ a script and not a one-line `curl | bash` in a cron job:
 | Versions are compared as **whole tokens** | `2.1.24` is a substring of `2.1.240`; a substring test would accept a mislabeled release at the one gate meant to catch it. The installed version is the leading `X.Y.Z` of the symlink target's basename, so a pid-suffixed install still reads as its bare version. |
 | The build is verified **before** the swap | It is checked directly, never through the launcher symlink. Reading it through the link is unsound once runs can overlap — another updater may have repointed it — and verifying first removes the need to undo a swap at all. |
 | A launcher that is not a symlink is **refused** | Replacing a regular file would destroy something this updater did not create and cannot restore. |
+| The destination is **re-checked under the commit lock** | Age-based in-flight protection assumes a run reaches the swap soon after installing; a suspended machine breaks that. One stat inside the lock is the only point where the answer cannot change underneath. |
 | Pruning is gated by **age**, not by the lock | An entry younger than `PRUNE_MIN_AGE_SECONDS` may belong to a run that has not swapped its link yet, so it is left alone. Gating on the lock instead would have been worse: an abandoned lock is never removed, so pruning would stop for good. |
 | An expired commit lock is **not reclaimed** | Every delete-and-reacquire protocol tried here let two runs enter the section the lock serializes. Unlike the run lock, this one spans two syscalls and cannot be stranded by an ordinary kill, so a stranded one means something needs a human — and stopping is the safe direction. The message names the directory to remove. |
 | The launcher update is **serialized** | Downloading and installing need no exclusion because they are append-only, but reading the current target, deciding, and swapping is a read-modify-write on shared state. A short commit lock covers only those steps; failing to take it leaves the launcher unchanged and the build in place for a later run. |
@@ -152,7 +153,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-89 assertions, offline: platform detection, the checksum gate (tampered, absent,
+92 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -146,7 +146,7 @@ asset; the attestation proves the release asset came out of this repo's CI.
 bash examples/local-auto-update/test-update.sh
 ```
 
-68 assertions, offline: platform detection, the checksum gate (tampered, absent,
+70 assertions, offline: platform detection, the checksum gate (tampered, absent,
 empty, and a decoy that only matches through an unescaped dot), pruning
 (including the rollback shape where the symlink points at an older build), hook
 throttling, lock behaviour (a young lock blocks; an aged one is ignored but

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -251,6 +251,50 @@ out="$(run_locked)"
 if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "an aged pid-less lock is reclaimed"; else bad "an aged pid-less lock is reclaimed (got: ${out})"; fi
 rm -rf "${LOCK_STATE}/.lock"
 
+# --- 5a. stale-lock reclaim race ----------------------------------------------
+# Two runs can both pass the dead-owner check. Reclaiming by deleting the
+# shared path lets the second run destroy the lock the first had just
+# re-acquired, and both install concurrently. The claim must be atomic: only
+# one rename of the stale directory can succeed, and the loser must exit
+# rather than fall through into installing.
+#
+# The race window is deterministic here: `log` is overridden in a sourced copy
+# of the script so that, at the message printed immediately before the reclaim
+# step, the other reclaimer "wins" in exactly that window. PROCEEDED printing
+# means acquire_lock returned — i.e. this run went on to install.
+RACE_STATE="${SANDBOX}/race-state"
+run_reclaim_race() { # <winner-state: claimed|completed>
+  CALICO_STATE_DIR="$RACE_STATE" CALICO_PLATFORM=linux-x64 bash -c '
+    stub="$1"; mode="$2"; live_pid="$3"; source "$stub"
+    log() {
+      if [[ "$*" == Reclaiming* ]]; then
+        if [[ "$mode" == claimed ]]; then
+          # Winner has renamed the stale lock away but not yet re-created it.
+          mv "$LOCK_DIR" "${LOCK_DIR}.stale.winner"
+        else
+          # Winner has finished: fresh lock, live owner.
+          rm -rf "$LOCK_DIR"; mkdir "$LOCK_DIR"
+          printf "%s\n" "$live_pid" > "${LOCK_DIR}/pid"
+        fi
+      fi
+      printf "%s\n" "$*"
+    }
+    acquire_lock
+    echo PROCEEDED
+  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH") "$1" "$$" 2>&1
+}
+
+mkdir -p "${RACE_STATE}/.lock"; printf '%s\n' "$dead_pid" > "${RACE_STATE}/.lock/pid"
+out="$(run_reclaim_race claimed)"
+if [[ "$out" != *PROCEEDED* ]]; then ok "losing the reclaim race mid-claim exits instead of installing"; else bad "losing the reclaim race mid-claim exits instead of installing (got: ${out})"; fi
+rm -rf "${RACE_STATE}/.lock" "${RACE_STATE}/.lock.stale.winner"
+
+mkdir -p "${RACE_STATE}/.lock"; printf '%s\n' "$dead_pid" > "${RACE_STATE}/.lock/pid"
+out="$(run_reclaim_race completed)"
+if [[ "$out" != *PROCEEDED* ]]; then ok "losing the reclaim race post-claim exits instead of installing"; else bad "losing the reclaim race post-claim exits instead of installing (got: ${out})"; fi
+check "the winner keeps its freshly acquired lock" "$$" "$(cat "${RACE_STATE}/.lock/pid" 2>/dev/null)"
+rm -rf "${RACE_STATE}/.lock"
+
 # --- 5b. lock age ---------------------------------------------------------------
 # `stat` formatting differs between GNU and BSD, and the GNU spelling of the BSD
 # flag SUCCEEDS with unrelated output rather than failing — so a `-f || -c`
@@ -480,16 +524,29 @@ if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
   ok "e2e: the stranded copy is cleared after recovery"
 else bad "e2e: the stranded copy is cleared after recovery"; fi
 
-# A preserved copy whose destination already exists is leftover, not a rescue.
+# A preserved copy alongside a present destination is NOT leftover: every
+# completed transaction removes its preserved copy (post-verify success deletes
+# it, failure moves it back), so both existing at once means the run died after
+# `install` wrote the replacement but before post-verification. The destination
+# is therefore unverified and the preserved copy is the only known-good build —
+# it must win. (An earlier revision deleted the preserved copy here, which
+# permanently destroyed the binary the mechanism exists to rescue.)
+# Compared by content, never by executing the fixture. The unverified
+# destination must still report itself as the patched 9.9.9 — otherwise the
+# unpatched-binary self-heal reinstalls over it and the assertion passes
+# whether or not the restore ran.
 e2e_reset "${SANDBOX}/asset-good"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
-printf 'STALE\n' > "$E2E/versions/9.9.9.preserved.4242"
+printf '#!/bin/sh\n# unverified replacement\necho "9.9.9 (Claude Code)"\necho "(patched)"\n' > "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9.preserved.4242"; chmod +x "$E2E/versions/9.9.9.preserved.4242"
 ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
 printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
 if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
-  ok "e2e: a leftover copy does not overwrite a present build"
-else bad "e2e: a leftover copy does not overwrite a present build"; fi
+  ok "e2e: a preserved copy wins over an unverified present destination"
+else bad "e2e: a preserved copy wins over an unverified present destination"; fi
+if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
+  ok "e2e: the winning preserved copy is consumed, not duplicated"
+else bad "e2e: the winning preserved copy is consumed, not duplicated"; fi
 
 # --- 8d. --check must agree with --run ----------------------------------------
 # A read-only check that reports "up to date" while --run would immediately

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -658,6 +658,29 @@ if [[ -L "$E2E/bin/calico-claude" && -e "$E2E/bin/calico-claude" ]]; then
   ok "e2e: the launcher still resolves to a real file"
 else bad "e2e: the launcher still resolves to a real file"; fi
 
+# --- 8e5. the launcher never advances past its record ---------------------------
+# The tag record and the symlink describe one fact between them. A stale high
+# rebuild rank left on top of a newer version makes later rebuilds read as
+# already current — unreachable even with --force — so the launcher must not
+# move when the record cannot be updated with it.
+#
+# A read-only state directory blocks both the commit lock and the tag write.
+# Both paths must produce the same outcome, which is what this asserts: the
+# launcher stays put and the record is untouched. CALICO_COMMIT_WAIT keeps the
+# lock retry from stretching the suite.
+
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
+ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
+printf 'v9.9.8-linux-x64-5\n' > "$E2E/state/installed-tag"
+chmod 500 "$E2E/state"
+out="$(CALICO_COMMIT_WAIT=1 e2e_run --run)"
+rc=$?
+chmod 700 "$E2E/state"
+check "e2e: an unwritable state directory does not fail the run" "0" "$rc"
+check "e2e: the launcher is not advanced past its record" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
+check "e2e: the stale record is left intact" "v9.9.8-linux-x64-5" "$(cat "$E2E/state/installed-tag")"
+
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.
 

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -251,6 +251,36 @@ out="$(run_locked)"
 if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "an aged pid-less lock is reclaimed"; else bad "an aged pid-less lock is reclaimed (got: ${out})"; fi
 rm -rf "${LOCK_STATE}/.lock"
 
+# --- 5b. lock age ---------------------------------------------------------------
+# `stat` formatting differs between GNU and BSD, and the GNU spelling of the BSD
+# flag SUCCEEDS with unrelated output rather than failing — so a `-f || -c`
+# chain silently never falls through on Linux. This asserts the measured age,
+# which fails on either platform if the wrong form is used.
+
+age_of() { # <seconds-ago> ; echoes what lock_age_seconds reports
+  local probe="${SANDBOX}/age-probe"
+  rm -rf "$probe"; mkdir -p "$probe/.lock"
+  python3 -c "import os,sys; t=float(sys.argv[2]); os.utime(sys.argv[1],(t,t))" \
+    "$probe/.lock" "$(( $(date +%s) - $1 ))"
+  CALICO_STATE_DIR="$probe" bash -c '
+    stub="$1"; source "$stub"; lock_age_seconds || echo UNKNOWN
+  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
+}
+
+reported="$(age_of 3600)"
+if [[ "$reported" =~ ^[0-9]+$ ]] && (( reported > 3500 && reported < 3700 )); then
+  ok "lock age is measured correctly on this platform ($reported s for a 1h-old lock)"
+else
+  bad "lock age is measured correctly on this platform (got: ${reported})"
+fi
+
+reported="$(age_of 5)"
+if [[ "$reported" =~ ^[0-9]+$ ]] && (( reported < 60 )); then
+  ok "a freshly created lock measures under the startup grace ($reported s)"
+else
+  bad "a freshly created lock measures under the startup grace (got: ${reported})"
+fi
+
 # --- 6. log rotation ----------------------------------------------------------
 LOG="${CALICO_STATE_DIR}/update.log"
 python3 -c "
@@ -432,6 +462,34 @@ check "e2e: the symlink still resolves to the restored build" "$E2E/versions/9.9
 if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
   ok "e2e: no preserved copy is left behind"
 else bad "e2e: no preserved copy is left behind"; fi
+
+# --- 8c2. interrupted reinstall recovery --------------------------------------
+# SIGKILL or power loss between "move the old build aside" and "install the new
+# one" runs no EXIT trap: the launcher points at nothing and the working binary
+# is stranded under a .preserved.<pid> name. The next run must put it back.
+
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9.preserved.4242"; chmod +x "$E2E/versions/9.9.9.preserved.4242"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"   # dangling, as after a kill
+printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --run)"
+if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
+  ok "e2e: an interrupted reinstall is recovered on the next run"
+else bad "e2e: an interrupted reinstall is recovered on the next run"; fi
+if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
+  ok "e2e: the stranded copy is cleared after recovery"
+else bad "e2e: the stranded copy is cleared after recovery"; fi
+
+# A preserved copy whose destination already exists is leftover, not a rescue.
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+printf 'STALE\n' > "$E2E/versions/9.9.9.preserved.4242"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --run)"
+if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
+  ok "e2e: a leftover copy does not overwrite a present build"
+else bad "e2e: a leftover copy does not overwrite a present build"; fi
 
 # --- 8d. --check must agree with --run ----------------------------------------
 # A read-only check that reports "up to date" while --run would immediately

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -51,10 +51,7 @@ done
 case "$url" in
   *checksums.txt) [ -n "$FAKE_CHECKSUMS" ] && cat "$FAKE_CHECKSUMS" > "$out" || exit 1 ;;
   *api.github.com*) cat "$FAKE_RELEASES" > "$out" ;;
-  *) # A competing updater finishing mid-download is simulated here rather than
-     # by timing: the hook runs at the moment this run is fetching the asset.
-     [ -n "$RACE_HOOK" ] && sh -c "$RACE_HOOK"
-     [ -n "$FAKE_ASSET" ] && cat "$FAKE_ASSET" > "$out" || exit 1 ;;
+  *) [ -n "$FAKE_ASSET" ] && cat "$FAKE_ASSET" > "$out" || exit 1 ;;
 esac
 STUB
 chmod +x "${STUB_BIN}/curl"
@@ -156,11 +153,9 @@ seed_versions() { # <current-version> <version...>
   [[ -n "$current" ]] && ln -sf "${CALICO_VERSIONS_DIR}/${current}" "$CALICO_BIN_LINK"
 }
 
-# Pruning is now gated on holding the lock, which acquire_lock sets. These cases
-# call the function directly, so they stand in for the lock holder explicitly.
 prune_with() { # <keep>
   CALICO_KEEP_VERSIONS="$1" bash -c '
-    stub="$1"; source "$stub"; LOCK_CREATED=1; prune_old_versions >/dev/null 2>&1
+    stub="$1"; source "$stub"; prune_old_versions >/dev/null 2>&1
   ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
   ls "$CALICO_VERSIONS_DIR" | sort | tr '\n' ' ' | sed 's/ $//'
 }
@@ -179,22 +174,6 @@ check "prune never deletes the current symlink target" "2.1.1 2.1.3 2.1.4 2.1.5"
 seed_versions "" 2.1.1 2.1.2 2.1.3 2.1.4
 rm -f "$CALICO_BIN_LINK"
 check "prune tolerates a missing symlink" "2.1.2 2.1.3 2.1.4" "$(prune_with 3)"
-
-# A build young enough to belong to an overlapping run is left alone even when
-# the retention count says it should go: that run may not have swapped its link
-# yet, and deleting its destination would strand it.
-#
-# The young build must fall OUTSIDE the retention count for this to test
-# anything. `ls -t` puts the newest first, so it has to sit behind a current
-# target that is newer still — otherwise it survives on its retention slot and
-# the age check is never consulted.
-rm -rf "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"; mkdir -p "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"
-printf 'old\n' > "${CALICO_VERSIONS_DIR}/2.1.1"
-touch -t 202601011000 "${CALICO_VERSIONS_DIR}/2.1.1"
-printf 'in flight\n' > "${CALICO_VERSIONS_DIR}/2.1.8"
-printf 'current\n' > "${CALICO_VERSIONS_DIR}/2.1.9"
-ln -sf "${CALICO_VERSIONS_DIR}/2.1.9" "$CALICO_BIN_LINK"
-check "prune leaves a just-created build alone" "2.1.8 2.1.9" "$(prune_with 1)"
 
 # --- 4. hook throttling -------------------------------------------------------
 # --hook must never block and must not spawn --run while inside the window.
@@ -402,7 +381,7 @@ e2e_run() { # <mode>
       FAKE_RELEASES="$E2E/releases.json" FAKE_ASSET="$E2E/asset" FAKE_CHECKSUMS="$E2E/checksums.txt" \
       CALICO_PLATFORM=linux-x64 CALICO_REPO="calico-test/stubbed" \
       CALICO_VERSIONS_DIR="$E2E/versions" CALICO_BIN_LINK="$E2E/bin/calico-claude" \
-      CALICO_STATE_DIR="$E2E/state" E2E_COUNTER="$E2E/calls" RACE_HOOK="${RACE_HOOK:-}" \
+      CALICO_STATE_DIR="$E2E/state" E2E_COUNTER="$E2E/calls" \
       bash "$UPDATE_SH" "$1" 2>&1
 }
 
@@ -411,9 +390,6 @@ printf '#!/bin/sh\necho "0.0.0 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}
 printf '#!/bin/sh\necho "9.9.99 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-superstring"
 # Passes the pre-install check, then reports a different version once installed.
 printf '#!/bin/sh\nn=$(cat "$E2E_COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$E2E_COUNTER"\nif [ "$n" -le 1 ]; then echo "9.9.9 (Claude Code)"; echo "(patched)"; else echo "0.0.0 (Claude Code)"; echo "(patched)"; fi\n' > "${SANDBOX}/asset-flips"
-# Verifies correctly, then deletes itself from its installed path — standing in
-# for a concurrent prune landing between verification and the swap.
-printf '#!/bin/sh\nn=$(cat "$E2E_COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$E2E_COUNTER"\n[ "$n" -ge 2 ] && rm -f "$0"\necho "9.9.9 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-vanishes"
 
 e2e_reset "${SANDBOX}/asset-good"
 out="$(e2e_run --run)"
@@ -573,113 +549,22 @@ if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
   bad "e2e: no launcher is created when the build fails its check"
 else ok "e2e: no launcher is created when the build fails its check"; fi
 
-# --- 8e2. a slower run must not downgrade the launcher --------------------------
-# Overlapping runs can be looking at different releases. If the newer one swaps
-# first, an unconditional swap here would move the launcher backwards, and the
-# tag record would then describe a build it no longer points at.
+# --- 8e2. a failed tag-record write leaves the launcher unchanged --------------
+# The tag record and the symlink describe one fact between them. The record is
+# written before the swap, so a failure to write it must leave the launcher
+# exactly where it was rather than advance past what the record says.
 
 e2e_reset "${SANDBOX}/asset-good"
 cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
 ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
-printf '#!/bin/sh\necho "9.9.10 (Claude Code)"\necho "(patched)"\n' > "$E2E/versions/9.9.10"
-chmod +x "$E2E/versions/9.9.10"
-out="$(RACE_HOOK="ln -sf $E2E/versions/9.9.10 $E2E/bin/calico-claude" e2e_run --run)"
-check "e2e: the launcher keeps the newer build another run installed" "$E2E/versions/9.9.10" "$(readlink "$E2E/bin/calico-claude")"
-if printf '%s' "$out" | grep -q "newer than"; then
-  ok "e2e: the skipped swap says why"
-else bad "e2e: the skipped swap says why (got: ${out})"; fi
-# The build it downloaded is still on disk; only the launcher was left alone.
-if [[ -e "$E2E/versions/9.9.9" ]]; then
-  ok "e2e: the downloaded build is kept for pruning"
-else bad "e2e: the downloaded build is kept for pruning"; fi
-
-# --- 8e3. the launcher update is serialized ------------------------------------
-# Reading the current target, deciding, and swapping is a read-modify-write on
-# shared state. A held commit lock must make this run leave the launcher alone
-# rather than race; an abandoned one must not wedge updates forever.
-
-e2e_reset "${SANDBOX}/asset-good"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
-ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
-mkdir -p "$E2E/state/.commit-lock"
-out="$(CALICO_COMMIT_WAIT=2 e2e_run --run)"
-check "e2e: a held commit lock leaves the launcher alone" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
-if [[ -e "$E2E/versions/9.9.9" ]]; then
-  ok "e2e: the build is still installed when the commit lock is unavailable"
-else bad "e2e: the build is still installed when the commit lock is unavailable"; fi
-if [[ -d "$E2E/state/.commit-lock" ]]; then
-  ok "e2e: another run's commit lock is not removed"
-else bad "e2e: another run's commit lock is not removed"; fi
-
-# An expired commit lock is NOT reclaimed. Every delete-and-reacquire protocol
-# tried here let two runs enter the section the lock serializes; stopping is the
-# safe direction, and unlike the run lock this one cannot be stranded by an
-# ordinary kill since it spans two syscalls.
-e2e_reset "${SANDBOX}/asset-good"
-mkdir -p "$E2E/state/.commit-lock"
-python3 -c "import os,sys; t=float(sys.argv[2]); os.utime(sys.argv[1],(t,t))" \
-  "$E2E/state/.commit-lock" "$(( $(date +%s) - 3600 ))"
-out="$(CALICO_COMMIT_WAIT=2 e2e_run --run)"
-check "e2e: an expired commit lock does not fail the run" "0" "$?"
-if [[ -d "$E2E/state/.commit-lock" ]]; then
-  ok "e2e: an expired commit lock is left in place, not reclaimed"
-else bad "e2e: an expired commit lock is left in place, not reclaimed"; fi
-if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
-  bad "e2e: the launcher is not moved while a commit lock is held"
-else ok "e2e: the launcher is not moved while a commit lock is held"; fi
-if printf '%s' "$out" | grep -q "remove it by hand"; then
-  ok "e2e: an expired commit lock tells the user how to clear it"
-else bad "e2e: an expired commit lock tells the user how to clear it (got: ${out})"; fi
-
-# Same version, newer rebuild: comparing X.Y.Z alone would call these equal and
-# let a stale base-tag run replace the rebuild.
-e2e_reset "${SANDBOX}/asset-good"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
-ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
-printf 'v9.9.9-linux-x64-2\n' > "$E2E/state/installed-tag"
-out="$(e2e_run --force)"
-check "e2e: a base-tag run does not replace a newer rebuild" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
-check "e2e: the newer rebuild tag survives" "v9.9.9-linux-x64-2" "$(cat "$E2E/state/installed-tag")"
-
-# --- 8e4. a destination pruned mid-run is not swapped to -------------------------
-# The age-based in-flight protection assumes a run reaches the swap within
-# PRUNE_MIN_AGE_SECONDS of installing. A suspended machine breaks that, and a
-# later run can prune the destination this one is about to point at.
-
-e2e_reset "${SANDBOX}/asset-vanishes"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
-ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
-# The fixture passes verification and then removes its own installed copy, which
-# is what a concurrent prune during a long pause looks like from here.
+printf 'v9.9.8-linux-x64\n' > "$E2E/state/installed-tag"
+chmod 400 "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
-check "e2e: a destination removed mid-run does not fail the run" "0" "$?"
-check "e2e: the launcher is not pointed at a removed destination" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
-if [[ -L "$E2E/bin/calico-claude" && -e "$E2E/bin/calico-claude" ]]; then
-  ok "e2e: the launcher still resolves to a real file"
-else bad "e2e: the launcher still resolves to a real file"; fi
-
-# --- 8e5. the launcher never advances past its record ---------------------------
-# The tag record and the symlink describe one fact between them. A stale high
-# rebuild rank left on top of a newer version makes later rebuilds read as
-# already current — unreachable even with --force — so the launcher must not
-# move when the record cannot be updated with it.
-#
-# A read-only state directory blocks both the commit lock and the tag write.
-# Both paths must produce the same outcome, which is what this asserts: the
-# launcher stays put and the record is untouched. CALICO_COMMIT_WAIT keeps the
-# lock retry from stretching the suite.
-
-e2e_reset "${SANDBOX}/asset-good"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
-ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
-printf 'v9.9.8-linux-x64-5\n' > "$E2E/state/installed-tag"
-chmod 500 "$E2E/state"
-out="$(CALICO_COMMIT_WAIT=1 e2e_run --run)"
 rc=$?
-chmod 700 "$E2E/state"
-check "e2e: an unwritable state directory does not fail the run" "0" "$rc"
-check "e2e: the launcher is not advanced past its record" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
-check "e2e: the stale record is left intact" "v9.9.8-linux-x64-5" "$(cat "$E2E/state/installed-tag")"
+chmod 600 "$E2E/state/installed-tag"
+check "e2e: a failed tag-record write does not fail the run" "0" "$rc"
+check "e2e: the launcher is not advanced when the tag write fails" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
+check "e2e: the stale record is left intact" "v9.9.8-linux-x64" "$(cat "$E2E/state/installed-tag")"
 
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -208,41 +208,48 @@ check "hook tolerates a corrupt last-check" "0" "$?"
 # A live owner means real contention; a dead one means the previous run was
 # killed before its EXIT trap ran, and the lock must be reclaimed rather than
 # obeyed forever.
-run_locked() { CALICO_PLATFORM=linux-x64 bash "$UPDATE_SH" --run 2>&1; }
+#
+# These cases get their own state directory. The hook cases above necessarily
+# spawn detached `--run` children, and one still finishing could otherwise
+# acquire or release a lock belonging to an assertion here — the assertions
+# would then pass or fail on timing rather than on behaviour.
+LOCK_STATE="${SANDBOX}/lock-state"
+mkdir -p "$LOCK_STATE"
+run_locked() { CALICO_PLATFORM=linux-x64 CALICO_STATE_DIR="$LOCK_STATE" bash "$UPDATE_SH" --run 2>&1; }
 
-mkdir -p "${CALICO_STATE_DIR}/.lock"
-printf '%s\n' "$$" > "${CALICO_STATE_DIR}/.lock/pid"
+mkdir -p "${LOCK_STATE}/.lock"
+printf '%s\n' "$$" > "${LOCK_STATE}/.lock/pid"
 out="$(run_locked)"
 rc=$?
 check "run exits 0 when a live owner holds the lock" "0" "$rc"
 if [[ "$out" == *"already in progress (pid $$)"* ]]; then ok "run reports the live lock owner"; else bad "run reports the live lock owner (got: ${out})"; fi
-if [[ -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "a live owner's lock survives"; else bad "a live owner's lock survives"; fi
-rm -rf "${CALICO_STATE_DIR}/.lock"
+if [[ -d "${LOCK_STATE}/.lock" ]]; then ok "a live owner's lock survives"; else bad "a live owner's lock survives"; fi
+rm -rf "${LOCK_STATE}/.lock"
 
 # Find a pid that is definitely not running, so the lock reads as abandoned.
 dead_pid=999999
 while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
-mkdir -p "${CALICO_STATE_DIR}/.lock"
-printf '%s\n' "$dead_pid" > "${CALICO_STATE_DIR}/.lock/pid"
+mkdir -p "${LOCK_STATE}/.lock"
+printf '%s\n' "$dead_pid" > "${LOCK_STATE}/.lock/pid"
 out="$(run_locked)"
 if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a stale lock is reclaimed instead of obeyed"; else bad "a stale lock is reclaimed instead of obeyed (got: ${out})"; fi
-if [[ ! -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "the reclaimed lock is released on exit"; else bad "the reclaimed lock is released on exit"; fi
-rm -rf "${CALICO_STATE_DIR}/.lock"
+if [[ ! -d "${LOCK_STATE}/.lock" ]]; then ok "the reclaimed lock is released on exit"; else bad "the reclaimed lock is released on exit"; fi
+rm -rf "${LOCK_STATE}/.lock"
 
 # A pid-less lock is ambiguous: a run killed between mkdir and the write, or one
 # that is about to write it. Deleting the second would let two installers run at
 # once, so a fresh one counts as contention and only an aged one is reclaimed.
-mkdir -p "${CALICO_STATE_DIR}/.lock"
+mkdir -p "${LOCK_STATE}/.lock"
 out="$(run_locked)"
 if [[ "$out" == *"starting up"* ]]; then ok "a freshly pid-less lock is treated as contention"; else bad "a freshly pid-less lock is treated as contention (got: ${out})"; fi
-if [[ -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "a freshly pid-less lock is not deleted"; else bad "a freshly pid-less lock is not deleted"; fi
-rm -rf "${CALICO_STATE_DIR}/.lock"
+if [[ -d "${LOCK_STATE}/.lock" ]]; then ok "a freshly pid-less lock is not deleted"; else bad "a freshly pid-less lock is not deleted"; fi
+rm -rf "${LOCK_STATE}/.lock"
 
-mkdir -p "${CALICO_STATE_DIR}/.lock"
-touch -t 202601010000 "${CALICO_STATE_DIR}/.lock"
+mkdir -p "${LOCK_STATE}/.lock"
+touch -t 202601010000 "${LOCK_STATE}/.lock"
 out="$(run_locked)"
 if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "an aged pid-less lock is reclaimed"; else bad "an aged pid-less lock is reclaimed (got: ${out})"; fi
-rm -rf "${CALICO_STATE_DIR}/.lock"
+rm -rf "${LOCK_STATE}/.lock"
 
 # --- 6. log rotation ----------------------------------------------------------
 LOG="${CALICO_STATE_DIR}/update.log"
@@ -401,6 +408,52 @@ e2e_reset "${SANDBOX}/asset-good"
 e2e_installed "v9.9.9-linux-x64"; rm -f "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
 if [[ "$out" == *"up to date"* ]]; then ok "a missing tag record does not force a reinstall"; else bad "a missing tag record does not force a reinstall (got: ${out})"; fi
+
+# --- 8c. same-version install must survive a late failure ---------------------
+# The pre-install check runs the artifact from the temp directory. An artifact
+# that passes there and fails from its installed location would, without a
+# preserved copy, leave `dest` holding the failed replacement — and `old_target`
+# names that same path, so rolling the symlink back would restore nothing.
+
+e2e_reset "${SANDBOX}/asset-flips"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --run)"
+rc=$?
+check "e2e: a late failure on a same-version install fails the run" "1" "$rc"
+# Compared by content, not by running it: the flipping fixture keys its output
+# off a counter file, so executing it here would reset that and report the good
+# version either way — the assertion would pass whether or not the restore ran.
+if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
+  ok "e2e: the replaced same-version build is restored"
+else bad "e2e: the replaced same-version build is restored"; fi
+check "e2e: the symlink still resolves to the restored build" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
+if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
+  ok "e2e: no preserved copy is left behind"
+else bad "e2e: no preserved copy is left behind"; fi
+
+# --- 8d. --check must agree with --run ----------------------------------------
+# A read-only check that reports "up to date" while --run would immediately
+# install tells the user the opposite of what is about to happen.
+
+e2e_reset "${SANDBOX}/asset-good"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
+e2e_installed "v9.9.9-linux-x64"
+out="$(e2e_run --check)"
+if [[ "$out" == *"rebuild available (v9.9.9-linux-x64-2)"* ]]; then ok "--check reports an available rebuild"; else bad "--check reports an available rebuild (got: ${out})"; fi
+
+e2e_reset "${SANDBOX}/asset-good"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
+e2e_installed "v9.9.9-linux-x64-2"
+out="$(e2e_run --check)"
+if [[ "$out" == *"up to date"* ]]; then ok "--check reports up to date once the rebuild is installed"; else bad "--check reports up to date once the rebuild is installed (got: ${out})"; fi
+
+# The official updater replacing the patched binary keeps the version identical.
+e2e_reset "${SANDBOX}/asset-good"
+printf '#!/bin/sh\necho "9.9.9 (Claude Code)"\n' > "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --check)"
+if [[ "$out" == *"reinstall needed"* ]]; then ok "--check reports an unpatched binary as needing reinstall"; else bad "--check reports an unpatched binary as needing reinstall (got: ${out})"; fi
 
 # --- 9. usage -----------------------------------------------------------------
 bash "$UPDATE_SH" >/dev/null 2>&1

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -229,11 +229,19 @@ if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a stale lock is reclaimed
 if [[ ! -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "the reclaimed lock is released on exit"; else bad "the reclaimed lock is released on exit"; fi
 rm -rf "${CALICO_STATE_DIR}/.lock"
 
-# A lock directory with no pid file at all (older layout, or a crash between
-# mkdir and the write) must also be reclaimable rather than permanent.
+# A pid-less lock is ambiguous: a run killed between mkdir and the write, or one
+# that is about to write it. Deleting the second would let two installers run at
+# once, so a fresh one counts as contention and only an aged one is reclaimed.
 mkdir -p "${CALICO_STATE_DIR}/.lock"
 out="$(run_locked)"
-if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a pid-less lock is reclaimed"; else bad "a pid-less lock is reclaimed (got: ${out})"; fi
+if [[ "$out" == *"starting up"* ]]; then ok "a freshly pid-less lock is treated as contention"; else bad "a freshly pid-less lock is treated as contention (got: ${out})"; fi
+if [[ -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "a freshly pid-less lock is not deleted"; else bad "a freshly pid-less lock is not deleted"; fi
+rm -rf "${CALICO_STATE_DIR}/.lock"
+
+mkdir -p "${CALICO_STATE_DIR}/.lock"
+touch -t 202601010000 "${CALICO_STATE_DIR}/.lock"
+out="$(run_locked)"
+if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "an aged pid-less lock is reclaimed"; else bad "an aged pid-less lock is reclaimed (got: ${out})"; fi
 rm -rf "${CALICO_STATE_DIR}/.lock"
 
 # --- 6. log rotation ----------------------------------------------------------
@@ -354,6 +362,45 @@ check "e2e: a binary failing post-verify fails the run" "1" "$?"
 if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
   bad "e2e: the symlink is removed when there is no rollback target"
 else ok "e2e: the symlink is removed when there is no rollback target"; fi
+
+# --- 8b. same-version rebuilds ------------------------------------------------
+# A corrected build is republished under a numeric suffix while the version
+# stays the same. Comparing versions alone reports "up to date", so unattended
+# users would never receive it.
+
+e2e_rebuild_releases() { # <highest-tag>
+  cat > "$E2E/releases.json" <<JSON
+[{"tag_name":"v9.9.9-linux-x64","assets":[
+  {"name":"claude.native.patched","browser_download_url":"https://example.invalid/asset"},
+  {"name":"checksums.txt","browser_download_url":"https://example.invalid/checksums.txt"}]},
+ {"tag_name":"$1","assets":[
+  {"name":"claude.native.patched","browser_download_url":"https://example.invalid/asset"},
+  {"name":"checksums.txt","browser_download_url":"https://example.invalid/checksums.txt"}]}]
+JSON
+}
+e2e_installed() { # <tag>
+  cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+  ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+  printf '%s\n' "$1" > "$E2E/state/installed-tag"
+}
+
+e2e_reset "${SANDBOX}/asset-good"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
+e2e_installed "v9.9.9-linux-x64"
+out="$(e2e_run --run)"
+if [[ "$out" == *"newer rebuild"* ]]; then ok "a newer rebuild of the installed version is picked up"; else bad "a newer rebuild of the installed version is picked up (got: ${out})"; fi
+check "the rebuild tag is recorded after install" "v9.9.9-linux-x64-2" "$(cat "$E2E/state/installed-tag")"
+
+e2e_reset "${SANDBOX}/asset-good"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
+e2e_installed "v9.9.9-linux-x64-2"
+out="$(e2e_run --run)"
+if [[ "$out" == *"up to date"* ]]; then ok "an already-installed rebuild is not reinstalled"; else bad "an already-installed rebuild is not reinstalled (got: ${out})"; fi
+
+# Installs predating this feature have no recorded tag. They must not be
+# reinstalled just because the file is missing.
+e2e_reset "${SANDBOX}/asset-good"
+e2e_installed "v9.9.9-linux-x64"; rm -f "$E2E/state/installed-tag"
+out="$(e2e_run --run)"
+if [[ "$out" == *"up to date"* ]]; then ok "a missing tag record does not force a reinstall"; else bad "a missing tag record does not force a reinstall (got: ${out})"; fi
 
 # --- 9. usage -----------------------------------------------------------------
 bash "$UPDATE_SH" >/dev/null 2>&1

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -557,14 +557,20 @@ else ok "e2e: no launcher is created when the build fails its check"; fi
 e2e_reset "${SANDBOX}/asset-good"
 cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
 ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
-printf 'v9.9.8-linux-x64\n' > "$E2E/state/installed-tag"
-chmod 400 "$E2E/state/installed-tag"
+# The record is made unwritable by replacing it with a DIRECTORY rather than by
+# clearing its mode bits: root ignores mode bits, so a chmod-based fixture would
+# quietly let the write succeed and assert nothing. A redirect onto a directory
+# fails for every user.
+rm -f "$E2E/state/installed-tag"
+mkdir -p "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
 rc=$?
-chmod 600 "$E2E/state/installed-tag"
+rmdir "$E2E/state/installed-tag"
 check "e2e: a failed tag-record write does not fail the run" "0" "$rc"
 check "e2e: the launcher is not advanced when the tag write fails" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
-check "e2e: the stale record is left intact" "v9.9.8-linux-x64" "$(cat "$E2E/state/installed-tag")"
+if [[ ! -e "$E2E/state/installed-tag" ]]; then
+  ok "e2e: the unwritable record is left as it was"
+else bad "e2e: the unwritable record is left as it was"; fi
 
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -27,6 +27,61 @@ export CALICO_VERSIONS_DIR="${SANDBOX}/versions"
 export CALICO_BIN_LINK="${SANDBOX}/bin/calico-claude"
 mkdir -p "$CALICO_STATE_DIR" "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"
 
+# --- curl stub ----------------------------------------------------------------
+# Installed before any case that can reach the network. `--hook` spawns a
+# detached `--run`, and a nonexistent CALICO_REPO does not prevent that run from
+# contacting api.github.com — it only guarantees a 404. Without the stub on PATH
+# the suite would break its own offline guarantee and could leave a detached
+# curl behind after the sandbox is removed.
+STUB_BIN="${SANDBOX}/stub-bin"
+mkdir -p "$STUB_BIN"
+cat > "${STUB_BIN}/curl" <<'STUB'
+#!/bin/sh
+# Minimal curl stand-in. Serves the release list, the asset, or its checksums
+# depending on the URL, so a full --run can be exercised without a network.
+out=""
+url=""
+prev=""
+for arg in "$@"; do
+  [ "$prev" = "-o" ] && out="$arg"
+  case "$arg" in http*) url="$arg" ;; esac
+  prev="$arg"
+done
+[ -n "$out" ] || exit 1
+case "$url" in
+  *checksums.txt) [ -n "$FAKE_CHECKSUMS" ] && cat "$FAKE_CHECKSUMS" > "$out" || exit 1 ;;
+  *api.github.com*) cat "$FAKE_RELEASES" > "$out" ;;
+  *) [ -n "$FAKE_ASSET" ] && cat "$FAKE_ASSET" > "$out" || exit 1 ;;
+esac
+STUB
+chmod +x "${STUB_BIN}/curl"
+cat > "${STUB_BIN}/gh" <<'STUB'
+#!/bin/sh
+# Unauthenticated gh: exercises the documented "skip attestation with a warning"
+# path rather than failing a stub asset that carries no real provenance.
+[ "$1" = "auth" ] && exit 1
+exit 1
+STUB
+chmod +x "${STUB_BIN}/gh"
+
+cat > "${SANDBOX}/releases.json" <<'JSON'
+[
+  {"tag_name": "v2.1.240-linux-x64", "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c"}]},
+  {"tag_name": "v2.1.240-linux-x64-2", "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a2"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c2"}]},
+  {"tag_name": "v2.1.241-linux-x64", "assets": [
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c3"}]},
+  {"tag_name": "v2.1.243-linux-x64", "draft": true, "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a4"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c4"}]},
+  {"tag_name": "v2.1.242-macos-arm64", "assets": [
+    {"name": "claude.native.macos.patched", "browser_download_url": "https://example.invalid/a5"}]}
+]
+JSON
+
 # --- 1. platform detection ----------------------------------------------------
 for pair in "linux-x64:claude.native.patched:0" \
             "linux-arm64:claude.native.patched:0" \
@@ -125,6 +180,8 @@ check "prune tolerates a missing symlink" "2.1.2 2.1.3 2.1.4" "$(prune_with 3)"
 # CALICO_REPO points at a nonexistent repo so any spawned --run fails fast
 # without touching the network in a meaningful way.
 export CALICO_REPO="calico-test/does-not-exist"
+export PATH="${STUB_BIN}:${PATH}"
+export FAKE_RELEASES="${SANDBOX}/releases.json"
 rm -f "${CALICO_STATE_DIR}/last-check" "${CALICO_STATE_DIR}/update.log"
 printf '%s\n' "$(date +%s)" > "${CALICO_STATE_DIR}/last-check"
 before="$(cat "${CALICO_STATE_DIR}/last-check")"
@@ -148,12 +205,36 @@ CALICO_THROTTLE_SECONDS=3600 bash "$UPDATE_SH" --hook < /dev/null >/dev/null 2>&
 check "hook tolerates a corrupt last-check" "0" "$?"
 
 # --- 5. lock ------------------------------------------------------------------
+# A live owner means real contention; a dead one means the previous run was
+# killed before its EXIT trap ran, and the lock must be reclaimed rather than
+# obeyed forever.
+run_locked() { CALICO_PLATFORM=linux-x64 bash "$UPDATE_SH" --run 2>&1; }
+
 mkdir -p "${CALICO_STATE_DIR}/.lock"
-out="$(CALICO_PLATFORM=linux-x64 bash "$UPDATE_SH" --run 2>&1)"
+printf '%s\n' "$$" > "${CALICO_STATE_DIR}/.lock/pid"
+out="$(run_locked)"
 rc=$?
-check "run exits 0 when the lock is held" "0" "$rc"
-if [[ "$out" == *"lock held"* ]]; then ok "run reports the held lock"; else bad "run reports the held lock"; fi
-rmdir "${CALICO_STATE_DIR}/.lock"
+check "run exits 0 when a live owner holds the lock" "0" "$rc"
+if [[ "$out" == *"already in progress (pid $$)"* ]]; then ok "run reports the live lock owner"; else bad "run reports the live lock owner (got: ${out})"; fi
+if [[ -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "a live owner's lock survives"; else bad "a live owner's lock survives"; fi
+rm -rf "${CALICO_STATE_DIR}/.lock"
+
+# Find a pid that is definitely not running, so the lock reads as abandoned.
+dead_pid=999999
+while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
+mkdir -p "${CALICO_STATE_DIR}/.lock"
+printf '%s\n' "$dead_pid" > "${CALICO_STATE_DIR}/.lock/pid"
+out="$(run_locked)"
+if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a stale lock is reclaimed instead of obeyed"; else bad "a stale lock is reclaimed instead of obeyed (got: ${out})"; fi
+if [[ ! -d "${CALICO_STATE_DIR}/.lock" ]]; then ok "the reclaimed lock is released on exit"; else bad "the reclaimed lock is released on exit"; fi
+rm -rf "${CALICO_STATE_DIR}/.lock"
+
+# A lock directory with no pid file at all (older layout, or a crash between
+# mkdir and the write) must also be reclaimable rather than permanent.
+mkdir -p "${CALICO_STATE_DIR}/.lock"
+out="$(run_locked)"
+if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a pid-less lock is reclaimed"; else bad "a pid-less lock is reclaimed (got: ${out})"; fi
+rm -rf "${CALICO_STATE_DIR}/.lock"
 
 # --- 6. log rotation ----------------------------------------------------------
 LOG="${CALICO_STATE_DIR}/update.log"
@@ -178,39 +259,8 @@ check "rotate_log leaves a small log alone" "1" "$(wc -l < "$LOG" | tr -d ' ')"
 # Stock macOS ships /bin/bash 3.2, where "${empty_array[@]}" is an unbound
 # variable under `set -u`. The suite otherwise runs under whatever `bash` is on
 # PATH (often Homebrew 5.x), which hides that class of bug entirely.
-STUB_BIN="${SANDBOX}/stub-bin"
-mkdir -p "$STUB_BIN"
-cat > "${STUB_BIN}/curl" <<'STUB'
-#!/bin/sh
-# Minimal curl stand-in: writes $FAKE_RELEASES to whatever -o names.
-out=""
-prev=""
-for arg in "$@"; do
-  [ "$prev" = "-o" ] && out="$arg"
-  prev="$arg"
-done
-[ -n "$out" ] || exit 1
-cat "$FAKE_RELEASES" > "$out"
-STUB
-chmod +x "${STUB_BIN}/curl"
-
-cat > "${SANDBOX}/releases.json" <<'JSON'
-[
-  {"tag_name": "v2.1.240-linux-x64", "assets": [
-    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a"},
-    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c"}]},
-  {"tag_name": "v2.1.240-linux-x64-2", "assets": [
-    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a2"},
-    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c2"}]},
-  {"tag_name": "v2.1.241-linux-x64", "assets": [
-    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c3"}]},
-  {"tag_name": "v2.1.243-linux-x64", "draft": true, "assets": [
-    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a4"},
-    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c4"}]},
-  {"tag_name": "v2.1.242-macos-arm64", "assets": [
-    {"name": "claude.native.macos.patched", "browser_download_url": "https://example.invalid/a5"}]}
-]
-JSON
+# The curl stub is installed near the top of this file, because the hook cases
+# below spawn a detached `--run` that would otherwise reach the network.
 
 run_check() { # <bash-binary> ; runs --check with a stubbed curl and no token
   env -u GH_TOKEN -u GITHUB_TOKEN \
@@ -239,7 +289,73 @@ else
   printf 'skip /bin/bash not present\n'
 fi
 
-# --- 8. usage -----------------------------------------------------------------
+# --- 8. end-to-end --run ------------------------------------------------------
+# Drives the real install path with stubbed curl and gh. These cover the parts
+# that unit-level cases cannot: what happens to files already on disk when the
+# incoming artifact turns out to be wrong.
+
+E2E="${SANDBOX}/e2e"
+e2e_reset() { # <asset-body-file>
+  rm -rf "$E2E"; mkdir -p "$E2E/versions" "$E2E/bin" "$E2E/state"
+  cp "$1" "$E2E/asset"; chmod +x "$E2E/asset"
+  ( cd "$E2E" && { shasum -a 256 asset 2>/dev/null || sha256sum asset; } \
+      | sed 's/asset$/claude.native.patched/' > "$E2E/checksums.txt" )
+  cat > "$E2E/releases.json" <<JSON
+[{"tag_name":"v9.9.9-linux-x64","assets":[
+  {"name":"claude.native.patched","browser_download_url":"https://example.invalid/asset"},
+  {"name":"checksums.txt","browser_download_url":"https://example.invalid/checksums.txt"}]}]
+JSON
+}
+e2e_run() { # <mode>
+  env PATH="${STUB_BIN}:${PATH}" \
+      FAKE_RELEASES="$E2E/releases.json" FAKE_ASSET="$E2E/asset" FAKE_CHECKSUMS="$E2E/checksums.txt" \
+      CALICO_PLATFORM=linux-x64 CALICO_REPO="calico-test/stubbed" \
+      CALICO_VERSIONS_DIR="$E2E/versions" CALICO_BIN_LINK="$E2E/bin/calico-claude" \
+      CALICO_STATE_DIR="$E2E/state" E2E_COUNTER="$E2E/calls" \
+      bash "$UPDATE_SH" "$1" 2>&1
+}
+
+printf '#!/bin/sh\necho "9.9.9 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-good"
+printf '#!/bin/sh\necho "0.0.0 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-wrongver"
+printf '#!/bin/sh\necho "9.9.99 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-superstring"
+# Passes the pre-install check, then reports a different version once installed.
+printf '#!/bin/sh\nn=$(cat "$E2E_COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$E2E_COUNTER"\nif [ "$n" -le 1 ]; then echo "9.9.9 (Claude Code)"; echo "(patched)"; else echo "0.0.0 (Claude Code)"; echo "(patched)"; fi\n' > "${SANDBOX}/asset-flips"
+
+e2e_reset "${SANDBOX}/asset-good"
+out="$(e2e_run --run)"
+check "e2e: a good artifact installs" "0" "$?"
+if [[ -L "$E2E/bin/calico-claude" && "$(readlink "$E2E/bin/calico-claude")" == "$E2E/versions/9.9.9" ]]; then
+  ok "e2e: symlink points at the installed version"
+else bad "e2e: symlink points at the installed version"; fi
+
+# The reinstall paths (--force, and the self-heal for an unpatched same-version
+# binary) write to a destination that already exists. If the incoming artifact
+# is only checked after that write, the rollback target is already destroyed.
+e2e_reset "${SANDBOX}/asset-wrongver"
+printf 'KNOWN GOOD\n' > "$E2E/versions/9.9.9"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+out="$(e2e_run --force)"
+rc=$?
+check "e2e: a bad artifact fails --force" "1" "$rc"
+check "e2e: the existing same-version build is left intact" "KNOWN GOOD" "$(cat "$E2E/versions/9.9.9")"
+check "e2e: the symlink still points at the surviving build" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
+
+# "2.1.24" is a substring of "2.1.240"; only an exact token comparison rejects it.
+e2e_reset "${SANDBOX}/asset-superstring"
+out="$(e2e_run --run)"
+check "e2e: a version that merely contains the expected one is rejected" "1" "$?"
+if [[ -e "$E2E/versions/9.9.9" ]]; then bad "e2e: superstring version must not be installed"; else ok "e2e: superstring version must not be installed"; fi
+
+# First install, nothing to roll back to: a link to a binary that just failed
+# its check is worse than no link at all.
+e2e_reset "${SANDBOX}/asset-flips"
+out="$(e2e_run --run)"
+check "e2e: a binary failing post-verify fails the run" "1" "$?"
+if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
+  bad "e2e: the symlink is removed when there is no rollback target"
+else ok "e2e: the symlink is removed when there is no rollback target"; fi
+
+# --- 9. usage -----------------------------------------------------------------
 bash "$UPDATE_SH" >/dev/null 2>&1
 check "no mode exits 2" "2" "$?"
 

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -205,9 +205,9 @@ CALICO_THROTTLE_SECONDS=3600 bash "$UPDATE_SH" --hook < /dev/null >/dev/null 2>&
 check "hook tolerates a corrupt last-check" "0" "$?"
 
 # --- 5. lock ------------------------------------------------------------------
-# A live owner means real contention; a dead one means the previous run was
-# killed before its EXIT trap ran, and the lock must be reclaimed rather than
-# obeyed forever.
+# The lock is an efficiency device: a young lock means another run is on it and
+# this one skips the duplicate work; an aged lock is assumed abandoned and is
+# ignored but NEVER removed — a run only ever deletes a lock it created itself.
 #
 # These cases get their own state directory. The hook cases above necessarily
 # spawn detached `--run` children, and one still finishing could otherwise
@@ -218,82 +218,21 @@ mkdir -p "$LOCK_STATE"
 run_locked() { CALICO_PLATFORM=linux-x64 CALICO_STATE_DIR="$LOCK_STATE" bash "$UPDATE_SH" --run 2>&1; }
 
 mkdir -p "${LOCK_STATE}/.lock"
-printf '%s\n' "$$" > "${LOCK_STATE}/.lock/pid"
 out="$(run_locked)"
 rc=$?
-check "run exits 0 when a live owner holds the lock" "0" "$rc"
-if [[ "$out" == *"already in progress (pid $$)"* ]]; then ok "run reports the live lock owner"; else bad "run reports the live lock owner (got: ${out})"; fi
+check "run exits 0 when a young lock exists (live owner)" "0" "$rc"
+if [[ "$out" == *"already in progress"* ]]; then ok "run reports the contention"; else bad "run reports the contention (got: ${out})"; fi
 if [[ -d "${LOCK_STATE}/.lock" ]]; then ok "a live owner's lock survives"; else bad "a live owner's lock survives"; fi
 rm -rf "${LOCK_STATE}/.lock"
 
-# Find a pid that is definitely not running, so the lock reads as abandoned.
-dead_pid=999999
-while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
-mkdir -p "${LOCK_STATE}/.lock"
-printf '%s\n' "$dead_pid" > "${LOCK_STATE}/.lock/pid"
-out="$(run_locked)"
-if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "a stale lock is reclaimed instead of obeyed"; else bad "a stale lock is reclaimed instead of obeyed (got: ${out})"; fi
-if [[ ! -d "${LOCK_STATE}/.lock" ]]; then ok "the reclaimed lock is released on exit"; else bad "the reclaimed lock is released on exit"; fi
-rm -rf "${LOCK_STATE}/.lock"
-
-# A pid-less lock is ambiguous: a run killed between mkdir and the write, or one
-# that is about to write it. Deleting the second would let two installers run at
-# once, so a fresh one counts as contention and only an aged one is reclaimed.
-mkdir -p "${LOCK_STATE}/.lock"
-out="$(run_locked)"
-if [[ "$out" == *"starting up"* ]]; then ok "a freshly pid-less lock is treated as contention"; else bad "a freshly pid-less lock is treated as contention (got: ${out})"; fi
-if [[ -d "${LOCK_STATE}/.lock" ]]; then ok "a freshly pid-less lock is not deleted"; else bad "a freshly pid-less lock is not deleted"; fi
-rm -rf "${LOCK_STATE}/.lock"
-
+# An aged lock (SIGKILL, power loss, reboot: no EXIT trap ever ran) must not
+# end updates forever — but it also must not be removed: it is not ours.
 mkdir -p "${LOCK_STATE}/.lock"
 touch -t 202601010000 "${LOCK_STATE}/.lock"
 out="$(run_locked)"
-if [[ "$out" == *"Reclaiming stale lock"* ]]; then ok "an aged pid-less lock is reclaimed"; else bad "an aged pid-less lock is reclaimed (got: ${out})"; fi
+if [[ "$out" == *"Ignoring lock"* ]]; then ok "an aged lock is ignored, not obeyed"; else bad "an aged lock is ignored, not obeyed (got: ${out})"; fi
+if [[ -d "${LOCK_STATE}/.lock" ]]; then ok "a run that ignored a lock leaves it in place on exit"; else bad "a run that ignored a lock leaves it in place on exit"; fi
 rm -rf "${LOCK_STATE}/.lock"
-
-# --- 5a. stale-lock reclaim race ----------------------------------------------
-# Two runs can both pass the dead-owner check. Reclaiming by deleting the
-# shared path lets the second run destroy the lock the first had just
-# re-acquired, and both install concurrently. The claim must be atomic: only
-# one rename of the stale directory can succeed, and the loser must exit
-# rather than fall through into installing.
-#
-# The race window is deterministic here: `log` is overridden in a sourced copy
-# of the script so that, at the message printed immediately before the reclaim
-# step, the other reclaimer "wins" in exactly that window. PROCEEDED printing
-# means acquire_lock returned — i.e. this run went on to install.
-RACE_STATE="${SANDBOX}/race-state"
-run_reclaim_race() { # <winner-state: claimed|completed>
-  CALICO_STATE_DIR="$RACE_STATE" CALICO_PLATFORM=linux-x64 bash -c '
-    stub="$1"; mode="$2"; live_pid="$3"; source "$stub"
-    log() {
-      if [[ "$*" == Reclaiming* ]]; then
-        if [[ "$mode" == claimed ]]; then
-          # Winner has renamed the stale lock away but not yet re-created it.
-          mv "$LOCK_DIR" "${LOCK_DIR}.stale.winner"
-        else
-          # Winner has finished: fresh lock, live owner.
-          rm -rf "$LOCK_DIR"; mkdir "$LOCK_DIR"
-          printf "%s\n" "$live_pid" > "${LOCK_DIR}/pid"
-        fi
-      fi
-      printf "%s\n" "$*"
-    }
-    acquire_lock
-    echo PROCEEDED
-  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH") "$1" "$$" 2>&1
-}
-
-mkdir -p "${RACE_STATE}/.lock"; printf '%s\n' "$dead_pid" > "${RACE_STATE}/.lock/pid"
-out="$(run_reclaim_race claimed)"
-if [[ "$out" != *PROCEEDED* ]]; then ok "losing the reclaim race mid-claim exits instead of installing"; else bad "losing the reclaim race mid-claim exits instead of installing (got: ${out})"; fi
-rm -rf "${RACE_STATE}/.lock" "${RACE_STATE}/.lock.stale.winner"
-
-mkdir -p "${RACE_STATE}/.lock"; printf '%s\n' "$dead_pid" > "${RACE_STATE}/.lock/pid"
-out="$(run_reclaim_race completed)"
-if [[ "$out" != *PROCEEDED* ]]; then ok "losing the reclaim race post-claim exits instead of installing"; else bad "losing the reclaim race post-claim exits instead of installing (got: ${out})"; fi
-check "the winner keeps its freshly acquired lock" "$$" "$(cat "${RACE_STATE}/.lock/pid" 2>/dev/null)"
-rm -rf "${RACE_STATE}/.lock"
 
 # --- 5b. lock age ---------------------------------------------------------------
 # `stat` formatting differs between GNU and BSD, and the GNU spelling of the BSD
@@ -483,12 +422,37 @@ e2e_installed "v9.9.9-linux-x64"; rm -f "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
 if [[ "$out" == *"up to date"* ]]; then ok "a missing tag record does not force a reinstall"; else bad "a missing tag record does not force a reinstall (got: ${out})"; fi
 
-# --- 8c. same-version install must survive a late failure ---------------------
-# The pre-install check runs the artifact from the temp directory. An artifact
-# that passes there and fails from its installed location would, without a
-# preserved copy, leave `dest` holding the failed replacement — and `old_target`
-# names that same path, so rolling the symlink back would restore nothing.
+# --- 8c. installs are append-only ---------------------------------------------
+# The load-bearing property: install never writes over a file that exists. A
+# same-version reinstall lands on a unique suffixed sibling, so no preserve,
+# restore, or interrupted-run recovery is ever needed — there is no intermediate
+# state to recover from.
 
+# A --force reinstall over an existing same-version file: the new build goes to
+# a NEW path and the existing file is untouched byte for byte. Compared with
+# cmp, never by executing a fixture.
+e2e_reset "${SANDBOX}/asset-good"
+printf 'PRE-EXISTING BYTES\n' > "$E2E/versions/9.9.9"
+cp "$E2E/versions/9.9.9" "${SANDBOX}/pre-existing-copy"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --force)"
+rc=$?
+check "e2e: a forced same-version reinstall succeeds" "0" "$rc"
+if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/pre-existing-copy"; then
+  ok "e2e: the pre-existing file is byte-identical after the reinstall"
+else bad "e2e: the pre-existing file is byte-identical after the reinstall"; fi
+new_target="$(readlink "$E2E/bin/calico-claude")"
+if [[ "$new_target" != "$E2E/versions/9.9.9" && "$new_target" == "$E2E/versions/9.9.9."* && -f "$new_target" ]]; then
+  ok "e2e: the reinstall landed on a new suffixed path ($(basename "$new_target"))"
+else bad "e2e: the reinstall landed on a new suffixed path (got: ${new_target})"; fi
+if cmp -s "$new_target" "${SANDBOX}/asset-good"; then
+  ok "e2e: the suffixed path holds the downloaded build"
+else bad "e2e: the suffixed path holds the downloaded build"; fi
+
+# A late failure (passes pre-install, fails once installed) on a same-version
+# rebuild: the previous target was never touched, so rollback is just the
+# symlink pointing back at it.
 e2e_reset "${SANDBOX}/asset-flips"; e2e_rebuild_releases "v9.9.9-linux-x64-2"
 cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
 ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
@@ -496,57 +460,31 @@ printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
 out="$(e2e_run --run)"
 rc=$?
 check "e2e: a late failure on a same-version install fails the run" "1" "$rc"
+check "e2e: the symlink is rolled back to the previous target" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
 # Compared by content, not by running it: the flipping fixture keys its output
-# off a counter file, so executing it here would reset that and report the good
-# version either way — the assertion would pass whether or not the restore ran.
+# off a counter file, so executing it would report the good version either way.
 if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
-  ok "e2e: the replaced same-version build is restored"
-else bad "e2e: the replaced same-version build is restored"; fi
-check "e2e: the symlink still resolves to the restored build" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
-if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
-  ok "e2e: no preserved copy is left behind"
-else bad "e2e: no preserved copy is left behind"; fi
+  ok "e2e: the previous build is untouched after the rollback"
+else bad "e2e: the previous build is untouched after the rollback"; fi
 
-# --- 8c2. interrupted reinstall recovery --------------------------------------
-# SIGKILL or power loss between "move the old build aside" and "install the new
-# one" runs no EXIT trap: the launcher points at nothing and the working binary
-# is stranded under a .preserved.<pid> name. The next run must put it back.
+# A suffixed symlink target still reads as its bare version, so the next run
+# reports "up to date" instead of reinstalling forever.
+suffix_probe="${SANDBOX}/suffix-probe"
+rm -rf "$suffix_probe"; mkdir -p "$suffix_probe/versions" "$suffix_probe/bin"
+printf 'x\n' > "$suffix_probe/versions/9.9.9.4242"
+ln -sf "$suffix_probe/versions/9.9.9.4242" "$suffix_probe/bin/calico-claude"
+out="$(CALICO_BIN_LINK="$suffix_probe/bin/calico-claude" bash -c '
+  stub="$1"; source "$stub"; get_installed_version; printf "%s" "$INSTALLED_VERSION"
+' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH"))"
+check "get_installed_version reports the bare version for a suffixed target" "9.9.9" "$out"
 
-e2e_reset "${SANDBOX}/asset-good"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9.preserved.4242"; chmod +x "$E2E/versions/9.9.9.preserved.4242"
-ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"   # dangling, as after a kill
-printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
-out="$(e2e_run --run)"
-if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
-  ok "e2e: an interrupted reinstall is recovered on the next run"
-else bad "e2e: an interrupted reinstall is recovered on the next run"; fi
-if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
-  ok "e2e: the stranded copy is cleared after recovery"
-else bad "e2e: the stranded copy is cleared after recovery"; fi
-
-# A preserved copy alongside a present destination is NOT leftover: every
-# completed transaction removes its preserved copy (post-verify success deletes
-# it, failure moves it back), so both existing at once means the run died after
-# `install` wrote the replacement but before post-verification. The destination
-# is therefore unverified and the preserved copy is the only known-good build —
-# it must win. (An earlier revision deleted the preserved copy here, which
-# permanently destroyed the binary the mechanism exists to rescue.)
-# Compared by content, never by executing the fixture. The unverified
-# destination must still report itself as the patched 9.9.9 — otherwise the
-# unpatched-binary self-heal reinstalls over it and the assertion passes
-# whether or not the restore ran.
-e2e_reset "${SANDBOX}/asset-good"
-printf '#!/bin/sh\n# unverified replacement\necho "9.9.9 (Claude Code)"\necho "(patched)"\n' > "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
-cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9.preserved.4242"; chmod +x "$E2E/versions/9.9.9.preserved.4242"
-ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
-printf 'v9.9.9-linux-x64\n' > "$E2E/state/installed-tag"
-out="$(e2e_run --run)"
-if cmp -s "$E2E/versions/9.9.9" "${SANDBOX}/asset-good"; then
-  ok "e2e: a preserved copy wins over an unverified present destination"
-else bad "e2e: a preserved copy wins over an unverified present destination"; fi
-if [[ -z "$(find "$E2E/versions" -name '*.preserved.*' 2>/dev/null)" ]]; then
-  ok "e2e: the winning preserved copy is consumed, not duplicated"
-else bad "e2e: the winning preserved copy is consumed, not duplicated"; fi
+# Pruning must recognise a suffixed current target and never delete it, even
+# when it is older than everything else.
+seed_versions "" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
+printf 'binary suffixed\n' > "${CALICO_VERSIONS_DIR}/2.1.0.4242"
+touch -t 202601010500 "${CALICO_VERSIONS_DIR}/2.1.0.4242"
+ln -sf "${CALICO_VERSIONS_DIR}/2.1.0.4242" "$CALICO_BIN_LINK"
+check "prune never deletes a suffixed current target" "2.1.0.4242 2.1.3 2.1.4 2.1.5" "$(prune_with 3)"
 
 # --- 8d. --check must agree with --run ----------------------------------------
 # A read-only check that reports "up to date" while --run would immediately

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -411,6 +411,9 @@ printf '#!/bin/sh\necho "0.0.0 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}
 printf '#!/bin/sh\necho "9.9.99 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-superstring"
 # Passes the pre-install check, then reports a different version once installed.
 printf '#!/bin/sh\nn=$(cat "$E2E_COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$E2E_COUNTER"\nif [ "$n" -le 1 ]; then echo "9.9.9 (Claude Code)"; echo "(patched)"; else echo "0.0.0 (Claude Code)"; echo "(patched)"; fi\n' > "${SANDBOX}/asset-flips"
+# Verifies correctly, then deletes itself from its installed path — standing in
+# for a concurrent prune landing between verification and the swap.
+printf '#!/bin/sh\nn=$(cat "$E2E_COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$E2E_COUNTER"\n[ "$n" -ge 2 ] && rm -f "$0"\necho "9.9.9 (Claude Code)"\necho "(patched)"\n' > "${SANDBOX}/asset-vanishes"
 
 e2e_reset "${SANDBOX}/asset-good"
 out="$(e2e_run --run)"
@@ -637,6 +640,23 @@ printf 'v9.9.9-linux-x64-2\n' > "$E2E/state/installed-tag"
 out="$(e2e_run --force)"
 check "e2e: a base-tag run does not replace a newer rebuild" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
 check "e2e: the newer rebuild tag survives" "v9.9.9-linux-x64-2" "$(cat "$E2E/state/installed-tag")"
+
+# --- 8e4. a destination pruned mid-run is not swapped to -------------------------
+# The age-based in-flight protection assumes a run reaches the swap within
+# PRUNE_MIN_AGE_SECONDS of installing. A suspended machine breaks that, and a
+# later run can prune the destination this one is about to point at.
+
+e2e_reset "${SANDBOX}/asset-vanishes"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
+ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
+# The fixture passes verification and then removes its own installed copy, which
+# is what a concurrent prune during a long pause looks like from here.
+out="$(e2e_run --run)"
+check "e2e: a destination removed mid-run does not fail the run" "0" "$?"
+check "e2e: the launcher is not pointed at a removed destination" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
+if [[ -L "$E2E/bin/calico-claude" && -e "$E2E/bin/calico-claude" ]]; then
+  ok "e2e: the launcher still resolves to a real file"
+else bad "e2e: the launcher still resolves to a real file"; fi
 
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -51,7 +51,10 @@ done
 case "$url" in
   *checksums.txt) [ -n "$FAKE_CHECKSUMS" ] && cat "$FAKE_CHECKSUMS" > "$out" || exit 1 ;;
   *api.github.com*) cat "$FAKE_RELEASES" > "$out" ;;
-  *) [ -n "$FAKE_ASSET" ] && cat "$FAKE_ASSET" > "$out" || exit 1 ;;
+  *) # A competing updater finishing mid-download is simulated here rather than
+     # by timing: the hook runs at the moment this run is fetching the asset.
+     [ -n "$RACE_HOOK" ] && sh -c "$RACE_HOOK"
+     [ -n "$FAKE_ASSET" ] && cat "$FAKE_ASSET" > "$out" || exit 1 ;;
 esac
 STUB
 chmod +x "${STUB_BIN}/curl"
@@ -399,7 +402,7 @@ e2e_run() { # <mode>
       FAKE_RELEASES="$E2E/releases.json" FAKE_ASSET="$E2E/asset" FAKE_CHECKSUMS="$E2E/checksums.txt" \
       CALICO_PLATFORM=linux-x64 CALICO_REPO="calico-test/stubbed" \
       CALICO_VERSIONS_DIR="$E2E/versions" CALICO_BIN_LINK="$E2E/bin/calico-claude" \
-      CALICO_STATE_DIR="$E2E/state" E2E_COUNTER="$E2E/calls" \
+      CALICO_STATE_DIR="$E2E/state" E2E_COUNTER="$E2E/calls" RACE_HOOK="${RACE_HOOK:-}" \
       bash "$UPDATE_SH" "$1" 2>&1
 }
 
@@ -566,6 +569,26 @@ out="$(e2e_run --run)"
 if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
   bad "e2e: no launcher is created when the build fails its check"
 else ok "e2e: no launcher is created when the build fails its check"; fi
+
+# --- 8e2. a slower run must not downgrade the launcher --------------------------
+# Overlapping runs can be looking at different releases. If the newer one swaps
+# first, an unconditional swap here would move the launcher backwards, and the
+# tag record would then describe a build it no longer points at.
+
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
+ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
+printf '#!/bin/sh\necho "9.9.10 (Claude Code)"\necho "(patched)"\n' > "$E2E/versions/9.9.10"
+chmod +x "$E2E/versions/9.9.10"
+out="$(RACE_HOOK="ln -sf $E2E/versions/9.9.10 $E2E/bin/calico-claude" e2e_run --run)"
+check "e2e: the launcher keeps the newer build another run installed" "$E2E/versions/9.9.10" "$(readlink "$E2E/bin/calico-claude")"
+if printf '%s' "$out" | grep -q "newer than"; then
+  ok "e2e: the skipped swap says why"
+else bad "e2e: the skipped swap says why (got: ${out})"; fi
+# The build it downloaded is still on disk; only the launcher was left alone.
+if [[ -e "$E2E/versions/9.9.9" ]]; then
+  ok "e2e: the downloaded build is kept for pruning"
+else bad "e2e: the downloaded build is kept for pruning"; fi
 
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -590,6 +590,45 @@ if [[ -e "$E2E/versions/9.9.9" ]]; then
   ok "e2e: the downloaded build is kept for pruning"
 else bad "e2e: the downloaded build is kept for pruning"; fi
 
+# --- 8e3. the launcher update is serialized ------------------------------------
+# Reading the current target, deciding, and swapping is a read-modify-write on
+# shared state. A held commit lock must make this run leave the launcher alone
+# rather than race; an abandoned one must not wedge updates forever.
+
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
+ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
+mkdir -p "$E2E/state/.commit-lock"
+out="$(CALICO_COMMIT_WAIT=2 e2e_run --run)"
+check "e2e: a held commit lock leaves the launcher alone" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
+if [[ -e "$E2E/versions/9.9.9" ]]; then
+  ok "e2e: the build is still installed when the commit lock is unavailable"
+else bad "e2e: the build is still installed when the commit lock is unavailable"; fi
+if [[ -d "$E2E/state/.commit-lock" ]]; then
+  ok "e2e: another run's commit lock is not removed"
+else bad "e2e: another run's commit lock is not removed"; fi
+
+# An abandoned commit lock must be taken over, or updates stop for good.
+e2e_reset "${SANDBOX}/asset-good"
+mkdir -p "$E2E/state/.commit-lock"
+python3 -c "import os,sys; t=float(sys.argv[2]); os.utime(sys.argv[1],(t,t))" \
+  "$E2E/state/.commit-lock" "$(( $(date +%s) - 3600 ))"
+out="$(e2e_run --run)"
+check "e2e: an abandoned commit lock is taken over" "0" "$?"
+if [[ -L "$E2E/bin/calico-claude" ]]; then
+  ok "e2e: the launcher is updated after taking over a stale commit lock"
+else bad "e2e: the launcher is updated after taking over a stale commit lock"; fi
+
+# Same version, newer rebuild: comparing X.Y.Z alone would call these equal and
+# let a stale base-tag run replace the rebuild.
+e2e_reset "${SANDBOX}/asset-good"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.9"; chmod +x "$E2E/versions/9.9.9"
+ln -sf "$E2E/versions/9.9.9" "$E2E/bin/calico-claude"
+printf 'v9.9.9-linux-x64-2\n' > "$E2E/state/installed-tag"
+out="$(e2e_run --force)"
+check "e2e: a base-tag run does not replace a newer rebuild" "$E2E/versions/9.9.9" "$(readlink "$E2E/bin/calico-claude")"
+check "e2e: the newer rebuild tag survives" "v9.9.9-linux-x64-2" "$(cat "$E2E/state/installed-tag")"
+
 # --- 8f. a launcher we do not manage is refused --------------------------------
 # swap_symlink would mv over a regular file, and nothing could put it back.
 

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -153,9 +153,11 @@ seed_versions() { # <current-version> <version...>
   [[ -n "$current" ]] && ln -sf "${CALICO_VERSIONS_DIR}/${current}" "$CALICO_BIN_LINK"
 }
 
+# Pruning is now gated on holding the lock, which acquire_lock sets. These cases
+# call the function directly, so they stand in for the lock holder explicitly.
 prune_with() { # <keep>
   CALICO_KEEP_VERSIONS="$1" bash -c '
-    stub="$1"; source "$stub"; prune_old_versions >/dev/null 2>&1
+    stub="$1"; source "$stub"; LOCK_CREATED=1; prune_old_versions >/dev/null 2>&1
   ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
   ls "$CALICO_VERSIONS_DIR" | sort | tr '\n' ' ' | sed 's/ $//'
 }
@@ -263,6 +265,44 @@ if [[ "$reported" =~ ^[0-9]+$ ]] && (( reported < 60 )); then
 else
   bad "a freshly created lock measures under the startup grace (got: ${reported})"
 fi
+
+# A run that proceeded past an ignored lock may be overlapping another updater,
+# which could be mid-install or holding a rollback target this run cannot see.
+seed_versions "2.1.5" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
+kept="$(CALICO_KEEP_VERSIONS=3 bash -c '
+  stub="$1"; source "$stub"; LOCK_CREATED=0; prune_old_versions >/dev/null 2>&1
+' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH"); ls "$CALICO_VERSIONS_DIR" | sort | tr '\n' ' ' | sed 's/ $//')"
+check "a run that does not hold the lock prunes nothing" "2.1.1 2.1.2 2.1.3 2.1.4 2.1.5" "$kept"
+
+# --- 5c. install path allocation ----------------------------------------------
+# The suffix must come from an exclusive create, not from the pid: pids are
+# unique only among live processes, so a suffixed build that survives pruning
+# can collide with a later run that is assigned the same pid.
+
+# Both allocations must happen inside ONE process. Calling a helper twice from
+# the harness would fork twice, giving each call a different pid — a pid-derived
+# suffix would then look unique and the mutation would go undetected.
+alloc() { # <base> [count] ; echoes <count> allocations from a single process
+  bash -c 'stub="$1"; source "$stub"; n="${3:-1}"; while (( n-- > 0 )); do allocate_dest "$2"; done' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH") "$1" "${2:-1}"
+}
+
+alloc_dir="${SANDBOX}/alloc"; rm -rf "$alloc_dir"; mkdir -p "$alloc_dir"
+base="${alloc_dir}/9.9.9"
+check "an unused base path is returned as-is" "$base" "$(alloc "$base")"
+
+printf 'EXISTING
+' > "$base"
+pair="$(alloc "$base" 2)"
+first="$(printf '%s\n' "$pair" | sed -n '1p')"
+second="$(printf '%s\n' "$pair" | sed -n '2p')"
+if [[ "$first" != "$base" && "$second" != "$base" ]]; then
+  ok "an occupied base path yields a suffixed sibling"
+else bad "an occupied base path yields a suffixed sibling ($first / $second)"; fi
+# Both calls run in the same test process, so a pid-derived suffix would repeat.
+if [[ "$first" != "$second" ]]; then
+  ok "two allocations against the same base differ"
+else bad "two allocations against the same base differ (both: $first)"; fi
+check "the occupied base is left untouched" "EXISTING" "$(cat "$base")"
 
 # --- 6. log rotation ----------------------------------------------------------
 LOG="${CALICO_STATE_DIR}/update.log"

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -608,16 +608,25 @@ if [[ -d "$E2E/state/.commit-lock" ]]; then
   ok "e2e: another run's commit lock is not removed"
 else bad "e2e: another run's commit lock is not removed"; fi
 
-# An abandoned commit lock must be taken over, or updates stop for good.
+# An expired commit lock is NOT reclaimed. Every delete-and-reacquire protocol
+# tried here let two runs enter the section the lock serializes; stopping is the
+# safe direction, and unlike the run lock this one cannot be stranded by an
+# ordinary kill since it spans two syscalls.
 e2e_reset "${SANDBOX}/asset-good"
 mkdir -p "$E2E/state/.commit-lock"
 python3 -c "import os,sys; t=float(sys.argv[2]); os.utime(sys.argv[1],(t,t))" \
   "$E2E/state/.commit-lock" "$(( $(date +%s) - 3600 ))"
-out="$(e2e_run --run)"
-check "e2e: an abandoned commit lock is taken over" "0" "$?"
-if [[ -L "$E2E/bin/calico-claude" ]]; then
-  ok "e2e: the launcher is updated after taking over a stale commit lock"
-else bad "e2e: the launcher is updated after taking over a stale commit lock"; fi
+out="$(CALICO_COMMIT_WAIT=2 e2e_run --run)"
+check "e2e: an expired commit lock does not fail the run" "0" "$?"
+if [[ -d "$E2E/state/.commit-lock" ]]; then
+  ok "e2e: an expired commit lock is left in place, not reclaimed"
+else bad "e2e: an expired commit lock is left in place, not reclaimed"; fi
+if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
+  bad "e2e: the launcher is not moved while a commit lock is held"
+else ok "e2e: the launcher is not moved while a commit lock is held"; fi
+if printf '%s' "$out" | grep -q "remove it by hand"; then
+  ok "e2e: an expired commit lock tells the user how to clear it"
+else bad "e2e: an expired commit lock tells the user how to clear it (got: ${out})"; fi
 
 # Same version, newer rebuild: comparing X.Y.Z alone would call these equal and
 # let a stale base-tag run replace the rebuild.

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# Offline self-check for update.sh. Exercises the pure-local logic (platform
+# detection, checksum gate, pruning, hook throttling, log rotation) in a
+# sandbox; never touches the real install paths and never downloads anything.
+#
+# Usage: bash test-update.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATE_SH="${SCRIPT_DIR}/update.sh"
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf 'ok   %s\n' "$*"; }
+bad()  { FAIL=$((FAIL + 1)); printf 'FAIL %s\n' "$*"; }
+check() { # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected [$2], got [$3])"; fi
+}
+
+export CALICO_STATE_DIR="${SANDBOX}/state"
+export CALICO_VERSIONS_DIR="${SANDBOX}/versions"
+export CALICO_BIN_LINK="${SANDBOX}/bin/calico-claude"
+mkdir -p "$CALICO_STATE_DIR" "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"
+
+# --- 1. platform detection ----------------------------------------------------
+for pair in "linux-x64:claude.native.patched:0" \
+            "linux-arm64:claude.native.patched:0" \
+            "macos-arm64:claude.native.macos.patched:1" \
+            "win32-x64:claude.native.windows.patched.exe:0" \
+            "win32-arm64:claude.native.windows.patched.exe:0"; do
+  plat="${pair%%:*}"; rest="${pair#*:}"; want_asset="${rest%%:*}"; want_macos="${rest##*:}"
+  out="$(CALICO_PLATFORM="$plat" bash -c '
+    source_stub="$1"; source "$source_stub"; detect_platform; printf "%s|%s" "$ASSET" "$IS_MACOS"
+  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH"))"
+  check "detect_platform $plat" "${want_asset}|${want_macos}" "$out"
+done
+
+out="$(CALICO_PLATFORM="bogus-plat" bash -c '
+  source_stub="$1"; source "$source_stub"; detect_platform 2>/dev/null; echo "SHOULD NOT REACH"
+' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH") 2>&1)"
+if [[ "$out" == *"SHOULD NOT REACH"* ]]; then bad "detect_platform rejects unknown suffix"; else ok "detect_platform rejects unknown suffix"; fi
+
+# --- 2. checksum gate ---------------------------------------------------------
+run_checksum_case() { # <dir> ; echoes exit status
+  # verify_checksum calls fail() -> exit 1, so the status must be read from the
+  # subshell itself rather than from a trailing echo inside it.
+  CALICO_PLATFORM=linux-x64 bash -c '
+    stub="$1"; dir="$2"; source "$stub"; detect_platform; verify_checksum "$dir"
+  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH") "$1" >/dev/null 2>&1
+  echo $?
+}
+
+good="${SANDBOX}/cs-good"; mkdir -p "$good"
+printf 'payload\n' > "${good}/claude.native.patched"
+( cd "$good" && { shasum -a 256 claude.native.patched 2>/dev/null || sha256sum claude.native.patched; } > checksums.txt )
+check "verify_checksum accepts a matching digest" "0" "$(run_checksum_case "$good")"
+
+tampered="${SANDBOX}/cs-tampered"; mkdir -p "$tampered"
+cp "${good}/checksums.txt" "$tampered/"
+printf 'TAMPERED\n' > "${tampered}/claude.native.patched"
+check "verify_checksum rejects a tampered asset" "1" "$(run_checksum_case "$tampered")"
+
+missing="${SANDBOX}/cs-missing"; mkdir -p "$missing"
+printf 'payload\n' > "${missing}/claude.native.patched"
+printf 'deadbeef  some-other-file\n' > "${missing}/checksums.txt"
+check "verify_checksum rejects a checksums.txt without our asset" "1" "$(run_checksum_case "$missing")"
+
+# A decoy whose name differs from the asset only where the asset has a dot:
+# an unescaped `.` in the grep pattern matches it, so the gate would verify the
+# decoy and let the real (unlisted, hostile) asset through.
+decoy="${SANDBOX}/cs-decoy"; mkdir -p "$decoy"
+printf 'decoy\n' > "${decoy}/claudeanativeapatched"
+( cd "$decoy" && { shasum -a 256 claudeanativeapatched 2>/dev/null || sha256sum claudeanativeapatched; } > checksums.txt )
+printf 'EVIL\n' > "${decoy}/claude.native.patched"
+check "verify_checksum rejects a decoy entry matching only via an unescaped dot" "1" "$(run_checksum_case "$decoy")"
+
+empty="${SANDBOX}/cs-empty"; mkdir -p "$empty"
+printf 'payload\n' > "${empty}/claude.native.patched"
+: > "${empty}/checksums.txt"
+check "verify_checksum rejects an empty checksums.txt" "1" "$(run_checksum_case "$empty")"
+
+# --- 3. pruning ---------------------------------------------------------------
+seed_versions() { # <current-version> <version...>
+  rm -rf "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"; mkdir -p "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"
+  local current="$1"; shift
+  local i=0
+  for v in "$@"; do
+    printf 'binary %s\n' "$v" > "${CALICO_VERSIONS_DIR}/${v}"
+    # Oldest listed gets the oldest mtime so `ls -t` order is deterministic.
+    touch -t "20260101$(printf '%02d' $((10 + i)))00" "${CALICO_VERSIONS_DIR}/${v}"
+    i=$((i + 1))
+  done
+  [[ -n "$current" ]] && ln -sf "${CALICO_VERSIONS_DIR}/${current}" "$CALICO_BIN_LINK"
+}
+
+prune_with() { # <keep>
+  CALICO_KEEP_VERSIONS="$1" bash -c '
+    stub="$1"; source "$stub"; prune_old_versions >/dev/null 2>&1
+  ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
+  ls "$CALICO_VERSIONS_DIR" | sort | tr '\n' ' ' | sed 's/ $//'
+}
+
+seed_versions "2.1.5" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
+check "prune keeps newest 3 including current" "2.1.3 2.1.4 2.1.5" "$(prune_with 3)"
+
+seed_versions "2.1.5" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
+check "prune with KEEP=0 keeps everything" "2.1.1 2.1.2 2.1.3 2.1.4 2.1.5" "$(prune_with 0)"
+
+# Rollback shape: the symlink points at an older build; it must survive.
+seed_versions "2.1.1" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
+# Rollback: the newest 3 are kept AND the older current target survives on top.
+check "prune never deletes the current symlink target" "2.1.1 2.1.3 2.1.4 2.1.5" "$(prune_with 3)"
+
+seed_versions "" 2.1.1 2.1.2 2.1.3 2.1.4
+rm -f "$CALICO_BIN_LINK"
+check "prune tolerates a missing symlink" "2.1.2 2.1.3 2.1.4" "$(prune_with 3)"
+
+# --- 4. hook throttling -------------------------------------------------------
+# --hook must never block and must not spawn --run while inside the window.
+# CALICO_REPO points at a nonexistent repo so any spawned --run fails fast
+# without touching the network in a meaningful way.
+export CALICO_REPO="calico-test/does-not-exist"
+rm -f "${CALICO_STATE_DIR}/last-check" "${CALICO_STATE_DIR}/update.log"
+printf '%s\n' "$(date +%s)" > "${CALICO_STATE_DIR}/last-check"
+before="$(cat "${CALICO_STATE_DIR}/last-check")"
+CALICO_THROTTLE_SECONDS=3600 bash "$UPDATE_SH" --hook < /dev/null >/dev/null 2>&1
+rc=$?
+check "hook inside throttle window exits 0" "0" "$rc"
+check "hook inside throttle window leaves last-check untouched" "$before" "$(cat "${CALICO_STATE_DIR}/last-check")"
+if [[ -s "${CALICO_STATE_DIR}/update.log" ]]; then bad "hook inside throttle window spawned a run"; else ok "hook inside throttle window spawned no run"; fi
+
+printf '%s\n' "$(( $(date +%s) - 7200 ))" > "${CALICO_STATE_DIR}/last-check"
+CALICO_THROTTLE_SECONDS=3600 bash "$UPDATE_SH" --hook < /dev/null >/dev/null 2>&1
+rc=$?
+check "hook past throttle window exits 0" "0" "$rc"
+now_stamp="$(cat "${CALICO_STATE_DIR}/last-check")"
+if (( $(date +%s) - now_stamp < 60 )); then ok "hook past throttle window refreshes last-check"; else bad "hook past throttle window refreshes last-check"; fi
+sleep 3
+if [[ -s "${CALICO_STATE_DIR}/update.log" ]]; then ok "hook past throttle window spawned a detached run"; else bad "hook past throttle window spawned a detached run"; fi
+
+printf 'garbage\n' > "${CALICO_STATE_DIR}/last-check"
+CALICO_THROTTLE_SECONDS=3600 bash "$UPDATE_SH" --hook < /dev/null >/dev/null 2>&1
+check "hook tolerates a corrupt last-check" "0" "$?"
+
+# --- 5. lock ------------------------------------------------------------------
+mkdir -p "${CALICO_STATE_DIR}/.lock"
+out="$(CALICO_PLATFORM=linux-x64 bash "$UPDATE_SH" --run 2>&1)"
+rc=$?
+check "run exits 0 when the lock is held" "0" "$rc"
+if [[ "$out" == *"lock held"* ]]; then ok "run reports the held lock"; else bad "run reports the held lock"; fi
+rmdir "${CALICO_STATE_DIR}/.lock"
+
+# --- 6. log rotation ----------------------------------------------------------
+LOG="${CALICO_STATE_DIR}/update.log"
+python3 -c "
+import sys
+with open('$LOG', 'w') as f:
+    for i in range(5000):
+        f.write('line %d\n' % i)
+"
+bash -c '
+  stub="$1"; source "$stub"; rotate_log
+' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
+lines="$(wc -l < "$LOG" | tr -d ' ')"
+check "rotate_log trims an oversized log to 1000 lines" "1000" "$lines"
+check "rotate_log keeps the newest lines" "line 4999" "$(tail -n 1 "$LOG")"
+
+printf 'short\n' > "$LOG"
+bash -c 'stub="$1"; source "$stub"; rotate_log' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
+check "rotate_log leaves a small log alone" "1" "$(wc -l < "$LOG" | tr -d ' ')"
+
+# --- 7. release selection under the oldest supported bash ---------------------
+# Stock macOS ships /bin/bash 3.2, where "${empty_array[@]}" is an unbound
+# variable under `set -u`. The suite otherwise runs under whatever `bash` is on
+# PATH (often Homebrew 5.x), which hides that class of bug entirely.
+STUB_BIN="${SANDBOX}/stub-bin"
+mkdir -p "$STUB_BIN"
+cat > "${STUB_BIN}/curl" <<'STUB'
+#!/bin/sh
+# Minimal curl stand-in: writes $FAKE_RELEASES to whatever -o names.
+out=""
+prev=""
+for arg in "$@"; do
+  [ "$prev" = "-o" ] && out="$arg"
+  prev="$arg"
+done
+[ -n "$out" ] || exit 1
+cat "$FAKE_RELEASES" > "$out"
+STUB
+chmod +x "${STUB_BIN}/curl"
+
+cat > "${SANDBOX}/releases.json" <<'JSON'
+[
+  {"tag_name": "v2.1.240-linux-x64", "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c"}]},
+  {"tag_name": "v2.1.240-linux-x64-2", "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a2"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c2"}]},
+  {"tag_name": "v2.1.241-linux-x64", "assets": [
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c3"}]},
+  {"tag_name": "v2.1.243-linux-x64", "draft": true, "assets": [
+    {"name": "claude.native.patched", "browser_download_url": "https://example.invalid/a4"},
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/c4"}]},
+  {"tag_name": "v2.1.242-macos-arm64", "assets": [
+    {"name": "claude.native.macos.patched", "browser_download_url": "https://example.invalid/a5"}]}
+]
+JSON
+
+run_check() { # <bash-binary> ; runs --check with a stubbed curl and no token
+  env -u GH_TOKEN -u GITHUB_TOKEN \
+    PATH="${STUB_BIN}:${PATH}" \
+    FAKE_RELEASES="${SANDBOX}/releases.json" \
+    CALICO_PLATFORM=linux-x64 \
+    CALICO_REPO="calico-test/stubbed" \
+    "$1" "$UPDATE_SH" --check 2>&1
+}
+
+out="$(run_check bash)"
+check "release selection prefers the rebuild suffix" "Latest release: 2.1.240 (tag v2.1.240-linux-x64-2)" "$(printf '%s\n' "$out" | grep '^Latest release:')"
+if printf '%s' "$out" | grep -q "2.1.241"; then bad "release without our asset is skipped"; else ok "release without our asset is skipped"; fi
+# The draft is the highest version in the fixture, so it wins unless filtered.
+if printf '%s' "$out" | grep -q "2.1.243"; then bad "draft release is skipped"; else ok "draft release is skipped"; fi
+
+if [[ -x /bin/bash ]]; then
+  bash32_out="$(run_check /bin/bash)"
+  if printf '%s' "$bash32_out" | grep -q "unbound variable"; then
+    bad "--check runs under /bin/bash $(/bin/bash -c 'echo $BASH_VERSION') without an unbound variable"
+  else
+    ok "--check runs under /bin/bash $(/bin/bash -c 'echo $BASH_VERSION') without an unbound variable"
+  fi
+  check "--check under /bin/bash selects the same release" "Latest release: 2.1.240 (tag v2.1.240-linux-x64-2)" "$(printf '%s\n' "$bash32_out" | grep '^Latest release:')"
+else
+  printf 'skip /bin/bash not present\n'
+fi
+
+# --- 8. usage -----------------------------------------------------------------
+bash "$UPDATE_SH" >/dev/null 2>&1
+check "no mode exits 2" "2" "$?"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -289,6 +289,18 @@ alloc() { # <base> [count] ; echoes <count> allocations from a single process
 alloc_dir="${SANDBOX}/alloc"; rm -rf "$alloc_dir"; mkdir -p "$alloc_dir"
 base="${alloc_dir}/9.9.9"
 check "an unused base path is returned as-is" "$base" "$(alloc "$base")"
+rm -f "$base"
+
+# Two overlapping runs can both find the base absent — an ignored lock permits
+# exactly that — so the base must be reserved, not merely tested for.
+fresh_pair="$(alloc "$base" 2)"
+fresh_first="$(printf '%s\n' "$fresh_pair" | sed -n '1p')"
+fresh_second="$(printf '%s\n' "$fresh_pair" | sed -n '2p')"
+check "the first allocation of a free base takes the base itself" "$base" "$fresh_first"
+if [[ "$fresh_second" != "$base" && "$fresh_second" != "$fresh_first" ]]; then
+  ok "a second allocation cannot take the base another run just reserved"
+else bad "a second allocation cannot take the base another run just reserved (got: $fresh_second)"; fi
+rm -f "$base" "$fresh_second"
 
 printf 'EXISTING
 ' > "$base"

--- a/examples/local-auto-update/test-update.sh
+++ b/examples/local-auto-update/test-update.sh
@@ -177,6 +177,22 @@ seed_versions "" 2.1.1 2.1.2 2.1.3 2.1.4
 rm -f "$CALICO_BIN_LINK"
 check "prune tolerates a missing symlink" "2.1.2 2.1.3 2.1.4" "$(prune_with 3)"
 
+# A build young enough to belong to an overlapping run is left alone even when
+# the retention count says it should go: that run may not have swapped its link
+# yet, and deleting its destination would strand it.
+#
+# The young build must fall OUTSIDE the retention count for this to test
+# anything. `ls -t` puts the newest first, so it has to sit behind a current
+# target that is newer still — otherwise it survives on its retention slot and
+# the age check is never consulted.
+rm -rf "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"; mkdir -p "$CALICO_VERSIONS_DIR" "${SANDBOX}/bin"
+printf 'old\n' > "${CALICO_VERSIONS_DIR}/2.1.1"
+touch -t 202601011000 "${CALICO_VERSIONS_DIR}/2.1.1"
+printf 'in flight\n' > "${CALICO_VERSIONS_DIR}/2.1.8"
+printf 'current\n' > "${CALICO_VERSIONS_DIR}/2.1.9"
+ln -sf "${CALICO_VERSIONS_DIR}/2.1.9" "$CALICO_BIN_LINK"
+check "prune leaves a just-created build alone" "2.1.8 2.1.9" "$(prune_with 1)"
+
 # --- 4. hook throttling -------------------------------------------------------
 # --hook must never block and must not spawn --run while inside the window.
 # CALICO_REPO points at a nonexistent repo so any spawned --run fails fast
@@ -248,7 +264,7 @@ age_of() { # <seconds-ago> ; echoes what lock_age_seconds reports
   python3 -c "import os,sys; t=float(sys.argv[2]); os.utime(sys.argv[1],(t,t))" \
     "$probe/.lock" "$(( $(date +%s) - $1 ))"
   CALICO_STATE_DIR="$probe" bash -c '
-    stub="$1"; source "$stub"; lock_age_seconds || echo UNKNOWN
+    stub="$1"; source "$stub"; path_age_seconds "$LOCK_DIR" || echo UNKNOWN
   ' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH")
 }
 
@@ -265,14 +281,6 @@ if [[ "$reported" =~ ^[0-9]+$ ]] && (( reported < 60 )); then
 else
   bad "a freshly created lock measures under the startup grace (got: ${reported})"
 fi
-
-# A run that proceeded past an ignored lock may be overlapping another updater,
-# which could be mid-install or holding a rollback target this run cannot see.
-seed_versions "2.1.5" 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5
-kept="$(CALICO_KEEP_VERSIONS=3 bash -c '
-  stub="$1"; source "$stub"; LOCK_CREATED=0; prune_old_versions >/dev/null 2>&1
-' _ <(sed 's/^main "\$@"$/:/' "$UPDATE_SH"); ls "$CALICO_VERSIONS_DIR" | sort | tr '\n' ' ' | sed 's/ $//')"
-check "a run that does not hold the lock prunes nothing" "2.1.1 2.1.2 2.1.3 2.1.4 2.1.5" "$kept"
 
 # --- 5c. install path allocation ----------------------------------------------
 # The suffix must come from an exclusive create, not from the pid: pids are
@@ -537,6 +545,39 @@ printf 'binary suffixed\n' > "${CALICO_VERSIONS_DIR}/2.1.0.4242"
 touch -t 202601010500 "${CALICO_VERSIONS_DIR}/2.1.0.4242"
 ln -sf "${CALICO_VERSIONS_DIR}/2.1.0.4242" "$CALICO_BIN_LINK"
 check "prune never deletes a suffixed current target" "2.1.0.4242 2.1.3 2.1.4 2.1.5" "$(prune_with 3)"
+
+# --- 8e. verification happens before the swap ---------------------------------
+# The build is checked directly, not through BIN_LINK. Nothing is undone on
+# failure because nothing was changed yet — so the launcher must be untouched.
+
+e2e_reset "${SANDBOX}/asset-flips"
+cp "${SANDBOX}/asset-good" "$E2E/versions/9.9.8"; chmod +x "$E2E/versions/9.9.8"
+ln -sf "$E2E/versions/9.9.8" "$E2E/bin/calico-claude"
+out="$(e2e_run --run)"
+check "e2e: a build failing its check fails the run" "1" "$?"
+check "e2e: the launcher still points at the previous build" "$E2E/versions/9.9.8" "$(readlink "$E2E/bin/calico-claude")"
+if printf '%s' "$out" | grep -q "Leaving .* untouched"; then
+  ok "e2e: the failure is reported as leaving the launcher alone"
+else bad "e2e: the failure is reported as leaving the launcher alone"; fi
+
+# First install: there is no previous target, and the link must not be created.
+e2e_reset "${SANDBOX}/asset-flips"
+out="$(e2e_run --run)"
+if [[ -e "$E2E/bin/calico-claude" || -L "$E2E/bin/calico-claude" ]]; then
+  bad "e2e: no launcher is created when the build fails its check"
+else ok "e2e: no launcher is created when the build fails its check"; fi
+
+# --- 8f. a launcher we do not manage is refused --------------------------------
+# swap_symlink would mv over a regular file, and nothing could put it back.
+
+e2e_reset "${SANDBOX}/asset-good"
+printf 'USER OWNED\n' > "$E2E/bin/calico-claude"
+out="$(e2e_run --run)"
+check "e2e: a non-symlink launcher fails the run" "1" "$?"
+check "e2e: the user's file is left exactly as it was" "USER OWNED" "$(cat "$E2E/bin/calico-claude")"
+if printf '%s' "$out" | grep -q "not a symlink"; then
+  ok "e2e: the refusal says why"
+else bad "e2e: the refusal says why (got: ${out})"; fi
 
 # --- 8d. --check must agree with --run ----------------------------------------
 # A read-only check that reports "up to date" while --run would immediately

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -618,7 +618,13 @@ perform_update() {
       log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}), but --force given; reinstalling."
     else
       log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}); nothing to do. Exiting."
-      prune_old_versions
+      # Same reasoning as the post-swap prune: the current target must not move
+      # while this decides what to delete. Skipping the pass when the lock is
+      # busy costs nothing.
+      if acquire_commit_lock; then
+        prune_old_versions
+        release_commit_lock
+      fi
       exit 0
     fi
   fi
@@ -720,13 +726,32 @@ perform_update() {
     exit 0
   fi
 
+  # The tag record and the symlink describe one fact between them, so a failure
+  # to write the record must not leave the launcher advanced. Treating that write
+  # as merely "degraded" could strand a high rebuild rank from an older version
+  # on top of a newer one, after which a later rebuild reads as already current
+  # and becomes unreachable even with --force. Write it to a temporary file
+  # first: a failure there is caught while the launcher is still untouched, and
+  # what remains after the swap is a rename.
+  local tag_tmp="${INSTALLED_TAG_FILE}.tmp.$$"
+  if ! printf '%s\n' "$LATEST_TAG" > "$tag_tmp" 2>/dev/null; then
+    rm -f "$tag_tmp" 2>/dev/null || true
+    log "Cannot write ${INSTALLED_TAG_FILE}; leaving ${BIN_LINK} unchanged so the record and the launcher stay consistent."
+    release_commit_lock
+    exit 0
+  fi
+
   swap_symlink "$dest"
-  printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
-    log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
-  release_commit_lock
+  mv -f "$tag_tmp" "$INSTALLED_TAG_FILE"
   log "Symlink ${BIN_LINK} -> ${dest}"
   log "Update to ${LATEST_TAG} complete."
+
+  # Pruned while still holding the commit lock. Pruning snapshots the current
+  # target and then deletes; if another run swaps in between, the snapshot names
+  # a build that is no longer current and the live one can be deleted, leaving
+  # the launcher dangling. Inside the lock the target cannot move.
   prune_old_versions
+  release_commit_lock
 }
 
 do_check() {

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+#
+# calico update.sh — unattended local updater for patched Claude Code builds
+# published by a Calico release repo (default: Nanako0129/calico-claude).
+#
+# It manages a SEPARATELY NAMED binary (default `calico-claude`) so the official
+# `claude` symlink stays under Anthropic's own updater. See README.md next to
+# this script for the SessionStart hook wiring.
+#
+# Modes:
+#   --hook   Throttled entry point for the SessionStart hook. Never blocks:
+#            if the last check was < THROTTLE_SECONDS ago it exits 0 immediately;
+#            otherwise it records the timestamp, spawns a detached `--run` and
+#            exits 0. stdin (the hook JSON payload) is ignored.
+#   --run    Perform an update if a newer release exists. Verifies checksum and
+#            build attestation (fail-hard) BEFORE installing; rolls back the
+#            symlink if the post-install version check fails.
+#   --force  Like --run, but skips the "already up to date" version gate so a
+#            same-version rebuilt release can be reinstalled. Checksum,
+#            attestation and post-verify still run (fail-hard) as usual.
+#   --check  Report installed vs latest release. Makes no changes.
+#
+# Dependencies: bash 3.2+, curl, python3, and a sha256 checker (`shasum` on
+# macOS, `sha256sum` on Linux). `gh` is optional and only used to verify build
+# provenance attestations.
+#
+# Environment overrides (all optional):
+#   CALICO_REPO           GitHub repo publishing the patched releases.
+#   CALICO_PLATFORM       Force a platform suffix (linux-x64, linux-arm64,
+#                         macos-arm64, win32-x64, win32-arm64).
+#   CALICO_BIN_LINK       Managed symlink path.
+#   CALICO_VERSIONS_DIR   Directory holding installed versions.
+#   CALICO_STATE_DIR      Lock/log/throttle state directory.
+#   CALICO_KEEP_VERSIONS  How many old versions to keep (default 3, 0 = keep all).
+#   CALICO_THROTTLE_SECONDS  Minimum seconds between --hook checks (default 3600).
+#   GH_TOKEN / GITHUB_TOKEN  Used as a bearer token for the releases API.
+
+set -euo pipefail
+
+# --- Constants ---------------------------------------------------------------
+REPO="${CALICO_REPO:-Nanako0129/calico-claude}"
+VERSIONS_DIR="${CALICO_VERSIONS_DIR:-${HOME}/.local/share/calico-claude/versions}"
+BIN_LINK="${CALICO_BIN_LINK:-${HOME}/.local/bin/calico-claude}"
+STATE_DIR="${CALICO_STATE_DIR:-${HOME}/.claude/calico}"
+LOCK_DIR="${STATE_DIR}/.lock"
+LAST_CHECK_FILE="${STATE_DIR}/last-check"
+LOG_FILE="${STATE_DIR}/update.log"
+THROTTLE_SECONDS="${CALICO_THROTTLE_SECONDS:-3600}"
+KEEP_VERSIONS="${CALICO_KEEP_VERSIONS:-3}"
+LOG_MAX_LINES=2000
+API_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
+
+# Populated by cleanup trap.
+TMP_DIR=""
+
+# Set to 1 by the --force mode. When forcing, perform_update skips the
+# "already up to date" version gate (but still runs checksum, attestation and
+# post-verify) so a same-version rebuilt release can be reinstalled.
+FORCE=0
+
+# --- Helpers -----------------------------------------------------------------
+log() {
+  printf '%s [calico] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+  if [[ -d "$LOCK_DIR" ]]; then
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+# Sets: RELEASE_SUFFIX, ASSET, IS_MACOS.
+# Mirrors detect_platform() in install-patched-claude.sh; keep the two in sync.
+detect_platform() {
+  IS_MACOS=0
+
+  if [[ -n "${CALICO_PLATFORM:-}" ]]; then
+    RELEASE_SUFFIX="$CALICO_PLATFORM"
+  else
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+      Linux)
+        case "$arch" in
+          x86_64)        RELEASE_SUFFIX="linux-x64" ;;
+          aarch64|arm64) RELEASE_SUFFIX="linux-arm64" ;;
+          *) fail "Unsupported Linux architecture: ${arch}" ;;
+        esac
+        ;;
+      Darwin)
+        case "$arch" in
+          arm64) RELEASE_SUFFIX="macos-arm64" ;;
+          *) fail "Unsupported macOS architecture: ${arch}. Only Apple Silicon is supported." ;;
+        esac
+        ;;
+      MINGW*|MSYS*|CYGWIN*)
+        case "$arch" in
+          x86_64|amd64)  RELEASE_SUFFIX="win32-x64" ;;
+          aarch64|arm64) RELEASE_SUFFIX="win32-arm64" ;;
+          *) fail "Unsupported Windows architecture: ${arch}" ;;
+        esac
+        ;;
+      *)
+        fail "Unsupported operating system: ${os}"
+        ;;
+    esac
+  fi
+
+  case "$RELEASE_SUFFIX" in
+    linux-x64|linux-arm64) ASSET="claude.native.patched" ;;
+    macos-arm64)           ASSET="claude.native.macos.patched"; IS_MACOS=1 ;;
+    win32-x64|win32-arm64) ASSET="claude.native.windows.patched.exe" ;;
+    *) fail "Unknown platform suffix: ${RELEASE_SUFFIX}" ;;
+  esac
+}
+
+# Verify "<sha256>  <file>" lines in $1 against files in the current directory.
+sha256_check() {
+  local list="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$list"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$list"
+  else
+    fail "Missing required command: shasum or sha256sum"
+  fi
+}
+
+acquire_lock() {
+  mkdir -p "$STATE_DIR"
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "Another update is already in progress (lock held); exiting."
+    exit 0
+  fi
+  trap cleanup EXIT
+}
+
+# Installed version = basename of the symlink target. Does NOT launch the binary.
+get_installed_version() {
+  local target
+  if [[ ! -L "$BIN_LINK" ]]; then
+    # Not a symlink we manage; still try to derive something sensible.
+    if [[ -e "$BIN_LINK" ]]; then
+      log "WARNING: ${BIN_LINK} is not a symlink; cannot derive installed version from link target."
+    fi
+    INSTALLED_VERSION=""
+    return
+  fi
+  target="$(readlink "$BIN_LINK")"
+  INSTALLED_VERSION="$(basename "$target")"
+}
+
+# True if the currently installed binary carries the Calico "(patched)"
+# version marker. Used to detect the official autoupdater overwriting the
+# patched build with a same-version official binary.
+installed_is_patched() {
+  local version_output
+  version_output="$("$BIN_LINK" --version 2>/dev/null || true)"
+  [[ "$version_output" == *"(patched)"* ]]
+}
+
+# Query the releases list, pick the highest semver whose tag matches
+# ^v(X.Y.Z)-<suffix>(-<rebuild>)?$ and that carries the expected asset.
+# Sets: LATEST_VERSION, LATEST_TAG, ASSET_URL, CHECKSUMS_URL (may be empty).
+# Returns 0 when a release was found, 1 when none matched.
+query_latest_release() {
+  require_cmd curl
+  require_cmd python3
+
+  local json_file
+  json_file="$(mktemp)" || fail "Failed to create temp file for release metadata"
+
+  # Built as one non-empty array: bash 3.2 (stock on macOS) treats "${a[@]}"
+  # on an EMPTY array as an unbound variable under `set -u`, so an optional
+  # token must never be its own array.
+  local -a curl_args=(
+    -fsSL
+    -H "Accept: application/vnd.github+json"
+    -H "User-Agent: calico-claude-updater"
+  )
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
+  elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
+  if ! curl "${curl_args[@]}" "$API_URL" -o "$json_file"; then
+    rm -f "$json_file"
+    fail "Failed to query GitHub releases API for ${REPO}"
+  fi
+
+  local parsed rc
+  set +e
+  parsed="$(python3 - "$ASSET" "$RELEASE_SUFFIX" "$json_file" <<'PY'
+import json, re, sys
+
+asset = sys.argv[1]
+suffix = sys.argv[2]
+json_file = sys.argv[3]
+# Rebuilt releases carry a numeric suffix (v2.1.235-macos-arm64-2). Rank them
+# above the base tag for the same version, matching install-patched-claude.sh.
+pat = re.compile(r'^v(\d+)\.(\d+)\.(\d+)-' + re.escape(suffix) + r'(?:-(\d+))?$')
+
+try:
+    with open(json_file, encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    sys.exit(2)
+
+if not isinstance(data, list):
+    sys.exit(2)
+
+best = None
+for rel in data:
+    if not isinstance(rel, dict):
+        continue
+    if rel.get("draft"):
+        continue
+    tag = rel.get("tag_name", "") or ""
+    m = pat.match(tag)
+    if not m:
+        continue
+    ver = tuple(int(x) for x in m.group(1, 2, 3))
+    rank = int(m.group(4) or "1")
+    asset_url = checksums_url = None
+    for a in rel.get("assets", []) or []:
+        name = a.get("name")
+        if name == asset:
+            asset_url = a.get("browser_download_url")
+        elif name == "checksums.txt":
+            checksums_url = a.get("browser_download_url")
+    if not asset_url:
+        continue
+    key = (ver, rank)
+    cand = (key, tag, "%d.%d.%d" % ver, asset_url, checksums_url or "")
+    if best is None or key > best[0]:
+        best = cand
+
+if best is None:
+    sys.exit(3)
+
+print(best[2])
+print(best[1])
+print(best[3])
+print(best[4])
+PY
+)"
+  rc=$?
+  set -e
+  rm -f "$json_file"
+
+  case "$rc" in
+    0) ;;
+    3) return 1 ;;  # no matching release
+    2) fail "Failed to parse GitHub releases JSON" ;;
+    *) fail "Release query failed (rc=${rc})" ;;
+  esac
+
+  LATEST_VERSION="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  LATEST_TAG="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  ASSET_URL="$(printf '%s\n' "$parsed" | sed -n '3p')"
+  CHECKSUMS_URL="$(printf '%s\n' "$parsed" | sed -n '4p')"
+
+  [[ -n "$LATEST_VERSION" && -n "$ASSET_URL" ]] || fail "Incomplete release metadata parsed"
+  return 0
+}
+
+# Compare dotted semver: echoes "newer" if $1 > $2, "same" if equal, "older" otherwise.
+semver_relation() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+def parse(v):
+    return tuple(int(x) for x in v.split("."))
+a = parse(sys.argv[1]); b = parse(sys.argv[2])
+print("newer" if a > b else ("same" if a == b else "older"))
+PY
+}
+
+verify_checksum() {
+  local dir="$1"
+  local checksums_file="${dir}/checksums.txt"
+
+  [[ -s "$checksums_file" ]] || fail "checksums.txt is missing or empty; refusing to install"
+
+  # Extract only the line for our asset so that unrelated entries (missing
+  # files) do not make the checker error out for the wrong reason.
+  local filtered="${dir}/checksums.selected.txt"
+  # Escape regex metacharacters: the asset name contains dots, which would
+  # otherwise match any character and let a decoy entry satisfy the gate.
+  local asset_re="${ASSET//./\\.}"
+  grep -E "[[:space:]]\*?${asset_re}\$" "$checksums_file" > "$filtered" || \
+    fail "No checksum entry for ${ASSET} in checksums.txt"
+
+  ( cd "$dir" && sha256_check "$(basename "$filtered")" ) >/dev/null 2>&1 || \
+    fail "Checksum verification FAILED for ${ASSET}; refusing to install"
+
+  log "Checksum verified for ${ASSET}"
+}
+
+verify_attestation() {
+  local file="$1"
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    if gh attestation verify "$file" --repo "$REPO" >/dev/null 2>&1; then
+      log "Attestation verified via gh for ${ASSET}"
+    else
+      fail "Attestation verification FAILED for ${ASSET}; refusing to install"
+    fi
+  else
+    log "WARNING: gh unavailable or not authenticated; skipping attestation verification"
+  fi
+}
+
+# Atomically point BIN_LINK at $1 (an absolute target path).
+swap_symlink() {
+  local target="$1"
+  local tmp="${BIN_LINK}.calico-tmp.$$"
+  ln -s "$target" "$tmp"
+  mv -f "$tmp" "$BIN_LINK"
+}
+
+# Keep the newest KEEP_VERSIONS entries in VERSIONS_DIR and delete the rest. The
+# current symlink target is always kept — after a rollback it may be older than
+# all of them, in which case it is retained on top of the newest KEEP_VERSIONS.
+# KEEP_VERSIONS=0 (or a non-numeric value) disables pruning entirely.
+# Entries are ordered by mtime (newest first) so hand-made names such as
+# "2.1.223.pre-something" are handled without a semver parse.
+prune_old_versions() {
+  [[ "$KEEP_VERSIONS" =~ ^[0-9]+$ ]] || return 0
+  (( KEEP_VERSIONS > 0 )) || return 0
+  [[ -d "$VERSIONS_DIR" ]] || return 0
+
+  local current=""
+  [[ -L "$BIN_LINK" ]] && current="$(basename "$(readlink "$BIN_LINK")")"
+
+  local -a entries=()
+  local name
+  # ls -t sorts by mtime, newest first. Names here are version strings written
+  # by this script, so they never contain newlines.
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    [[ -f "${VERSIONS_DIR}/${name}" ]] || continue
+    entries+=("$name")
+  done < <(ls -t "$VERSIONS_DIR" 2>/dev/null)
+
+  local kept=0
+  for name in "${entries[@]:-}"; do
+    [[ -n "$name" ]] || continue
+    if [[ "$name" == "$current" ]]; then
+      # Always kept, and counted, so KEEP_VERSIONS=3 means three builds on disk
+      # in the normal case rather than four.
+      kept=$((kept + 1))
+      continue
+    fi
+    kept=$((kept + 1))
+    if (( kept <= KEEP_VERSIONS )); then
+      continue
+    fi
+    rm -f "${VERSIONS_DIR}/${name}" && log "Pruned old version ${name}"
+  done
+}
+
+# Keep the detached --run log from growing without bound.
+rotate_log() {
+  [[ -f "$LOG_FILE" ]] || return 0
+  local lines
+  lines="$(wc -l < "$LOG_FILE" 2>/dev/null | tr -d ' ')"
+  [[ "$lines" =~ ^[0-9]+$ ]] || return 0
+  (( lines > LOG_MAX_LINES )) || return 0
+  local tmp="${LOG_FILE}.trim.$$"
+  tail -n "$((LOG_MAX_LINES / 2))" "$LOG_FILE" > "$tmp" 2>/dev/null && mv -f "$tmp" "$LOG_FILE"
+  rm -f "$tmp" 2>/dev/null || true
+}
+
+perform_update() {
+  acquire_lock
+  detect_platform
+
+  get_installed_version
+  log "Installed version: ${INSTALLED_VERSION:-<unknown>} (${RELEASE_SUFFIX})"
+
+  if ! query_latest_release; then
+    log "No matching ${RELEASE_SUFFIX} release found for ${REPO}; nothing to do. Exiting."
+    exit 0
+  fi
+  log "Latest release: ${LATEST_VERSION} (tag ${LATEST_TAG})"
+
+  if [[ -n "$INSTALLED_VERSION" ]]; then
+    local rel
+    rel="$(semver_relation "$LATEST_VERSION" "$INSTALLED_VERSION")"
+    if [[ "$rel" == "newer" ]]; then
+      : # proceed to install
+    elif [[ "$rel" == "same" ]] && ! installed_is_patched; then
+      # Same version but the official autoupdater (or a manual `claude
+      # install`) overwrote the patched binary — self-heal by reinstalling
+      # the patched build of the same version.
+      log "Installed ${INSTALLED_VERSION} matches latest but is NOT patched (official binary detected); reinstalling patched build."
+    elif [[ "$FORCE" == "1" ]]; then
+      # --force: reinstall even when already up to date and already patched
+      # (e.g. the release was rebuilt at the same version). Checksum,
+      # attestation and post-verify below still run unconditionally.
+      log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}), but --force given; reinstalling."
+    else
+      log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}); nothing to do. Exiting."
+      prune_old_versions
+      exit 0
+    fi
+  fi
+
+  # --- Download -------------------------------------------------------------
+  TMP_DIR="$(mktemp -d)" || fail "Failed to create temp download dir"
+  local asset_path="${TMP_DIR}/${ASSET}"
+  log "Downloading ${ASSET} (${LATEST_TAG})"
+  # -sS: no progress meter (this log is appended to unattended), errors still shown.
+  curl -fsSL "$ASSET_URL" -o "$asset_path" || fail "Failed to download ${ASSET}"
+
+  if [[ -n "$CHECKSUMS_URL" ]]; then
+    curl -fsSL "$CHECKSUMS_URL" -o "${TMP_DIR}/checksums.txt" || fail "Failed to download checksums.txt"
+  else
+    fail "Release ${LATEST_TAG} has no checksums.txt asset; refusing to install"
+  fi
+
+  # --- Verify (fail-hard, BEFORE install) -----------------------------------
+  verify_checksum "$TMP_DIR"
+  verify_attestation "$asset_path"
+
+  # --- Install --------------------------------------------------------------
+  mkdir -p "$VERSIONS_DIR"
+  local dest="${VERSIONS_DIR}/${LATEST_VERSION}"
+  install -m 0755 "$asset_path" "$dest" || fail "Failed to install binary to ${dest}"
+  if (( IS_MACOS )); then
+    xattr -d com.apple.quarantine "$dest" 2>/dev/null || true
+  fi
+  log "Installed patched binary to ${dest}"
+
+  # --- Atomic symlink swap --------------------------------------------------
+  mkdir -p "$(dirname "$BIN_LINK")"
+  local old_target=""
+  [[ -L "$BIN_LINK" ]] && old_target="$(readlink "$BIN_LINK")"
+  swap_symlink "$dest"
+  log "Symlink ${BIN_LINK} -> ${dest}"
+
+  # --- Post-verify with rollback --------------------------------------------
+  local version_output
+  version_output="$("$BIN_LINK" --version 2>&1 || true)"
+  if [[ "$version_output" == *"$LATEST_VERSION"* && "$version_output" == *"(patched)"* ]]; then
+    log "Post-verify OK: ${version_output//$'\n'/ | }"
+    log "Update to ${LATEST_VERSION} complete."
+    prune_old_versions
+  else
+    log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"
+    if [[ -n "$old_target" ]]; then
+      swap_symlink "$old_target"
+      log "Rolled back symlink ${BIN_LINK} -> ${old_target}"
+    else
+      log "WARNING: no previous symlink target recorded; cannot roll back."
+    fi
+    exit 1
+  fi
+}
+
+do_check() {
+  detect_platform
+  get_installed_version
+  local installed_display="${INSTALLED_VERSION:-<unknown>}"
+  if query_latest_release; then
+    printf 'Platform:       %s\n' "$RELEASE_SUFFIX"
+    printf 'Installed:      %s\n' "$installed_display"
+    printf 'Latest release: %s (tag %s)\n' "$LATEST_VERSION" "$LATEST_TAG"
+    if [[ -n "$INSTALLED_VERSION" ]]; then
+      case "$(semver_relation "$LATEST_VERSION" "$INSTALLED_VERSION")" in
+        newer) printf 'Status:         update available\n' ;;
+        same)  printf 'Status:         up to date\n' ;;
+        older) printf 'Status:         installed is newer than latest release\n' ;;
+      esac
+    fi
+  else
+    printf 'Platform:       %s\n' "$RELEASE_SUFFIX"
+    printf 'Installed:      %s\n' "$installed_display"
+    printf 'Latest release: none (no matching %s release published yet)\n' "$RELEASE_SUFFIX"
+  fi
+}
+
+do_hook() {
+  # Never block session startup. Ignore stdin (the hook JSON payload).
+  mkdir -p "$STATE_DIR"
+  local now last
+  now="$(date +%s)"
+  last="$(cat "$LAST_CHECK_FILE" 2>/dev/null || echo 0)"
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+
+  if (( now - last < THROTTLE_SECONDS )); then
+    exit 0
+  fi
+
+  # An unwritable stamp must not turn the "never blocks" hook into a failure.
+  printf '%s\n' "$now" > "$LAST_CHECK_FILE" 2>/dev/null || \
+    log "WARNING: could not write ${LAST_CHECK_FILE}; throttling is degraded."
+  rotate_log
+  nohup bash "$0" --run < /dev/null >> "$LOG_FILE" 2>&1 &
+  disown
+  exit 0
+}
+
+main() {
+  local mode="${1:-}"
+  case "$mode" in
+    --hook)  do_hook ;;
+    --run)   perform_update ;;
+    --force) FORCE=1; perform_update ;;
+    --check) do_check ;;
+    *)
+      cat >&2 <<EOF
+Usage: $0 [--hook|--run|--force|--check]
+
+  --hook   Throttled SessionStart entry point (spawns detached --run, never blocks).
+  --run    Update if a newer verified release exists.
+  --force  Reinstall even when already up to date (skips only the version gate).
+  --check  Report installed vs latest release without changing anything.
+EOF
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -54,6 +54,10 @@ API_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
 # Populated by cleanup trap.
 TMP_DIR=""
 
+# Set while a reinstall has moved the existing build aside; cleanup restores it.
+PRESERVED_PATH=""
+PRESERVED_DEST=""
+
 # Set to 1 by the --force mode. When forcing, perform_update skips the
 # "already up to date" version gate (but still runs checksum, attestation and
 # post-verify) so a same-version rebuilt release can be reinstalled.
@@ -70,6 +74,16 @@ fail() {
 }
 
 cleanup() {
+  # Set while a reinstall has the previous build moved aside. Restoring it here
+  # covers every exit that runs a trap; recover_preserved covers the ones that
+  # do not.
+  if [[ -n "$PRESERVED_PATH" && -e "$PRESERVED_PATH" ]]; then
+    if [[ -e "$PRESERVED_DEST" ]]; then
+      rm -f "$PRESERVED_PATH" 2>/dev/null || true
+    else
+      mv -f "$PRESERVED_PATH" "$PRESERVED_DEST" 2>/dev/null || true
+    fi
+  fi
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
     rm -rf "$TMP_DIR"
   fi
@@ -185,16 +199,20 @@ sha256_check() {
 # a corpse to reclaim. Only needs to exceed the mkdir-to-write window.
 LOCK_STARTUP_GRACE=60
 
-# Age of the lock directory in seconds. stat is not portable, so try both forms.
+# Age of the lock directory in seconds, or empty when it cannot be determined.
+#
+# Exit status cannot drive the fallback here: GNU `stat -f` means
+# --file-system, so on Linux it SUCCEEDS with unrelated multi-line output and a
+# `-f || -c` chain never reaches the second form. Try the GNU spelling first and
+# validate the output instead.
 lock_age_seconds() {
   local mtime
-  mtime="$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo 0)"
-  [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
-  if (( mtime == 0 )); then
-    printf '%s\n' "$((LOCK_STARTUP_GRACE + 1))"
-  else
-    printf '%s\n' "$(( $(date +%s) - mtime ))"
+  mtime="$(stat -c %Y "$LOCK_DIR" 2>/dev/null || true)"
+  if [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+    mtime="$(stat -f %m "$LOCK_DIR" 2>/dev/null || true)"
   fi
+  [[ "$mtime" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$(( $(date +%s) - mtime ))"
 }
 
 # The lock records its owner pid. A run killed by SIGKILL, a power loss, or a
@@ -215,9 +233,18 @@ acquire_lock() {
     # let two installers proceed at once and then remove each other's lock.
     # Concurrent SessionStart hooks make this reachable, since their throttle
     # check is not synchronized either. Age is what separates the two.
-    if [[ ! -s "${LOCK_DIR}/pid" ]] && (( $(lock_age_seconds) < LOCK_STARTUP_GRACE )); then
-      log "Another update is starting up (lock has no owner yet); exiting."
-      exit 0
+    if [[ ! -s "${LOCK_DIR}/pid" ]]; then
+      local age
+      if ! age="$(lock_age_seconds)"; then
+        # Unknown age. Reclaiming could let two installers run at once, which is
+        # worse than waiting; a genuinely abandoned lock is then cleared by hand.
+        log "Lock has no owner and its age cannot be determined; leaving it alone. Remove ${LOCK_DIR} manually if no update is running."
+        exit 0
+      fi
+      if (( age < LOCK_STARTUP_GRACE )); then
+        log "Another update is starting up (lock has no owner yet); exiting."
+        exit 0
+      fi
     fi
     log "Reclaiming stale lock (owner ${owner:-unknown} is no longer running)."
     rm -rf "$LOCK_DIR"
@@ -466,9 +493,28 @@ rotate_log() {
   rm -f "$tmp" 2>/dev/null || true
 }
 
+# A reinstall moves the existing build aside before installing over it. If the
+# run is killed between those two points, EXIT traps do not run (SIGKILL, power
+# loss), and the launcher is left pointing at nothing while the working binary
+# sits under a .preserved.<pid> name. Put it back on the next run.
+recover_preserved() {
+  [[ -d "$VERSIONS_DIR" ]] || return 0
+  local preserved base
+  for preserved in "$VERSIONS_DIR"/*.preserved.*; do
+    [[ -e "$preserved" ]] || continue
+    base="${preserved%.preserved.*}"
+    if [[ -e "$base" ]]; then
+      rm -f "$preserved"
+    elif mv -f "$preserved" "$base"; then
+      log "Recovered ${base} left behind by an interrupted reinstall."
+    fi
+  done
+}
+
 perform_update() {
   acquire_lock
   detect_platform
+  recover_preserved
 
   get_installed_version
   log "Installed version: ${INSTALLED_VERSION:-<unknown>} (${RELEASE_SUFFIX})"
@@ -552,10 +598,11 @@ perform_update() {
   local preserved=""
   if [[ -e "$dest" ]]; then
     preserved="${dest}.preserved.$$"
+    PRESERVED_DEST="$dest"
     mv -f "$dest" "$preserved" || fail "Failed to preserve the existing ${dest}"
+    PRESERVED_PATH="$preserved"
   fi
   if ! install -m 0755 "$asset_path" "$dest"; then
-    [[ -n "$preserved" ]] && mv -f "$preserved" "$dest"
     fail "Failed to install binary to ${dest}"
   fi
   if (( IS_MACOS )); then
@@ -575,6 +622,7 @@ perform_update() {
   version_output="$("$BIN_LINK" --version 2>&1 || true)"
   if version_output_matches "$version_output" "$LATEST_VERSION"; then
     log "Post-verify OK: ${version_output//$'\n'/ | }"
+    PRESERVED_PATH=""
     [[ -n "$preserved" ]] && rm -f "$preserved"
     printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
       log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
@@ -584,6 +632,7 @@ perform_update() {
     log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"
     if [[ -n "$preserved" ]]; then
       mv -f "$preserved" "$dest"
+      PRESERVED_PATH=""
       log "Restored the previous ${dest} that this install had replaced."
     fi
     if [[ -n "$old_target" ]]; then

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -247,7 +247,28 @@ acquire_lock() {
       fi
     fi
     log "Reclaiming stale lock (owner ${owner:-unknown} is no longer running)."
-    rm -rf "$LOCK_DIR"
+    # Two runs can both see the same dead owner. `rm -rf` on the shared path
+    # would let the second run delete the lock the first had just re-acquired
+    # and both would install concurrently — so the claim must be one atomic
+    # step. Renaming to a per-pid name is that step: only one rename of the
+    # stale directory can succeed, and the loser exits instead of installing.
+    local claimed="${LOCK_DIR}.stale.$$"
+    if ! mv "$LOCK_DIR" "$claimed" 2>/dev/null; then
+      log "Lost the race to reclaim the stale lock; exiting."
+      exit 0
+    fi
+    # The rename can still land on a FRESH lock: another reclaimer may have
+    # finished swapping the stale directory for its own between our staleness
+    # check and the mv. Re-check the owner of what was actually grabbed; a
+    # live one gets its lock back and this run bows out.
+    local grabbed
+    grabbed="$(cat "${claimed}/pid" 2>/dev/null || true)"
+    if [[ "$grabbed" =~ ^[0-9]+$ ]] && kill -0 "$grabbed" 2>/dev/null; then
+      mv "$claimed" "$LOCK_DIR" 2>/dev/null || rm -rf "$claimed"
+      log "Lost the race to reclaim the stale lock; exiting."
+      exit 0
+    fi
+    rm -rf "$claimed"
     if ! mkdir "$LOCK_DIR" 2>/dev/null; then
       log "Lost the race to reclaim the stale lock; exiting."
       exit 0
@@ -503,9 +524,13 @@ recover_preserved() {
   for preserved in "$VERSIONS_DIR"/*.preserved.*; do
     [[ -e "$preserved" ]] || continue
     base="${preserved%.preserved.*}"
-    if [[ -e "$base" ]]; then
-      rm -f "$preserved"
-    elif mv -f "$preserved" "$base"; then
+    # Restore unconditionally, even over a present $base. Every completed
+    # transaction removes its preserved copy (post-verify success deletes it,
+    # failure moves it back), so one still on disk means the previous run died
+    # mid-install — and a $base present alongside it is the replacement that
+    # was never post-verified. Preferring that $base would delete the only
+    # known-good build and keep an unverified one.
+    if mv -f "$preserved" "$base"; then
       log "Recovered ${base} left behind by an interrupted reinstall."
     fi
   done

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -191,17 +191,21 @@ sha256_check() {
 # is IGNORED, never removed. Any real run finishes far inside an hour.
 LOCK_MAX_AGE_SECONDS=3600
 
-# Age of the lock directory in seconds, or empty when it cannot be determined.
+# Seconds a freshly installed build is treated as possibly in flight.
+PRUNE_MIN_AGE_SECONDS=300
+
+# Age of a path in seconds, or non-zero when it cannot be determined.
 #
 # Exit status cannot drive the fallback here: GNU `stat -f` means
 # --file-system, so on Linux it SUCCEEDS with unrelated multi-line output and a
 # `-f || -c` chain never reaches the second form. Try the GNU spelling first and
 # validate the output instead.
-lock_age_seconds() {
+path_age_seconds() {
+  local target="$1"
   local mtime
-  mtime="$(stat -c %Y "$LOCK_DIR" 2>/dev/null || true)"
+  mtime="$(stat -c %Y "$target" 2>/dev/null || true)"
   if [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
-    mtime="$(stat -f %m "$LOCK_DIR" 2>/dev/null || true)"
+    mtime="$(stat -f %m "$target" 2>/dev/null || true)"
   fi
   [[ "$mtime" =~ ^[0-9]+$ ]] || return 1
   printf '%s\n' "$(( $(date +%s) - mtime ))"
@@ -220,7 +224,7 @@ acquire_lock() {
     LOCK_CREATED=1
   else
     local age
-    if age="$(lock_age_seconds)" && (( age < LOCK_MAX_AGE_SECONDS )); then
+    if age="$(path_age_seconds "$LOCK_DIR")" && (( age < LOCK_MAX_AGE_SECONDS )); then
       log "Another update is already in progress (lock is ${age}s old); exiting."
       exit 0
     fi
@@ -450,12 +454,6 @@ swap_symlink() {
 # target is matched by its literal basename, so a pid-suffixed append-only
 # install ("2.1.240.4242") is protected exactly like a bare one.
 prune_old_versions() {
-  # Only the lock holder prunes. A lock old enough to be ignored lets runs
-  # overlap by design, and an overlapping run may have installed its destination
-  # without having swapped the symlink yet, or be holding a rollback target that
-  # this run's symlink does not name. Deleting either would strand it. Skipping
-  # a cleanup pass costs nothing; the next run that does hold the lock prunes.
-  [[ "$LOCK_CREATED" == "1" ]] || return 0
   [[ "$KEEP_VERSIONS" =~ ^[0-9]+$ ]] || return 0
   (( KEEP_VERSIONS > 0 )) || return 0
   [[ -d "$VERSIONS_DIR" ]] || return 0
@@ -486,6 +484,16 @@ prune_old_versions() {
     if (( kept <= KEEP_VERSIONS )); then
       continue
     fi
+    # A build young enough to belong to an overlapping run is left alone: it may
+    # have been installed moments ago by an updater that has not swapped its
+    # link yet, and deleting it would strand that run. Gating this on holding
+    # the lock instead would be worse — an abandoned lock is never removed, so
+    # pruning would stop for good and old builds would accumulate forever.
+    local age
+    if age="$(path_age_seconds "${VERSIONS_DIR}/${name}")" &&
+      (( age < PRUNE_MIN_AGE_SECONDS )); then
+      continue
+    fi
     rm -f "${VERSIONS_DIR}/${name}" && log "Pruned old version ${name}"
   done
 }
@@ -507,6 +515,11 @@ perform_update() {
   detect_platform
 
   get_installed_version
+  # A launcher that is not a symlink is not ours to replace. swap_symlink would
+  # mv over it, and nothing here could put a user's own executable back.
+  if [[ -e "$BIN_LINK" && ! -L "$BIN_LINK" ]]; then
+    fail "${BIN_LINK} exists but is not a symlink; refusing to replace it. Move it aside if it should be managed by this updater."
+  fi
   log "Installed version: ${INSTALLED_VERSION:-<unknown>} (${RELEASE_SUFFIX})"
 
   if ! query_latest_release; then
@@ -587,38 +600,30 @@ perform_update() {
   fi
   log "Installed patched binary to ${dest}"
 
-  # --- Atomic symlink swap --------------------------------------------------
+  # --- Verify the build before it becomes the launcher ----------------------
+  # Checked directly, not through BIN_LINK. Reading it through the symlink is
+  # unsound once runs can overlap: another updater may have pointed the link at
+  # its own build between our swap and our check, and we would then judge -- and
+  # roll back -- someone else's successful install. Verifying first also removes
+  # the need to undo a swap at all.
+  local version_output
+  version_output="$("$dest" --version 2>&1 || true)"
+  if ! version_output_matches "$version_output" "$LATEST_VERSION"; then
+    log "ERROR: the installed build reports '${version_output//$'\n'/ | }', expected ${LATEST_VERSION} and (patched). Leaving ${BIN_LINK} untouched."
+    # $dest stays in VERSIONS_DIR and is pruned later like any other old build.
+    exit 1
+  fi
+  log "Verified before swap: ${version_output//$'\n'/ | }"
+
+  # --- Point the launcher at it ---------------------------------------------
   mkdir -p "$(dirname "$BIN_LINK")"
-  local old_target=""
-  [[ -L "$BIN_LINK" ]] && old_target="$(readlink "$BIN_LINK")"
   swap_symlink "$dest"
   log "Symlink ${BIN_LINK} -> ${dest}"
 
-  # --- Post-verify with rollback --------------------------------------------
-  local version_output
-  version_output="$("$BIN_LINK" --version 2>&1 || true)"
-  if version_output_matches "$version_output" "$LATEST_VERSION"; then
-    log "Post-verify OK: ${version_output//$'\n'/ | }"
-    printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
-      log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
-    log "Update to ${LATEST_TAG} complete."
-    prune_old_versions
-  else
-    log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"
-    # Nothing was overwritten, so rollback is just the symlink: the previous
-    # target was never touched. The failed install stays in VERSIONS_DIR and is
-    # pruned later like any other old build.
-    if [[ -n "$old_target" ]]; then
-      swap_symlink "$old_target"
-      log "Rolled back symlink ${BIN_LINK} -> ${old_target}"
-    else
-      # First install: there is nothing to roll back to, but leaving the link
-      # pointing at a binary that just failed its check is worse than no link.
-      rm -f "$BIN_LINK"
-      log "Removed ${BIN_LINK}; it pointed at a binary that failed post-verify and there was no previous target."
-    fi
-    exit 1
-  fi
+  printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
+    log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
+  log "Update to ${LATEST_TAG} complete."
+  prune_old_versions
 }
 
 do_check() {

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -74,7 +74,6 @@ fail() {
 }
 
 cleanup() {
-  release_commit_lock
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
     rm -rf "$TMP_DIR"
   fi
@@ -191,20 +190,6 @@ sha256_check() {
 # A lock older than this is assumed abandoned (SIGKILL, power loss, reboot) and
 # is IGNORED, never removed. Any real run finishes far inside an hour.
 LOCK_MAX_AGE_SECONDS=3600
-
-# The commit lock covers only pointing the launcher: reading the current target
-# and tag, deciding, then swapping. Downloading and installing need no exclusion
-# because they are append-only. Held for two syscalls, so a stale one means a
-# process died inside that window — rare enough that taking it over on expiry is
-# safe, since the worst case of a lost race there is two valid builds competing
-# for the link and the later one winning.
-COMMIT_LOCK_DIR="${STATE_DIR}/.commit-lock"
-COMMIT_LOCK_MAX_AGE_SECONDS=60
-COMMIT_LOCK_WAIT_SECONDS="${CALICO_COMMIT_WAIT:-30}"
-COMMIT_LOCK_HELD=0
-
-# Seconds a freshly installed build is treated as possibly in flight.
-PRUNE_MIN_AGE_SECONDS=300
 
 # Age of a path in seconds, or non-zero when it cannot be determined.
 #
@@ -449,61 +434,6 @@ allocate_dest() {
   mktemp "${base}.XXXXXX"
 }
 
-# Serialize the launcher update. Returns 1 when it could not be taken, which is
-# not an error: the build is installed and a later run will point at it.
-acquire_commit_lock() {
-  local deadline=$(( $(date +%s) + COMMIT_LOCK_WAIT_SECONDS ))
-  while ! mkdir "$COMMIT_LOCK_DIR" 2>/dev/null; do
-    if (( $(date +%s) >= deadline )); then
-      local age
-      age="$(path_age_seconds "$COMMIT_LOCK_DIR" || true)"
-      if [[ "$age" =~ ^[0-9]+$ ]] && (( age > COMMIT_LOCK_MAX_AGE_SECONDS )); then
-        # Deliberately NOT reclaimed. Every delete-and-reacquire protocol tried
-        # here had the same hole: two runs both see the lock expired, one
-        # removes and recreates it, the second removes that new lock and takes
-        # it, and both enter the section the lock exists to serialize. There is
-        # no way to fix that without an atomic primitive this script does not
-        # have — so it is not attempted.
-        #
-        # Unlike the run lock, an abandoned commit lock cannot be left behind by
-        # an ordinary kill: it is held across two syscalls. If one is somehow
-        # stranded it needs a human, and stopping is the safe direction — the
-        # build is installed and nothing is corrupted, only the launcher stays
-        # where it was.
-        log "Commit lock ${COMMIT_LOCK_DIR} has been held for ${age}s. It is not reclaimed automatically; remove it by hand if no update is running."
-      fi
-      return 1
-    fi
-    sleep 1
-  done
-  COMMIT_LOCK_HELD=1
-  return 0
-}
-
-release_commit_lock() {
-  if [[ "$COMMIT_LOCK_HELD" == "1" ]]; then
-    rm -rf "$COMMIT_LOCK_DIR" 2>/dev/null || true
-    COMMIT_LOCK_HELD=0
-  fi
-}
-
-# Rank-aware comparison of two release tags for the same or different versions.
-# Echoes "newer", "same" or "older" describing $1 relative to $2.
-release_relation() { # <version-a> <tag-a> <version-b> <tag-b>
-  local rel
-  rel="$(semver_relation "$1" "$3")"
-  if [[ "$rel" != "same" ]]; then
-    printf '%s\n' "$rel"
-    return 0
-  fi
-  local rank_a rank_b
-  rank_a="$(tag_rebuild_rank "$2")"
-  rank_b="$(tag_rebuild_rank "$4")"
-  if (( rank_a > rank_b )); then printf 'newer\n'
-  elif (( rank_a < rank_b )); then printf 'older\n'
-  else printf 'same\n'; fi
-}
-
 # Atomically point BIN_LINK at $1 (an absolute target path).
 swap_symlink() {
   local target="$1"
@@ -549,16 +479,6 @@ prune_old_versions() {
     fi
     kept=$((kept + 1))
     if (( kept <= KEEP_VERSIONS )); then
-      continue
-    fi
-    # A build young enough to belong to an overlapping run is left alone: it may
-    # have been installed moments ago by an updater that has not swapped its
-    # link yet, and deleting it would strand that run. Gating this on holding
-    # the lock instead would be worse — an abandoned lock is never removed, so
-    # pruning would stop for good and old builds would accumulate forever.
-    local age
-    if age="$(path_age_seconds "${VERSIONS_DIR}/${name}")" &&
-      (( age < PRUNE_MIN_AGE_SECONDS )); then
       continue
     fi
     rm -f "${VERSIONS_DIR}/${name}" && log "Pruned old version ${name}"
@@ -618,13 +538,7 @@ perform_update() {
       log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}), but --force given; reinstalling."
     else
       log "Installed version ${INSTALLED_VERSION} is up to date (latest ${LATEST_VERSION}); nothing to do. Exiting."
-      # Same reasoning as the post-swap prune: the current target must not move
-      # while this decides what to delete. Skipping the pass when the lock is
-      # busy costs nothing.
-      if acquire_commit_lock; then
-        prune_old_versions
-        release_commit_lock
-      fi
+      prune_old_versions
       exit 0
     fi
   fi
@@ -689,69 +603,24 @@ perform_update() {
   log "Verified before swap: ${version_output//$'\n'/ | }"
 
   # --- Point the launcher at it ---------------------------------------------
-  # Reading the current target, deciding, and swapping is a read-modify-write on
-  # state other runs share. The check and the swap were previously two unguarded
-  # steps, so a newer run could land between them and be overwritten. Everything
-  # up to here needed no exclusion; only this does.
   mkdir -p "$(dirname "$BIN_LINK")"
-  if ! acquire_commit_lock; then
-    log "Could not take the commit lock within ${COMMIT_LOCK_WAIT_SECONDS}s; leaving ${BIN_LINK} unchanged. ${dest} is installed and a later run will point at it."
-    exit 0
-  fi
-
-  # Read inside the lock, so the tag record and the symlink are always read and
-  # written as one pair — comparing versions alone would let a stale base-tag
-  # run replace a newer same-version rebuild.
-  if [[ -L "$BIN_LINK" ]]; then
-    local live_version live_tag
-    live_version="$(basename "$(readlink "$BIN_LINK")")"
-    live_version="$(printf '%s' "$live_version" | sed -n 's/^\([0-9][0-9.]*[0-9]\).*/\1/p')"
-    live_tag="$(cat "$INSTALLED_TAG_FILE" 2>/dev/null || true)"
-    if [[ -n "$live_version" ]] &&
-      [[ "$(release_relation "$live_version" "${live_tag:-v}" "$LATEST_VERSION" "$LATEST_TAG")" == "newer" ]]; then
-      log "${BIN_LINK} already points at ${live_tag:-$live_version}, newer than ${LATEST_TAG}; leaving it alone. The build stays in ${VERSIONS_DIR}."
-      release_commit_lock
-      exit 0
-    fi
-  fi
-
-  # The age-based in-flight protection assumes a run reaches this point within
-  # PRUNE_MIN_AGE_SECONDS of installing. A suspended laptop breaks that: this run
-  # can sit here for hours while a later one, seeing an aged run lock and an aged
-  # destination, prunes it. Re-checking inside the commit lock costs one stat and
-  # is the only point where the answer cannot change underneath us.
-  if [[ ! -e "$dest" ]]; then
-    log "${dest} was removed while this run was paused; leaving ${BIN_LINK} unchanged. A later run will reinstall."
-    release_commit_lock
-    exit 0
-  fi
 
   # The tag record and the symlink describe one fact between them, so a failure
   # to write the record must not leave the launcher advanced. Treating that write
   # as merely "degraded" could strand a high rebuild rank from an older version
   # on top of a newer one, after which a later rebuild reads as already current
-  # and becomes unreachable even with --force. Write it to a temporary file
-  # first: a failure there is caught while the launcher is still untouched, and
-  # what remains after the swap is a rename.
-  local tag_tmp="${INSTALLED_TAG_FILE}.tmp.$$"
-  if ! printf '%s\n' "$LATEST_TAG" > "$tag_tmp" 2>/dev/null; then
-    rm -f "$tag_tmp" 2>/dev/null || true
+  # and becomes unreachable even with --force. Written before the swap: a
+  # failure here is caught while the launcher is still untouched.
+  if ! printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null; then
     log "Cannot write ${INSTALLED_TAG_FILE}; leaving ${BIN_LINK} unchanged so the record and the launcher stay consistent."
-    release_commit_lock
     exit 0
   fi
 
   swap_symlink "$dest"
-  mv -f "$tag_tmp" "$INSTALLED_TAG_FILE"
   log "Symlink ${BIN_LINK} -> ${dest}"
   log "Update to ${LATEST_TAG} complete."
 
-  # Pruned while still holding the commit lock. Pruning snapshots the current
-  # target and then deletes; if another run swaps in between, the snapshot names
-  # a build that is no longer current and the live one can be deleted, leaving
-  # the launcher dangling. Inside the lock the target cannot move.
   prune_old_versions
-  release_commit_lock
 }
 
 do_check() {

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -422,7 +422,11 @@ verify_attestation() {
 # race between two runs choosing a name at the same instant.
 allocate_dest() {
   local base="$1"
-  if [[ ! -e "$base" ]]; then
+  # `set -o noclobber` makes this redirect an O_EXCL create: it succeeds only if
+  # it created the file. Testing `[[ -e ]]` first would not do — two overlapping
+  # runs can both find the base absent and then install over each other, which
+  # an ignored lock explicitly permits. Reserving it is the test.
+  if (set -o noclobber; : > "$base") 2>/dev/null; then
     printf '%s\n' "$base"
     return 0
   fi

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -407,6 +407,28 @@ verify_attestation() {
   fi
 }
 
+# An install path that is guaranteed not to exist yet.
+#
+# Installs are append-only: never write over a file that exists. --force, the
+# unpatched self-heal, and a same-version rebuild would otherwise install over
+# the current symlink target, and every preserve/restore/recover mechanism this
+# script ever needed existed to undo exactly that.
+#
+# The suffix comes from mktemp rather than the pid. Pids are unique only among
+# processes alive at the same moment, not over time: a suffixed build that
+# survives pruning can still be on disk when a later run is assigned the same
+# pid, and `install` would then overwrite it — reopening the very hole this
+# design closes. mktemp creates the file exclusively, which also settles the
+# race between two runs choosing a name at the same instant.
+allocate_dest() {
+  local base="$1"
+  if [[ ! -e "$base" ]]; then
+    printf '%s\n' "$base"
+    return 0
+  fi
+  mktemp "${base}.XXXXXX"
+}
+
 # Atomically point BIN_LINK at $1 (an absolute target path).
 swap_symlink() {
   local target="$1"
@@ -424,6 +446,12 @@ swap_symlink() {
 # target is matched by its literal basename, so a pid-suffixed append-only
 # install ("2.1.240.4242") is protected exactly like a bare one.
 prune_old_versions() {
+  # Only the lock holder prunes. A lock old enough to be ignored lets runs
+  # overlap by design, and an overlapping run may have installed its destination
+  # without having swapped the symlink yet, or be holding a rollback target that
+  # this run's symlink does not name. Deleting either would strand it. Skipping
+  # a cleanup pass costs nothing; the next run that does hold the lock prunes.
+  [[ "$LOCK_CREATED" == "1" ]] || return 0
   [[ "$KEEP_VERSIONS" =~ ^[0-9]+$ ]] || return 0
   (( KEEP_VERSIONS > 0 )) || return 0
   [[ -d "$VERSIONS_DIR" ]] || return 0
@@ -544,16 +572,9 @@ perform_update() {
 
   # --- Install --------------------------------------------------------------
   mkdir -p "$VERSIONS_DIR"
-  local dest="${VERSIONS_DIR}/${LATEST_VERSION}"
-  # Installs are append-only: never write over a file that exists. --force, the
-  # unpatched self-heal, and a same-version rebuild would otherwise install
-  # over the current symlink target, and every preserve/restore/recover
-  # mechanism this script ever needed existed to undo exactly that. A suffixed
-  # sibling makes the intermediate state impossible; pruning cleans it up like
-  # any other old build. The pid is unique among concurrent runs on one machine.
-  if [[ -e "$dest" ]]; then
-    dest="${dest}.$$"
-  fi
+  local dest
+  dest="$(allocate_dest "${VERSIONS_DIR}/${LATEST_VERSION}")" ||
+    fail "Failed to allocate an install path under ${VERSIONS_DIR}"
   if ! install -m 0755 "$asset_path" "$dest"; then
     fail "Failed to install binary to ${dest}"
   fi

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -54,9 +54,9 @@ API_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
 # Populated by cleanup trap.
 TMP_DIR=""
 
-# Set while a reinstall has moved the existing build aside; cleanup restores it.
-PRESERVED_PATH=""
-PRESERVED_DEST=""
+# 1 only when THIS run created LOCK_DIR. A run that proceeds past someone
+# else's aged lock must not remove that lock on exit.
+LOCK_CREATED=0
 
 # Set to 1 by the --force mode. When forcing, perform_update skips the
 # "already up to date" version gate (but still runs checksum, attestation and
@@ -74,20 +74,12 @@ fail() {
 }
 
 cleanup() {
-  # Set while a reinstall has the previous build moved aside. Restoring it here
-  # covers every exit that runs a trap; recover_preserved covers the ones that
-  # do not.
-  if [[ -n "$PRESERVED_PATH" && -e "$PRESERVED_PATH" ]]; then
-    if [[ -e "$PRESERVED_DEST" ]]; then
-      rm -f "$PRESERVED_PATH" 2>/dev/null || true
-    else
-      mv -f "$PRESERVED_PATH" "$PRESERVED_DEST" 2>/dev/null || true
-    fi
-  fi
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
     rm -rf "$TMP_DIR"
   fi
-  if [[ -d "$LOCK_DIR" ]]; then
+  # Only ever remove a lock this run created. Removing another run's lock is
+  # where every past lock defect came from.
+  if [[ "$LOCK_CREATED" == "1" && -d "$LOCK_DIR" ]]; then
     rm -rf "$LOCK_DIR" 2>/dev/null || true
   fi
 }
@@ -195,9 +187,9 @@ sha256_check() {
   fi
 }
 
-# Seconds a pid-less lock is treated as a run still starting up rather than as
-# a corpse to reclaim. Only needs to exceed the mkdir-to-write window.
-LOCK_STARTUP_GRACE=60
+# A lock older than this is assumed abandoned (SIGKILL, power loss, reboot) and
+# is IGNORED, never removed. Any real run finishes far inside an hour.
+LOCK_MAX_AGE_SECONDS=3600
 
 # Age of the lock directory in seconds, or empty when it cannot be determined.
 #
@@ -215,70 +207,32 @@ lock_age_seconds() {
   printf '%s\n' "$(( $(date +%s) - mtime ))"
 }
 
-# The lock records its owner pid. A run killed by SIGKILL, a power loss, or a
-# reboot leaves the directory behind with no EXIT trap to remove it; without a
-# liveness check every later run would treat that corpse as contention and exit
-# 0 forever, silently ending all updates.
+# The lock is an efficiency device, not a correctness one: installs are
+# append-only, so two concurrent updaters waste a download rather than break an
+# installation. That is why there is no claim protocol here — this run NEVER
+# deletes, moves, or takes over a lock it did not create (deleting another
+# process's lock is where every past lock defect came from). A young foreign
+# lock means someone else is on it, so skip the duplicate work; an aged or
+# unmeasurable one is assumed abandoned and simply ignored.
 acquire_lock() {
   mkdir -p "$STATE_DIR"
-  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    local owner
-    owner="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
-    if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
-      log "Another update is already in progress (pid ${owner}); exiting."
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCK_CREATED=1
+  else
+    local age
+    if age="$(lock_age_seconds)" && (( age < LOCK_MAX_AGE_SECONDS )); then
+      log "Another update is already in progress (lock is ${age}s old); exiting."
       exit 0
     fi
-    # No readable owner yet. That is either a run killed between mkdir and the
-    # write, or a run that is about to write it — and deleting the latter would
-    # let two installers proceed at once and then remove each other's lock.
-    # Concurrent SessionStart hooks make this reachable, since their throttle
-    # check is not synchronized either. Age is what separates the two.
-    if [[ ! -s "${LOCK_DIR}/pid" ]]; then
-      local age
-      if ! age="$(lock_age_seconds)"; then
-        # Unknown age. Reclaiming could let two installers run at once, which is
-        # worse than waiting; a genuinely abandoned lock is then cleared by hand.
-        log "Lock has no owner and its age cannot be determined; leaving it alone. Remove ${LOCK_DIR} manually if no update is running."
-        exit 0
-      fi
-      if (( age < LOCK_STARTUP_GRACE )); then
-        log "Another update is starting up (lock has no owner yet); exiting."
-        exit 0
-      fi
-    fi
-    log "Reclaiming stale lock (owner ${owner:-unknown} is no longer running)."
-    # Two runs can both see the same dead owner. `rm -rf` on the shared path
-    # would let the second run delete the lock the first had just re-acquired
-    # and both would install concurrently — so the claim must be one atomic
-    # step. Renaming to a per-pid name is that step: only one rename of the
-    # stale directory can succeed, and the loser exits instead of installing.
-    local claimed="${LOCK_DIR}.stale.$$"
-    if ! mv "$LOCK_DIR" "$claimed" 2>/dev/null; then
-      log "Lost the race to reclaim the stale lock; exiting."
-      exit 0
-    fi
-    # The rename can still land on a FRESH lock: another reclaimer may have
-    # finished swapping the stale directory for its own between our staleness
-    # check and the mv. Re-check the owner of what was actually grabbed; a
-    # live one gets its lock back and this run bows out.
-    local grabbed
-    grabbed="$(cat "${claimed}/pid" 2>/dev/null || true)"
-    if [[ "$grabbed" =~ ^[0-9]+$ ]] && kill -0 "$grabbed" 2>/dev/null; then
-      mv "$claimed" "$LOCK_DIR" 2>/dev/null || rm -rf "$claimed"
-      log "Lost the race to reclaim the stale lock; exiting."
-      exit 0
-    fi
-    rm -rf "$claimed"
-    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-      log "Lost the race to reclaim the stale lock; exiting."
-      exit 0
-    fi
+    log "Ignoring lock ${LOCK_DIR} (age ${age:-unknown}s, older than ${LOCK_MAX_AGE_SECONDS}s or unmeasurable); proceeding without holding it."
   fi
-  printf '%s\n' "$$" > "${LOCK_DIR}/pid"
   trap cleanup EXIT
 }
 
-# Installed version = basename of the symlink target. Does NOT launch the binary.
+# Installed version = leading X.Y.Z of the symlink target's basename. Installs
+# are append-only, so a reinstall of a present version lands on a suffixed
+# sibling (e.g. "2.1.240.4242") — the whole basename is not always a bare
+# version. Does NOT launch the binary.
 get_installed_version() {
   local target
   if [[ ! -L "$BIN_LINK" ]]; then
@@ -290,7 +244,7 @@ get_installed_version() {
     return
   fi
   target="$(readlink "$BIN_LINK")"
-  INSTALLED_VERSION="$(basename "$target")"
+  INSTALLED_VERSION="$(basename "$target" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
 }
 
 # True if the currently installed binary carries the Calico "(patched)"
@@ -466,7 +420,9 @@ swap_symlink() {
 # all of them, in which case it is retained on top of the newest KEEP_VERSIONS.
 # KEEP_VERSIONS=0 (or a non-numeric value) disables pruning entirely.
 # Entries are ordered by mtime (newest first) so hand-made names such as
-# "2.1.223.pre-something" are handled without a semver parse.
+# "2.1.223.pre-something" are handled without a semver parse. The current
+# target is matched by its literal basename, so a pid-suffixed append-only
+# install ("2.1.240.4242") is protected exactly like a bare one.
 prune_old_versions() {
   [[ "$KEEP_VERSIONS" =~ ^[0-9]+$ ]] || return 0
   (( KEEP_VERSIONS > 0 )) || return 0
@@ -514,32 +470,9 @@ rotate_log() {
   rm -f "$tmp" 2>/dev/null || true
 }
 
-# A reinstall moves the existing build aside before installing over it. If the
-# run is killed between those two points, EXIT traps do not run (SIGKILL, power
-# loss), and the launcher is left pointing at nothing while the working binary
-# sits under a .preserved.<pid> name. Put it back on the next run.
-recover_preserved() {
-  [[ -d "$VERSIONS_DIR" ]] || return 0
-  local preserved base
-  for preserved in "$VERSIONS_DIR"/*.preserved.*; do
-    [[ -e "$preserved" ]] || continue
-    base="${preserved%.preserved.*}"
-    # Restore unconditionally, even over a present $base. Every completed
-    # transaction removes its preserved copy (post-verify success deletes it,
-    # failure moves it back), so one still on disk means the previous run died
-    # mid-install — and a $base present alongside it is the replacement that
-    # was never post-verified. Preferring that $base would delete the only
-    # known-good build and keep an unverified one.
-    if mv -f "$preserved" "$base"; then
-      log "Recovered ${base} left behind by an interrupted reinstall."
-    fi
-  done
-}
-
 perform_update() {
   acquire_lock
   detect_platform
-  recover_preserved
 
   get_installed_version
   log "Installed version: ${INSTALLED_VERSION:-<unknown>} (${RELEASE_SUFFIX})"
@@ -596,9 +529,8 @@ perform_update() {
   verify_attestation "$asset_path"
 
   # --- Pre-install artifact check -------------------------------------------
-  # Run the downloaded file where it sits. Installing first would overwrite an
-  # existing same-version build (the --force and self-heal paths both do this),
-  # destroying the very file the post-install rollback would need to restore.
+  # Run the downloaded file where it sits. Cheap, and it keeps a bad artifact
+  # out of VERSIONS_DIR entirely instead of leaving it there for pruning.
   chmod +x "$asset_path" || fail "Failed to make ${ASSET} executable"
   if (( IS_MACOS )); then
     xattr -d com.apple.quarantine "$asset_path" 2>/dev/null || true
@@ -613,19 +545,14 @@ perform_update() {
   # --- Install --------------------------------------------------------------
   mkdir -p "$VERSIONS_DIR"
   local dest="${VERSIONS_DIR}/${LATEST_VERSION}"
-  # --force, the unpatched self-heal, and a rebuild all install over a
-  # destination that is also the current symlink target. The pre-install check
-  # cannot cover the case where an artifact passes from the temp directory and
-  # then fails from its installed location: the old binary would already be
-  # gone, and `old_target` would name the file the failed replacement now
-  # occupies, so rolling the symlink back would restore nothing. Move the
-  # existing build aside first; it is put back if post-verify fails.
-  local preserved=""
+  # Installs are append-only: never write over a file that exists. --force, the
+  # unpatched self-heal, and a same-version rebuild would otherwise install
+  # over the current symlink target, and every preserve/restore/recover
+  # mechanism this script ever needed existed to undo exactly that. A suffixed
+  # sibling makes the intermediate state impossible; pruning cleans it up like
+  # any other old build. The pid is unique among concurrent runs on one machine.
   if [[ -e "$dest" ]]; then
-    preserved="${dest}.preserved.$$"
-    PRESERVED_DEST="$dest"
-    mv -f "$dest" "$preserved" || fail "Failed to preserve the existing ${dest}"
-    PRESERVED_PATH="$preserved"
+    dest="${dest}.$$"
   fi
   if ! install -m 0755 "$asset_path" "$dest"; then
     fail "Failed to install binary to ${dest}"
@@ -647,19 +574,15 @@ perform_update() {
   version_output="$("$BIN_LINK" --version 2>&1 || true)"
   if version_output_matches "$version_output" "$LATEST_VERSION"; then
     log "Post-verify OK: ${version_output//$'\n'/ | }"
-    PRESERVED_PATH=""
-    [[ -n "$preserved" ]] && rm -f "$preserved"
     printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
       log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
     log "Update to ${LATEST_TAG} complete."
     prune_old_versions
   else
     log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"
-    if [[ -n "$preserved" ]]; then
-      mv -f "$preserved" "$dest"
-      PRESERVED_PATH=""
-      log "Restored the previous ${dest} that this install had replaced."
-    fi
+    # Nothing was overwritten, so rollback is just the symlink: the previous
+    # target was never touched. The failed install stays in VERSIONS_DIR and is
+    # pruned later like any other old build.
     if [[ -n "$old_target" ]]; then
       swap_symlink "$old_target"
       log "Rolled back symlink ${BIN_LINK} -> ${old_target}"

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -73,7 +73,7 @@ cleanup() {
     rm -rf "$TMP_DIR"
   fi
   if [[ -d "$LOCK_DIR" ]]; then
-    rmdir "$LOCK_DIR" 2>/dev/null || true
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
   fi
 }
 
@@ -128,6 +128,20 @@ detect_platform() {
   esac
 }
 
+# Leading X.Y.Z token of a `--version` line. Substring matching is not safe
+# here: "2.1.24" is a substring of "2.1.240", so a mislabeled release would pass
+# the very gate meant to catch it.
+version_token() {
+  printf '%s' "$1" | sed -n '1s/^[^0-9]*\([0-9][0-9.]*[0-9]\).*/\1/p'
+}
+
+# True when `--version` output reports exactly $2 and carries the patched marker.
+version_output_matches() {
+  local output="$1" expected="$2"
+  [[ "$output" == *"(patched)"* ]] || return 1
+  [[ "$(version_token "$output")" == "$expected" ]]
+}
+
 # Verify "<sha256>  <file>" lines in $1 against files in the current directory.
 sha256_check() {
   local list="$1"
@@ -140,12 +154,27 @@ sha256_check() {
   fi
 }
 
+# The lock records its owner pid. A run killed by SIGKILL, a power loss, or a
+# reboot leaves the directory behind with no EXIT trap to remove it; without a
+# liveness check every later run would treat that corpse as contention and exit
+# 0 forever, silently ending all updates.
 acquire_lock() {
   mkdir -p "$STATE_DIR"
   if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    log "Another update is already in progress (lock held); exiting."
-    exit 0
+    local owner
+    owner="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
+    if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
+      log "Another update is already in progress (pid ${owner}); exiting."
+      exit 0
+    fi
+    log "Reclaiming stale lock (owner ${owner:-unknown} is no longer running)."
+    rm -rf "$LOCK_DIR"
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+      log "Lost the race to reclaim the stale lock; exiting."
+      exit 0
+    fi
   fi
+  printf '%s\n' "$$" > "${LOCK_DIR}/pid"
   trap cleanup EXIT
 }
 
@@ -437,6 +466,21 @@ perform_update() {
   verify_checksum "$TMP_DIR"
   verify_attestation "$asset_path"
 
+  # --- Pre-install artifact check -------------------------------------------
+  # Run the downloaded file where it sits. Installing first would overwrite an
+  # existing same-version build (the --force and self-heal paths both do this),
+  # destroying the very file the post-install rollback would need to restore.
+  chmod +x "$asset_path" || fail "Failed to make ${ASSET} executable"
+  if (( IS_MACOS )); then
+    xattr -d com.apple.quarantine "$asset_path" 2>/dev/null || true
+  fi
+  local artifact_version
+  artifact_version="$("$asset_path" --version 2>&1 || true)"
+  if ! version_output_matches "$artifact_version" "$LATEST_VERSION"; then
+    fail "Downloaded ${ASSET} reports '${artifact_version//$'\n'/ | }', expected ${LATEST_VERSION} and (patched); refusing to install"
+  fi
+  log "Artifact verified before install: ${artifact_version//$'\n'/ | }"
+
   # --- Install --------------------------------------------------------------
   mkdir -p "$VERSIONS_DIR"
   local dest="${VERSIONS_DIR}/${LATEST_VERSION}"
@@ -456,7 +500,7 @@ perform_update() {
   # --- Post-verify with rollback --------------------------------------------
   local version_output
   version_output="$("$BIN_LINK" --version 2>&1 || true)"
-  if [[ "$version_output" == *"$LATEST_VERSION"* && "$version_output" == *"(patched)"* ]]; then
+  if version_output_matches "$version_output" "$LATEST_VERSION"; then
     log "Post-verify OK: ${version_output//$'\n'/ | }"
     log "Update to ${LATEST_VERSION} complete."
     prune_old_versions
@@ -466,7 +510,10 @@ perform_update() {
       swap_symlink "$old_target"
       log "Rolled back symlink ${BIN_LINK} -> ${old_target}"
     else
-      log "WARNING: no previous symlink target recorded; cannot roll back."
+      # First install: there is nothing to roll back to, but leaving the link
+      # pointing at a binary that just failed its check is worse than no link.
+      rm -f "$BIN_LINK"
+      log "Removed ${BIN_LINK}; it pointed at a binary that failed post-verify and there was no previous target."
     fi
     exit 1
   fi

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -44,6 +44,7 @@ BIN_LINK="${CALICO_BIN_LINK:-${HOME}/.local/bin/calico-claude}"
 STATE_DIR="${CALICO_STATE_DIR:-${HOME}/.claude/calico}"
 LOCK_DIR="${STATE_DIR}/.lock"
 LAST_CHECK_FILE="${STATE_DIR}/last-check"
+INSTALLED_TAG_FILE="${STATE_DIR}/installed-tag"
 LOG_FILE="${STATE_DIR}/update.log"
 THROTTLE_SECONDS="${CALICO_THROTTLE_SECONDS:-3600}"
 KEEP_VERSIONS="${CALICO_KEEP_VERSIONS:-3}"
@@ -142,6 +143,32 @@ version_output_matches() {
   [[ "$(version_token "$output")" == "$expected" ]]
 }
 
+# Rebuild rank of a release tag. A corrected build is republished under a numeric
+# suffix (v2.1.240-macos-arm64-2); the base tag ranks 1. Platform suffixes such
+# as `x64` or `arm64` are not bare integers, so a base tag never misreads as a
+# rebuild.
+tag_rebuild_rank() {
+  local suffix="${1##*-}"
+  if [[ "$suffix" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$suffix"
+  else
+    printf '1\n'
+  fi
+}
+
+# Rank of the tag this script last installed. Absent (first run, or an install
+# predating this file) means the base build, so a base-tag release still reads
+# as "nothing newer" and nothing is reinstalled needlessly.
+installed_rebuild_rank() {
+  local recorded
+  recorded="$(cat "$INSTALLED_TAG_FILE" 2>/dev/null || true)"
+  if [[ -n "$recorded" ]]; then
+    tag_rebuild_rank "$recorded"
+  else
+    printf '1\n'
+  fi
+}
+
 # Verify "<sha256>  <file>" lines in $1 against files in the current directory.
 sha256_check() {
   local list="$1"
@@ -151,6 +178,22 @@ sha256_check() {
     sha256sum -c "$list"
   else
     fail "Missing required command: shasum or sha256sum"
+  fi
+}
+
+# Seconds a pid-less lock is treated as a run still starting up rather than as
+# a corpse to reclaim. Only needs to exceed the mkdir-to-write window.
+LOCK_STARTUP_GRACE=60
+
+# Age of the lock directory in seconds. stat is not portable, so try both forms.
+lock_age_seconds() {
+  local mtime
+  mtime="$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo 0)"
+  [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+  if (( mtime == 0 )); then
+    printf '%s\n' "$((LOCK_STARTUP_GRACE + 1))"
+  else
+    printf '%s\n' "$(( $(date +%s) - mtime ))"
   fi
 }
 
@@ -165,6 +208,15 @@ acquire_lock() {
     owner="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
     if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
       log "Another update is already in progress (pid ${owner}); exiting."
+      exit 0
+    fi
+    # No readable owner yet. That is either a run killed between mkdir and the
+    # write, or a run that is about to write it — and deleting the latter would
+    # let two installers proceed at once and then remove each other's lock.
+    # Concurrent SessionStart hooks make this reachable, since their throttle
+    # check is not synchronized either. Age is what separates the two.
+    if [[ ! -s "${LOCK_DIR}/pid" ]] && (( $(lock_age_seconds) < LOCK_STARTUP_GRACE )); then
+      log "Another update is starting up (lock has no owner yet); exiting."
       exit 0
     fi
     log "Reclaiming stale lock (owner ${owner:-unknown} is no longer running)."
@@ -432,6 +484,12 @@ perform_update() {
     rel="$(semver_relation "$LATEST_VERSION" "$INSTALLED_VERSION")"
     if [[ "$rel" == "newer" ]]; then
       : # proceed to install
+    elif [[ "$rel" == "same" ]] &&
+      (( $(tag_rebuild_rank "$LATEST_TAG") > $(installed_rebuild_rank) )); then
+      # Same version, but republished as a corrected build. Without this the
+      # unattended path would report "up to date" and no user would ever receive
+      # a rebuild until upstream happened to ship a new version.
+      log "Installed ${INSTALLED_VERSION} matches latest, but ${LATEST_TAG} is a newer rebuild; reinstalling."
     elif [[ "$rel" == "same" ]] && ! installed_is_patched; then
       # Same version but the official autoupdater (or a manual `claude
       # install`) overwrote the patched binary — self-heal by reinstalling
@@ -502,7 +560,9 @@ perform_update() {
   version_output="$("$BIN_LINK" --version 2>&1 || true)"
   if version_output_matches "$version_output" "$LATEST_VERSION"; then
     log "Post-verify OK: ${version_output//$'\n'/ | }"
-    log "Update to ${LATEST_VERSION} complete."
+    printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
+      log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
+    log "Update to ${LATEST_TAG} complete."
     prune_old_versions
   else
     log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -611,12 +611,25 @@ perform_update() {
   # on top of a newer one, after which a later rebuild reads as already current
   # and becomes unreachable even with --force. Written before the swap: a
   # failure here is caught while the launcher is still untouched.
+  local previous_tag
+  previous_tag="$(cat "$INSTALLED_TAG_FILE" 2>/dev/null || true)"
   if ! printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null; then
     log "Cannot write ${INSTALLED_TAG_FILE}; leaving ${BIN_LINK} unchanged so the record and the launcher stay consistent."
     exit 0
   fi
 
-  swap_symlink "$dest"
+  # The swap can still fail — an unwritable launcher directory, or a leftover
+  # .calico-tmp path defeating `ln`. The record already names the new build at
+  # this point, and leaving it there would make a later same-version rebuild
+  # compare equal and exit as up to date. Put the old record back before failing.
+  if ! swap_symlink "$dest"; then
+    if [[ -n "$previous_tag" ]]; then
+      printf '%s\n' "$previous_tag" > "$INSTALLED_TAG_FILE" 2>/dev/null || true
+    else
+      rm -f "$INSTALLED_TAG_FILE" 2>/dev/null || true
+    fi
+    fail "Failed to point ${BIN_LINK} at ${dest}; the release record was restored."
+  fi
   log "Symlink ${BIN_LINK} -> ${dest}"
   log "Update to ${LATEST_TAG} complete."
 

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -542,7 +542,22 @@ perform_update() {
   # --- Install --------------------------------------------------------------
   mkdir -p "$VERSIONS_DIR"
   local dest="${VERSIONS_DIR}/${LATEST_VERSION}"
-  install -m 0755 "$asset_path" "$dest" || fail "Failed to install binary to ${dest}"
+  # --force, the unpatched self-heal, and a rebuild all install over a
+  # destination that is also the current symlink target. The pre-install check
+  # cannot cover the case where an artifact passes from the temp directory and
+  # then fails from its installed location: the old binary would already be
+  # gone, and `old_target` would name the file the failed replacement now
+  # occupies, so rolling the symlink back would restore nothing. Move the
+  # existing build aside first; it is put back if post-verify fails.
+  local preserved=""
+  if [[ -e "$dest" ]]; then
+    preserved="${dest}.preserved.$$"
+    mv -f "$dest" "$preserved" || fail "Failed to preserve the existing ${dest}"
+  fi
+  if ! install -m 0755 "$asset_path" "$dest"; then
+    [[ -n "$preserved" ]] && mv -f "$preserved" "$dest"
+    fail "Failed to install binary to ${dest}"
+  fi
   if (( IS_MACOS )); then
     xattr -d com.apple.quarantine "$dest" 2>/dev/null || true
   fi
@@ -560,12 +575,17 @@ perform_update() {
   version_output="$("$BIN_LINK" --version 2>&1 || true)"
   if version_output_matches "$version_output" "$LATEST_VERSION"; then
     log "Post-verify OK: ${version_output//$'\n'/ | }"
+    [[ -n "$preserved" ]] && rm -f "$preserved"
     printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
       log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
     log "Update to ${LATEST_TAG} complete."
     prune_old_versions
   else
     log "ERROR: Post-verify FAILED. Expected version ${LATEST_VERSION} and (patched). Got: ${version_output//$'\n'/ | }"
+    if [[ -n "$preserved" ]]; then
+      mv -f "$preserved" "$dest"
+      log "Restored the previous ${dest} that this install had replaced."
+    fi
     if [[ -n "$old_target" ]]; then
       swap_symlink "$old_target"
       log "Rolled back symlink ${BIN_LINK} -> ${old_target}"
@@ -590,8 +610,20 @@ do_check() {
     if [[ -n "$INSTALLED_VERSION" ]]; then
       case "$(semver_relation "$LATEST_VERSION" "$INSTALLED_VERSION")" in
         newer) printf 'Status:         update available\n' ;;
-        same)  printf 'Status:         up to date\n' ;;
         older) printf 'Status:         installed is newer than latest release\n' ;;
+        same)
+          # Same version is not the same as nothing to do: --run also reinstalls
+          # for a newer rebuild of this version, or when the official updater
+          # has replaced the patched binary. Reporting "up to date" in either
+          # case would tell the user the opposite of what --run is about to do.
+          if (( $(tag_rebuild_rank "$LATEST_TAG") > $(installed_rebuild_rank) )); then
+            printf 'Status:         rebuild available (%s)\n' "$LATEST_TAG"
+          elif ! installed_is_patched; then
+            printf 'Status:         reinstall needed (installed binary is not patched)\n'
+          else
+            printf 'Status:         up to date\n'
+          fi
+          ;;
       esac
     fi
   else

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -74,6 +74,7 @@ fail() {
 }
 
 cleanup() {
+  release_commit_lock
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
     rm -rf "$TMP_DIR"
   fi
@@ -190,6 +191,17 @@ sha256_check() {
 # A lock older than this is assumed abandoned (SIGKILL, power loss, reboot) and
 # is IGNORED, never removed. Any real run finishes far inside an hour.
 LOCK_MAX_AGE_SECONDS=3600
+
+# The commit lock covers only pointing the launcher: reading the current target
+# and tag, deciding, then swapping. Downloading and installing need no exclusion
+# because they are append-only. Held for two syscalls, so a stale one means a
+# process died inside that window — rare enough that taking it over on expiry is
+# safe, since the worst case of a lost race there is two valid builds competing
+# for the link and the later one winning.
+COMMIT_LOCK_DIR="${STATE_DIR}/.commit-lock"
+COMMIT_LOCK_MAX_AGE_SECONDS=60
+COMMIT_LOCK_WAIT_SECONDS="${CALICO_COMMIT_WAIT:-30}"
+COMMIT_LOCK_HELD=0
 
 # Seconds a freshly installed build is treated as possibly in flight.
 PRUNE_MIN_AGE_SECONDS=300
@@ -437,6 +449,51 @@ allocate_dest() {
   mktemp "${base}.XXXXXX"
 }
 
+# Serialize the launcher update. Returns 1 when it could not be taken, which is
+# not an error: the build is installed and a later run will point at it.
+acquire_commit_lock() {
+  local deadline=$(( $(date +%s) + COMMIT_LOCK_WAIT_SECONDS ))
+  while ! mkdir "$COMMIT_LOCK_DIR" 2>/dev/null; do
+    local age
+    if age="$(path_age_seconds "$COMMIT_LOCK_DIR")" &&
+      (( age > COMMIT_LOCK_MAX_AGE_SECONDS )); then
+      log "Commit lock is ${age}s old; a run died holding it. Taking it over."
+      rm -rf "$COMMIT_LOCK_DIR"
+      continue
+    fi
+    if (( $(date +%s) >= deadline )); then
+      return 1
+    fi
+    sleep 1
+  done
+  COMMIT_LOCK_HELD=1
+  return 0
+}
+
+release_commit_lock() {
+  if [[ "$COMMIT_LOCK_HELD" == "1" ]]; then
+    rm -rf "$COMMIT_LOCK_DIR" 2>/dev/null || true
+    COMMIT_LOCK_HELD=0
+  fi
+}
+
+# Rank-aware comparison of two release tags for the same or different versions.
+# Echoes "newer", "same" or "older" describing $1 relative to $2.
+release_relation() { # <version-a> <tag-a> <version-b> <tag-b>
+  local rel
+  rel="$(semver_relation "$1" "$3")"
+  if [[ "$rel" != "same" ]]; then
+    printf '%s\n' "$rel"
+    return 0
+  fi
+  local rank_a rank_b
+  rank_a="$(tag_rebuild_rank "$2")"
+  rank_b="$(tag_rebuild_rank "$4")"
+  if (( rank_a > rank_b )); then printf 'newer\n'
+  elif (( rank_a < rank_b )); then printf 'older\n'
+  else printf 'same\n'; fi
+}
+
 # Atomically point BIN_LINK at $1 (an absolute target path).
 swap_symlink() {
   local target="$1"
@@ -616,28 +673,37 @@ perform_update() {
   log "Verified before swap: ${version_output//$'\n'/ | }"
 
   # --- Point the launcher at it ---------------------------------------------
-  # Overlapping runs (possible once an aged lock is ignored) can be looking at
-  # different releases: one queried the API before a rebuild was published and
-  # the other after. If the newer run swaps first, an unconditional swap here
-  # would downgrade the launcher, and the tag record written below would then
-  # describe a build it no longer points at — every later run would read that
-  # pairing and treat the older build as current.
+  # Reading the current target, deciding, and swapping is a read-modify-write on
+  # state other runs share. The check and the swap were previously two unguarded
+  # steps, so a newer run could land between them and be overwritten. Everything
+  # up to here needed no exclusion; only this does.
   mkdir -p "$(dirname "$BIN_LINK")"
+  if ! acquire_commit_lock; then
+    log "Could not take the commit lock within ${COMMIT_LOCK_WAIT_SECONDS}s; leaving ${BIN_LINK} unchanged. ${dest} is installed and a later run will point at it."
+    exit 0
+  fi
+
+  # Read inside the lock, so the tag record and the symlink are always read and
+  # written as one pair — comparing versions alone would let a stale base-tag
+  # run replace a newer same-version rebuild.
   if [[ -L "$BIN_LINK" ]]; then
-    local live_version
+    local live_version live_tag
     live_version="$(basename "$(readlink "$BIN_LINK")")"
     live_version="$(printf '%s' "$live_version" | sed -n 's/^\([0-9][0-9.]*[0-9]\).*/\1/p')"
+    live_tag="$(cat "$INSTALLED_TAG_FILE" 2>/dev/null || true)"
     if [[ -n "$live_version" ]] &&
-      [[ "$(semver_relation "$live_version" "$LATEST_VERSION")" == "newer" ]]; then
-      log "${BIN_LINK} already points at ${live_version}, newer than ${LATEST_VERSION}; leaving it alone. The build stays in ${VERSIONS_DIR}."
+      [[ "$(release_relation "$live_version" "${live_tag:-v}" "$LATEST_VERSION" "$LATEST_TAG")" == "newer" ]]; then
+      log "${BIN_LINK} already points at ${live_tag:-$live_version}, newer than ${LATEST_TAG}; leaving it alone. The build stays in ${VERSIONS_DIR}."
+      release_commit_lock
       exit 0
     fi
   fi
-  swap_symlink "$dest"
-  log "Symlink ${BIN_LINK} -> ${dest}"
 
+  swap_symlink "$dest"
   printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
     log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."
+  release_commit_lock
+  log "Symlink ${BIN_LINK} -> ${dest}"
   log "Update to ${LATEST_TAG} complete."
   prune_old_versions
 }

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -709,6 +709,17 @@ perform_update() {
     fi
   fi
 
+  # The age-based in-flight protection assumes a run reaches this point within
+  # PRUNE_MIN_AGE_SECONDS of installing. A suspended laptop breaks that: this run
+  # can sit here for hours while a later one, seeing an aged run lock and an aged
+  # destination, prunes it. Re-checking inside the commit lock costs one stat and
+  # is the only point where the answer cannot change underneath us.
+  if [[ ! -e "$dest" ]]; then
+    log "${dest} was removed while this run was paused; leaving ${BIN_LINK} unchanged. A later run will reinstall."
+    release_commit_lock
+    exit 0
+  fi
+
   swap_symlink "$dest"
   printf '%s\n' "$LATEST_TAG" > "$INSTALLED_TAG_FILE" 2>/dev/null ||
     log "WARNING: could not record ${INSTALLED_TAG_FILE}; rebuild tracking is degraded."

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -454,14 +454,24 @@ allocate_dest() {
 acquire_commit_lock() {
   local deadline=$(( $(date +%s) + COMMIT_LOCK_WAIT_SECONDS ))
   while ! mkdir "$COMMIT_LOCK_DIR" 2>/dev/null; do
-    local age
-    if age="$(path_age_seconds "$COMMIT_LOCK_DIR")" &&
-      (( age > COMMIT_LOCK_MAX_AGE_SECONDS )); then
-      log "Commit lock is ${age}s old; a run died holding it. Taking it over."
-      rm -rf "$COMMIT_LOCK_DIR"
-      continue
-    fi
     if (( $(date +%s) >= deadline )); then
+      local age
+      age="$(path_age_seconds "$COMMIT_LOCK_DIR" || true)"
+      if [[ "$age" =~ ^[0-9]+$ ]] && (( age > COMMIT_LOCK_MAX_AGE_SECONDS )); then
+        # Deliberately NOT reclaimed. Every delete-and-reacquire protocol tried
+        # here had the same hole: two runs both see the lock expired, one
+        # removes and recreates it, the second removes that new lock and takes
+        # it, and both enter the section the lock exists to serialize. There is
+        # no way to fix that without an atomic primitive this script does not
+        # have — so it is not attempted.
+        #
+        # Unlike the run lock, an abandoned commit lock cannot be left behind by
+        # an ordinary kill: it is held across two syscalls. If one is somehow
+        # stranded it needs a human, and stopping is the safe direction — the
+        # build is installed and nothing is corrupted, only the launcher stays
+        # where it was.
+        log "Commit lock ${COMMIT_LOCK_DIR} has been held for ${age}s. It is not reclaimed automatically; remove it by hand if no update is running."
+      fi
       return 1
     fi
     sleep 1

--- a/examples/local-auto-update/update.sh
+++ b/examples/local-auto-update/update.sh
@@ -616,7 +616,23 @@ perform_update() {
   log "Verified before swap: ${version_output//$'\n'/ | }"
 
   # --- Point the launcher at it ---------------------------------------------
+  # Overlapping runs (possible once an aged lock is ignored) can be looking at
+  # different releases: one queried the API before a rebuild was published and
+  # the other after. If the newer run swaps first, an unconditional swap here
+  # would downgrade the launcher, and the tag record written below would then
+  # describe a build it no longer points at — every later run would read that
+  # pairing and treat the older build as current.
   mkdir -p "$(dirname "$BIN_LINK")"
+  if [[ -L "$BIN_LINK" ]]; then
+    local live_version
+    live_version="$(basename "$(readlink "$BIN_LINK")")"
+    live_version="$(printf '%s' "$live_version" | sed -n 's/^\([0-9][0-9.]*[0-9]\).*/\1/p')"
+    if [[ -n "$live_version" ]] &&
+      [[ "$(semver_relation "$live_version" "$LATEST_VERSION")" == "newer" ]]; then
+      log "${BIN_LINK} already points at ${live_version}, newer than ${LATEST_VERSION}; leaving it alone. The build stays in ${VERSIONS_DIR}."
+      exit 0
+    fi
+  fi
   swap_symlink "$dest"
   log "Symlink ${BIN_LINK} -> ${dest}"
 


### PR DESCRIPTION
Stacked on #8. Review that one first; this PR's diff is `f06bef7` + `a7d30f1`.

Ordered after the rate-limit PR on purpose: the rewritten README documents that module, so merging the docs first would describe a feature that does not exist yet.

## examples/local-auto-update/

Generalizes a personal, macOS-arm64-only updater into a portable example. It manages a separately named binary (default `calico-claude`) so the official `claude` symlink stays under Anthropic's updater and the two never contend.

Wired as a SessionStart hook, `--hook` reads a throttle stamp, spawns a detached `--run` at most hourly, and returns immediately; it never blocks session startup. `--run` resolves the highest matching release and verifies checksum plus `gh` attestation as fail-hard gates **before** anything reaches the versions directory. Install is followed by an atomic symlink swap and a post-install check requiring both the expected version string and `(patched)`; failure restores the previous symlink target and exits non-zero. A same-version binary that no longer reports `(patched)` is treated as the official updater having overwritten the patched build, and is reinstalled.

Generalized from the original: platform detection for all five release platforms, `shasum`/`sha256sum` split, `xattr` guarded by macOS, `CALICO_*` overrides for every path and policy knob, retention of the newest N builds (~300 MB each, current target always kept so a rollback survives), log rotation, and `curl -fsSL` so progress meters stop flooding an unattended log.

**Two defects carried by the original are fixed:**

- The release tag regex accepted only `^v(X.Y.Z)-<platform>$`, so a rebuilt release published under a `-<N>` suffix could never be found. Rebuild suffixes are now accepted and ranked above the base tag, matching `install-patched-claude.sh`.
- The optional auth header was built as its own array and expanded as `"${auth_header[@]}"`. Under bash 3.2 (stock on macOS) with `set -u` that is an unbound variable whenever no token is set, aborting every mode before its first request. The token is now appended to a single always-non-empty `curl_args` array.

`test-update.sh` is an offline self-check (33 assertions, no network, no writes outside a `mktemp` sandbox): platform detection, the checksum gate (tampered asset, empty `checksums.txt`, no entry for our asset, and a decoy whose name differs from the asset only where the asset has a dot), pruning including the rollback shape, hook throttling and corrupt state, lock contention, log rotation, and release selection against a stubbed `curl`.

Two cases execute under `/bin/bash` specifically rather than PATH bash, because a Homebrew bash 5.x hides the 3.2 unbound-variable class of bug entirely — it hid the one above. Each new assertion was mutation-tested: removing the draft filter fails 3 cases, reverting the regex escaping fails the decoy case, restoring the old prune semantics fails the retention case.

## README.md

Rewritten to lead with tables (1 table before, 16 after).

The module inventory now lists all 18 patch modules by their real ids and descriptions from `PATCH_MODULES`, split into always-active display patches and dormant opt-in adapters with their triggers. `gateway-fast-mode`, `create-diff-colors` and `word-diff-line-bg` were previously undocumented entirely.

The committed-status-line-usage rules become four tables — trust conditions, all-zero sentinel definition, wrapper classification, displayed state — instead of four dense paragraphs. The release pipeline is a mermaid flowchart with its failure edges, backed by a table of what each gate guarantees. Install moves ahead of the module detail so the commands are not two hundred lines down, and the side-by-side install is promoted from a FAQ entry to a section.

No technical content was dropped; every symbol, env var and figure was grep-verified present after the rewrite.

## chore

`.DS_Store` and `.claude/worktrees/` added to `.gitignore`. The narrower worktree path is used instead of `.claude/` so project-level settings there stay committable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeGTwEV8Xdgj9ngxHPjptK
