### PR TITLE
feat(patch): disable near-limit usage wrap-up prompt injection

### DIFF
--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1600,19 +1600,24 @@ function patchDisableUsageWrapUpHints(content) {
     ['"tengu_vellum_anchor"', '"calico_vellum_gone_"'],
   ];
 
-  let candidates = 0;
-  let patched = 0;
-  let output = content;
-  for (const [from, to] of gateRenames) {
-    const count = output.split(from).length - 1;
-    candidates += count;
-    if (count > 0) {
-      output = output.split(from).join(to);
-      patched += count;
-    }
+  const perGateCounts = gateRenames.map(([from]) => content.split(from).length - 1);
+  const candidates = perGateCounts.reduce((sum, count) => sum + count, 0);
+  const presentGates = perGateCounts.filter((count) => count > 0).length;
+
+  if (presentGates > 0 && presentGates < gateRenames.length) {
+    // Partial match: upstream changed or removed exactly one gate literal
+    // while keeping the other. Renaming only the survivor would ship a bundle
+    // with the other wrap-up injection path still active under its new gate
+    // name, so patch nothing and report zero patched to fail --assert-all
+    // loudly instead.
+    return {
+      content,
+      candidates,
+      patched: 0,
+    };
   }
 
-  if (patched === 0) {
+  if (presentGates === 0) {
     // Pre-feature bundles (< 2.1.238) carry neither gate; that is an expected
     // no-op, not a matcher failure, so report it as skipped and keep
     // --assert-all green for older rebuilds. A 2.1.238+ bundle (or one with
@@ -1627,20 +1632,30 @@ function patchDisableUsageWrapUpHints(content) {
         major < 2 || (major === 2 && (minor < 1 || (minor === 1 && micro < 238)));
       if (preFeature) {
         return {
-          content: output,
+          content,
           candidates,
-          patched,
+          patched: 0,
           skipped: true,
           reason: `pre-2.1.238 bundle (${major}.${minor}.${micro}) has no usage wrap-up gates`,
         };
       }
     }
+    return {
+      content,
+      candidates,
+      patched: 0,
+    };
+  }
+
+  let output = content;
+  for (const [from, to] of gateRenames) {
+    output = output.split(from).join(to);
   }
 
   return {
     content: output,
     candidates,
-    patched,
+    patched: candidates,
   };
 }
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1612,6 +1612,31 @@ function patchDisableUsageWrapUpHints(content) {
     }
   }
 
+  if (patched === 0) {
+    // Pre-feature bundles (< 2.1.238) carry neither gate; that is an expected
+    // no-op, not a matcher failure, so report it as skipped and keep
+    // --assert-all green for older rebuilds. A 2.1.238+ bundle (or one with
+    // unparseable VERSION metadata) without the gates stays a hard failure:
+    // that is how --assert-all catches upstream renaming the gates away.
+    const versionMatch = content.match(
+      /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
+    );
+    if (versionMatch) {
+      const [major, minor, micro] = versionMatch.slice(1).map(Number);
+      const preFeature =
+        major < 2 || (major === 2 && (minor < 1 || (minor === 1 && micro < 238)));
+      if (preFeature) {
+        return {
+          content: output,
+          candidates,
+          patched,
+          skipped: true,
+          reason: `pre-2.1.238 bundle (${major}.${minor}.${micro}) has no usage wrap-up gates`,
+        };
+      }
+    }
+  }
+
   return {
     content: output,
     candidates,
@@ -3349,8 +3374,11 @@ function main() {
     patchResults.set(module.id, {
       candidates: result.candidates,
       patched: result.patched,
-      skipped: false,
-      reason: null,
+      // A module may report an expected no-op (e.g. the target feature does
+      // not exist in this bundle version) as skipped so --assert-all treats
+      // it like a disabled module instead of a matcher failure.
+      skipped: result.skipped === true,
+      reason: result.skipped === true ? result.reason ?? "not applicable" : null,
     });
   }
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1584,6 +1584,41 @@ function patchSubagentPromptVisibility(content, ctx = {}) {
   };
 }
 
+function patchDisableUsageWrapUpHints(content) {
+  // 2.1.238+ injects meta wrap-up prompts near the usage limit ("Checkpoint
+  // now: finish the current step, then list up to 3 short bullets ...") plus a
+  // matching TUI notice. Both injection paths are gated on statsig flags read
+  // by name with disabled defaults ("off" / !1), so renaming the gate name
+  // literals makes every lookup miss and fall back to disabled. Replacements
+  // are the same length as the originals, so no preserveLength branch is
+  // needed. Anchoring on the gate-name string literals (not minified locals)
+  // keeps this stable across bundle rebuilds.
+  const gateRenames = [
+    // grace-window wrap-up injection ("off" | "basic" | "next-steps")
+    ['"tengu_lantern_wick_mode"', '"calico_lantern_wick_off"'],
+    // 95% near-limit "checkpoint now" injection + notice (boolean)
+    ['"tengu_vellum_anchor"', '"calico_vellum_gone_"'],
+  ];
+
+  let candidates = 0;
+  let patched = 0;
+  let output = content;
+  for (const [from, to] of gateRenames) {
+    const count = output.split(from).length - 1;
+    candidates += count;
+    if (count > 0) {
+      output = output.split(from).join(to);
+      patched += count;
+    }
+  }
+
+  return {
+    content: output,
+    candidates,
+    patched,
+  };
+}
+
 function patchDisableSpinnerTips(content, ctx = {}) {
   const disabledGuardPattern = /if\([A-Za-z_$][\w$]*\(\)\.spinnerTipsEnabled===!1\)return;/g;
   const enabledExpressionPattern = /[A-Za-z_$][\w$]*\.spinnerTipsEnabled!==!1/g;
@@ -3203,6 +3238,11 @@ const PATCH_MODULES = [
     apply: patchDisableSpinnerTips,
   },
   {
+    id: "disable-usage-wrapup",
+    description: "Disable near-limit / grace-window wrap-up prompt injection",
+    apply: patchDisableUsageWrapUpHints,
+  },
+  {
     id: "version-output",
     description: "Append (patched) to plain --version output",
     apply: patchVersionOutput,
@@ -3371,6 +3411,7 @@ function main() {
 }
 
 module.exports = {
+  patchDisableUsageWrapUpHints,
   patchGatewayFastMode,
   patchActiveTurnPromptIdentity,
   patchCompactRequestSource,

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1187,13 +1187,33 @@ const CHECKS: Check[] = [
       "usage-limit wrap-up statsig gate names renamed to dead calico gates",
     run: (content: string): string | null => {
       // Bundles older than the feature carry neither the original gates nor
-      // the renames; that is a pass (nothing to neutralize). If upstream
-      // reintroduces or renames the gates, --assert-all on the patch module
-      // is the guard that catches zero candidates.
+      // the renames; that is a pass (nothing to neutralize). 2.1.238+ bundles
+      // must carry BOTH renamed gates, so a bundle where upstream changed or
+      // removed one gate literal while the patcher renamed only the survivor
+      // cannot pass as "nothing to neutralize" with an injection path left
+      // active under a new gate name.
       const problems: string[] = [];
       for (const gate of ["tengu_lantern_wick_mode", "tengu_vellum_anchor"]) {
         if (content.includes(`"${gate}"`)) {
           problems.push(`found residual usage wrap-up gate "${gate}"`);
+        }
+      }
+      const versionMatch = content.match(
+        /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
+      );
+      if (versionMatch) {
+        const [major, minor, micro] = versionMatch.slice(1).map(Number);
+        const featureEra =
+          major > 2 ||
+          (major === 2 && (minor > 1 || (minor === 1 && micro >= 238)));
+        if (featureEra) {
+          for (const renamed of ["calico_lantern_wick_off", "calico_vellum_gone_"]) {
+            if (!content.includes(`"${renamed}"`)) {
+              problems.push(
+                `expected renamed usage wrap-up gate "${renamed}" in a 2.1.238+ bundle`
+              );
+            }
+          }
         }
       }
       return problems.length > 0 ? problems.join("; ") : null;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1180,8 +1180,9 @@ const CHECKS: Check[] = [
   {
     id: "disable-usage-wrapup",
     kind: "custom",
-    // When this module is disabled, the renamed calico gate must not exist.
-    disabledMarker: '"calico_lantern_wick_off"',
+    // When this module is disabled, neither renamed calico gate may exist —
+    // matching either one catches partially patched or transitional bundles.
+    disabledMarker: /"calico_lantern_wick_off"|"calico_vellum_gone_"/,
     describe:
       "usage-limit wrap-up statsig gate names renamed to dead calico gates",
     run: (content: string): string | null => {

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1178,6 +1178,27 @@ const CHECKS: Check[] = [
     describe: "original spinner-tips disabled guard must be gone",
   },
   {
+    id: "disable-usage-wrapup",
+    kind: "custom",
+    // When this module is disabled, the renamed calico gate must not exist.
+    disabledMarker: '"calico_lantern_wick_off"',
+    describe:
+      "usage-limit wrap-up statsig gate names renamed to dead calico gates",
+    run: (content: string): string | null => {
+      // Bundles older than the feature carry neither the original gates nor
+      // the renames; that is a pass (nothing to neutralize). If upstream
+      // reintroduces or renames the gates, --assert-all on the patch module
+      // is the guard that catches zero candidates.
+      const problems: string[] = [];
+      for (const gate of ["tengu_lantern_wick_mode", "tengu_vellum_anchor"]) {
+        if (content.includes(`"${gate}"`)) {
+          problems.push(`found residual usage wrap-up gate "${gate}"`);
+        }
+      }
+      return problems.length > 0 ? problems.join("; ") : null;
+    },
+  },
+  {
     id: "version-output",
     kind: "presence",
     // The literal marker; \n here is a backslash + n (two chars) inside the bundle's

--- a/tests/usage-wrapup-gates.test.js
+++ b/tests/usage-wrapup-gates.test.js
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { patchDisableUsageWrapUpHints } = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
 
 const patcherPath = path.join(__dirname, "..", "patch-claude-display.ts");
 
@@ -78,6 +79,46 @@ test("never reports skipped when gates are present and patched", () => {
   );
   assert.equal(result.patched, 2);
   assert.ok(!result.skipped);
+});
+
+test("refuses to patch when only one gate literal survives", () => {
+  // Upstream changing or removing exactly one gate must not ship a bundle
+  // with the other injection path still active: nothing gets renamed and
+  // patched stays 0 so --assert-all fails loudly.
+  for (const survivor of ['"tengu_lantern_wick_mode"', '"tengu_vellum_anchor"']) {
+    const partial = versionedBundle("2.1.238", `it(${survivor},"off")`);
+    const result = patchDisableUsageWrapUpHints(partial);
+    assert.ok(result.candidates > 0);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, partial);
+    assert.ok(!result.skipped);
+  }
+});
+
+test("verifier requires both renamed gates on 2.1.238+ bundles", () => {
+  const both = versionedBundle(
+    "2.1.238",
+    'it("calico_lantern_wick_off","off");it("calico_vellum_gone_",!1)'
+  );
+  assert.equal(evaluatePatchModule("disable-usage-wrapup", both), null);
+
+  const lanternOnly = versionedBundle("2.1.238", 'it("calico_lantern_wick_off","off")');
+  assert.match(
+    evaluatePatchModule("disable-usage-wrapup", lanternOnly),
+    /expected renamed usage wrap-up gate "calico_vellum_gone_"/
+  );
+
+  const residual = versionedBundle("2.1.238", 'it("tengu_vellum_anchor",!1)');
+  assert.match(
+    evaluatePatchModule("disable-usage-wrapup", residual),
+    /residual usage wrap-up gate/
+  );
+
+  // Pre-feature bundles carry neither name and pass with nothing to prove.
+  assert.equal(
+    evaluatePatchModule("disable-usage-wrapup", versionedBundle("2.1.237", "run()")),
+    null
+  );
 });
 
 // End-to-end --assert-all behavior through the CLI: a pre-2.1.238 bundle must

--- a/tests/usage-wrapup-gates.test.js
+++ b/tests/usage-wrapup-gates.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { patchDisableUsageWrapUpHints } = require("../patch-claude-display.ts");
+
+// Mirrors the 2.1.238 bundle shape: gate names assigned to minified vars, then
+// read through the statsig getter `it(gate, default)` at the two injection
+// sites (grace-window wrap-up and 95% near-limit checkpoint).
+const fixture =
+  'var GIS=3600000,VIS=300000,KIS,WHp,GHp="tengu_lantern_wick_mode",KHp,_3n="tengu_vellum_anchor",' +
+  'YHp="[Usage limit approaching. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work.]";' +
+  'if(!Ne&&te&&cNp(Pe.depth===0)){let Wr=VHp(it(GHp,"off"));if(Wr!=="off"){inject(Wr==="next-steps"?KHp:WHp)}}' +
+  "if(!Ne&&te&&Pe.depth>0&&uNp()){if(it(_3n,!1)){notice(JHp);inject(YHp)}}";
+
+test("renames both usage wrap-up statsig gates to dead calico gates", () => {
+  const result = patchDisableUsageWrapUpHints(fixture);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 2);
+  assert.ok(!result.content.includes('"tengu_lantern_wick_mode"'));
+  assert.ok(!result.content.includes('"tengu_vellum_anchor"'));
+  assert.ok(result.content.includes('"calico_lantern_wick_off"'));
+  assert.ok(result.content.includes('"calico_vellum_gone_"'));
+});
+
+test("replacement gate names preserve byte length", () => {
+  const result = patchDisableUsageWrapUpHints(fixture);
+  assert.equal(result.content.length, fixture.length);
+});
+
+test("is idempotent on already-patched content", () => {
+  const once = patchDisableUsageWrapUpHints(fixture);
+  const twice = patchDisableUsageWrapUpHints(once.content);
+  assert.equal(twice.candidates, 0);
+  assert.equal(twice.patched, 0);
+  assert.equal(twice.content, once.content);
+});
+
+test("leaves pre-feature bundles untouched", () => {
+  const oldBundle = 'var x="tengu_something_else";run(x)';
+  const result = patchDisableUsageWrapUpHints(oldBundle);
+  assert.equal(result.candidates, 0);
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, oldBundle);
+});

--- a/tests/usage-wrapup-gates.test.js
+++ b/tests/usage-wrapup-gates.test.js
@@ -1,7 +1,13 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 const { patchDisableUsageWrapUpHints } = require("../patch-claude-display.ts");
+
+const patcherPath = path.join(__dirname, "..", "patch-claude-display.ts");
 
 // Mirrors the 2.1.238 bundle shape: gate names assigned to minified vars, then
 // read through the statsig getter `it(gate, default)` at the two injection
@@ -41,4 +47,73 @@ test("leaves pre-feature bundles untouched", () => {
   assert.equal(result.candidates, 0);
   assert.equal(result.patched, 0);
   assert.equal(result.content, oldBundle);
+});
+
+function versionedBundle(version, body) {
+  return `var pkg={PACKAGE_URL:"@anthropic-ai/claude-code",VERSION:"${version}"};${body}`;
+}
+
+test("reports pre-2.1.238 bundles without gates as skipped for --assert-all", () => {
+  const result = patchDisableUsageWrapUpHints(versionedBundle("2.1.237", "run()"));
+  assert.equal(result.patched, 0);
+  assert.equal(result.skipped, true);
+  assert.match(result.reason, /pre-2\.1\.238/);
+});
+
+test("keeps gate absence on 2.1.238+ bundles a hard failure", () => {
+  const result = patchDisableUsageWrapUpHints(versionedBundle("2.1.238", "run()"));
+  assert.equal(result.patched, 0);
+  assert.ok(!result.skipped);
+});
+
+test("does not mark unparseable-version bundles as skipped", () => {
+  const result = patchDisableUsageWrapUpHints("run()");
+  assert.equal(result.patched, 0);
+  assert.ok(!result.skipped);
+});
+
+test("never reports skipped when gates are present and patched", () => {
+  const result = patchDisableUsageWrapUpHints(
+    versionedBundle("2.1.238", fixture)
+  );
+  assert.equal(result.patched, 2);
+  assert.ok(!result.skipped);
+});
+
+// End-to-end --assert-all behavior through the CLI: a pre-2.1.238 bundle must
+// pass as an expected skip, while a 2.1.238+ bundle missing the gates must
+// still fail. All other modules are disabled via the --list-patches inventory
+// so this exercises only the wrap-up module's verdict.
+function runPatcherAssertAll(bundleText) {
+  const listing = execFileSync(process.execPath, [patcherPath, "--list-patches"], {
+    encoding: "utf8",
+  });
+  const otherIds = [...listing.matchAll(/^ {2}(\S+) - /gm)]
+    .map((m) => m[1])
+    .filter((id) => id !== "disable-usage-wrapup");
+  const tmpFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "wrapup-assertall-")),
+    "content.js"
+  );
+  fs.writeFileSync(tmpFile, bundleText, "utf8");
+  try {
+    execFileSync(
+      process.execPath,
+      [patcherPath, "--file", tmpFile, "--disable", otherIds.join(","), "--assert-all"],
+      { encoding: "utf8" }
+    );
+    return { exitCode: 0 };
+  } catch (error) {
+    return { exitCode: error.status ?? 1 };
+  } finally {
+    fs.rmSync(path.dirname(tmpFile), { recursive: true, force: true });
+  }
+}
+
+test("--assert-all passes on a pre-2.1.238 bundle without gates", () => {
+  assert.equal(runPatcherAssertAll(versionedBundle("2.1.237", "run()")).exitCode, 0);
+});
+
+test("--assert-all fails on a 2.1.238 bundle without gates", () => {
+  assert.notEqual(runPatcherAssertAll(versionedBundle("2.1.238", "run()")).exitCode, 0);
 });


### PR DESCRIPTION
## What

Claude Code 2.1.238 injects meta wrap-up prompts into the conversation when claude.ai usage approaches or reaches the 5-hour limit:

- At >=95% utilization: `[Usage limit approaching. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work. Don't start subagents or long-running work.]`, plus the TUI notice `Approaching your 5-hour usage limit — Claude will wrap up the current step.`
- During the post-limit grace window: the same "checkpoint now" text or a shorter "wrap up" variant.

Both paths are gated on server-side statsig flags with disabled defaults: `tengu_lantern_wick_mode` (`"off" | "basic" | "next-steps"`, grace window) and `tengu_vellum_anchor` (boolean, 95% near-limit). Users hit this only when the A/B flags are remotely enabled, so the behavior appears without any client update and cannot be turned off locally.

## How

New `disable-usage-wrapup` module (`patchDisableUsageWrapUpHints`) renames both gate-name string literals to same-length dead names (`calico_lantern_wick_off`, `calico_vellum_gone_`). Every statsig lookup then misses and falls back to the built-in disabled default — the exact off path users outside the experiment get. Anchors are the gate-name literals, not minified locals, so the matcher survives bundle rebuilds; equal-length replacement needs no `preserveLength` branch.

`verify-patched-binary.ts` gains a matching custom check asserting the original gate names are absent from the patched bundle (with a `disabledMarker` so disabling the module proves absence). Pre-feature bundles carry neither name and pass trivially; `--assert-all` is the guard that catches upstream renaming the gates away.

## Verification

- `tests/usage-wrapup-gates.test.js`: rename, byte-length preservation, idempotency, pre-feature no-op. Full suite on this branch: 108 passing.
- Built against upstream 2.1.238 (darwin arm64): 3 gate-name occurrences renamed in the extracted bundle, structural verifier green, patched binary runs (`--version` reports `(patched)`).
- Residual gate strings remain in the module's embedded JSC bytecode constant pool; that cache is validated against the source hash and is inert once the source changes.
- End-to-end observation caveat: the "no injection at 95%" behavior is only observable when a real session actually approaches the limit; structural evidence shows the gate lookups must miss and take the same disabled path as unflagged users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqsRorJHaLgJePNR5ZSDAH