### PR TITLE
fix(patch): restore four modules broken by 2.1.238 and stop pinning minified locals

### DIFF
--- a/.github/workflows/patch-claude.yml
+++ b/.github/workflows/patch-claude.yml
@@ -336,6 +336,8 @@ jobs:
             echo "node_lief_version=${{ steps.dependencies.outputs.version }}"
             echo "run_id=${{ github.run_id }}"
             echo "run_attempt=${{ github.run_attempt }}"
+            echo "source_commit=${{ github.sha }}"
+            echo "source_ref=${{ github.ref_name }}"
           } > work/metadata.txt
 
       - name: Create platform release
@@ -364,7 +366,14 @@ jobs:
             "$VERSION" \
             "$NODE_LIEF_VERSION" >> "$NOTES_PATH"
 
+          # --target pins the tag to the commit that actually produced these
+          # assets. Without it gh creates the tag on the default branch's head,
+          # so a release dispatched from any other ref ends up tagged at code
+          # that cannot rebuild it — and the attestation, which records the real
+          # run, then contradicts the tag. Every 2.1.238 tag was created this
+          # way before this line existed.
           gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
             --title "$TITLE" \
             --notes-file "$NOTES_PATH" \
             work/metadata.txt \

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -59,6 +59,22 @@ These rules are not style preferences. They are what keeps the patcher alive acr
 - If you have to match a function body, match the semantic shape of that body, not its symbol names.
 - Only widen a matcher as much as needed to survive bundle churn.
 - When a patch has multiple known upstream shapes, keep them as separate targeted branches instead of one giant regex.
+- **Injected code must never name a minified local literally.** Use a captured group, or a name this
+  repo invents (`__calico*`, `__cc*`). A pinned local in a matcher merely fails to match; a pinned
+  local in an injection is worse, because it can match and then operate on the wrong binding. In
+  2.1.238 `compact-body-policy` injected around a hardcoded `n`, which is `fetchOverride` on
+  macos/linux-x64/windows-x64 and `model` on the arm64 Linux and Windows builds — had the matcher
+  succeeded there, it would have wrapped the model string as if it were a fetch function. The matcher
+  failing was luck, not protection.
+- **Minified locals differ across platforms for the same version.** The same rule that protects
+  against upstream rebuilds also has to hold across the five release platforms; a matcher validated
+  on one bundle proves nothing about the others. Verify against every platform's bundle before
+  claiming a module is fixed. Extracting a bundle is static — no need to run the binary — so any
+  platform can be checked from any machine.
+- **A falling candidate count is silent.** `--assert-all` only fails a module at `patched == 0`, so a
+  matcher that quietly stops matching one of its sites still ships. Four separate defects have hidden
+  this way. When a count changes, find out why before assuming the bundle changed rather than the
+  matcher.
 
 ## Native Patching Flow
 

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -197,6 +197,37 @@ Likely break signs:
 - a later agent turn retains the previous turn's input total instead of the latest one
 - the module reports `0` candidates or the verifier reports a missing refresh seam
 
+### remora client factory (`active-turn-prompt-id`, `compact-request-source`, `compact-body-policy`)
+
+These three remora adapters share one anchor: the async Anthropic client factory ("Zie") whose
+destructured parameter object owns `source` and `agentContext`. Each keys its rewrite on that factory
+so quota checks, token counts, and side queries stay outside the compact/active-turn namespace.
+
+Old bundle shapes we match:
+
+- 2.1.237 factory signature:
+  `async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i}){…}`
+- 2.1.237 header locals inside the factory body:
+  `…,c=<sanitizer>(i)?void 0:i,u=<extraHeaders>(),p={…,"X-Claude-Code-Session-Id":<sid>(),...u,…}`,
+  where `c` is the sanitized agent context, `u` the extra-header object, `p` the header literal, and
+  `...u,` the extra-header spread
+- 2.1.238 appends `,credentials:s` to the parameter object
+  (`…,source:o,agentContext:i,credentials:s}`). Because that consumes the `s` binding, every following
+  minified body local shifts by one letter: `c=…,u=…,p={` becomes `u=…,d=…,f={` and the spread `...u,`
+  becomes `...d,`. The header-object injection at the signature boundary (`compact-body-policy`) is
+  unaffected because it reads only the stable `o`/`n` parameters
+
+What we widened for 2.1.238:
+
+- the factory-signature matcher tolerates any further simple `,key:local` bindings after
+  `agentContext:i`, so appended destructured parameters do not drop the anchor
+- `active-turn-prompt-id` and `compact-request-source` capture the sanitized-context / extra-header /
+  header-object local names (and the extra-header spread name) instead of pinning `c`/`u`/`p`/`...u,`,
+  so a one-letter rename no longer silently skips the site. `compact-request-source` keeps the injected
+  IIFE parameter as the literal `u` because the verifier's wrap-needle matches on `((u)=>…`
+- `scripts/verify-patched-binary.ts` mirrors both widenings in its `compact-request-source` and
+  `compact-body-policy` structural checks so a patched 2.1.238 binary verifies
+
 ### `statusline-committed-usage`
 
 Intent:
@@ -217,6 +248,11 @@ Source of truth:
   is still the one built from a single bracketed block (`ueo([block],…)`) whose message carries no
   inline `usage:` — the two non-streaming fallback sites use `ueo(<var>.content,…)` plus
   `usage:B5e(…)` and stay outside the anchor
+- Claude Code 2.1.238 appends a fifth argument (the storage-V5 handle) to the content builder call:
+  `Gio([Ga],n,i.agentId,{requestId:Te??void 0,messageId:Gr.id},i.storageV5)` (2.1.237 had no fifth
+  argument). The batch-wrapper matcher accepts an optional trailing `,<identifier-or-member>` before
+  the content-builder call closes, so both 2.1.237 and 2.1.238 match and a further appended argument
+  will not break it again
 - production app state shallow-copies the wrapper before the terminal event; the shared object cell
   survives that copy, unlike the old primitive top-level boolean which remained stale `false`
 - the normal terminal `message_delta` mutation loop is the only path that can set `committed:!0`

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -69,7 +69,8 @@ These rules are not style preferences. They are what keeps the patcher alive acr
 - **A captured identifier must never be interpolated into a replacement string.** `$` sequences
   expand there — `$1`-`$9` and `$&`/`$$`/`` $` ``/`$'` against a regex searchValue, and `$&`/`$$`/
   `` $` ``/`$'` even against a plain string one — and this bundle's identifier grammar
-  (`[A-Za-z_$][\w$]*`) lets a minifier hand back a name containing any of them. A source local named
+  (`[A-Za-z_$][\w$]*`) admits `$`, so a minified name can carry `$$` or `$1`-`$9`; it cannot carry
+  the others, since `&`, `` ` `` and `'` are not identifier characters. A source local named
   `$1e` turned an injected classifier call into a reference to the wrong capture group instead of the
   real parameter. Build the replacement text as usual, then pass it to `.replace` through a callback
   (`.replace(pattern, () => text)`) so it is emitted verbatim; a callback's return value never goes

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -214,8 +214,8 @@ Old bundle shapes we match:
 - 2.1.238 appends `,credentials:s` to the parameter object
   (`…,source:o,agentContext:i,credentials:s}`). Because that consumes the `s` binding, every following
   minified body local shifts by one letter: `c=…,u=…,p={` becomes `u=…,d=…,f={` and the spread `...u,`
-  becomes `...d,`. The header-object injection at the signature boundary (`compact-body-policy`) is
-  unaffected because it reads only the stable `o`/`n` parameters
+  becomes `...d,`. The header-object injection at the signature boundary (`compact-body-policy`)
+  reads the `source`/`fetchOverride` parameter locals — which are NOT stable either; see below
 
 What we widened for 2.1.238:
 
@@ -227,6 +227,27 @@ What we widened for 2.1.238:
   IIFE parameter as the literal `u` because the verifier's wrap-needle matches on `((u)=>…`
 - `scripts/verify-patched-binary.ts` mirrors both widenings in its `compact-request-source` and
   `compact-body-policy` structural checks so a patched 2.1.238 binary verifies
+
+Minified locals differ ACROSS PLATFORMS for the same version — matchers must never pin one:
+
+- the 2.1.238 macos-arm64 bundle destructures the factory as
+  `async function Tme({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i,credentials:s})`,
+  while the linux-arm64 (`_me`) and windows-arm64 (`bme`) bundles of the SAME version swap the
+  `model`/`fetchOverride` locals: `{…,model:n,fetchOverride:r,…}`. The minifier assigns local names
+  per platform build, so a matcher that pins any destructured local (the original `model:r,
+  fetchOverride:n,source:o,agentContext:i` pin) passes CI on macos/linux-x64/windows-x64 and reports
+  0 candidates on the arm64 Linux/Windows builds of the identical upstream release
+- the durable rule: anchor on the destructured PROPERTY names (`apiKey:`, `model:`, `source:`, …),
+  capture every local binding, and reuse captures via backreference. Injected code that must name a
+  local (the `compact-body-policy` fetchOverride wrap, the `active-turn-prompt-id` source-classifier
+  call and sanitized-context rebuild) derives the name from the capture, never from a literal
+- `scripts/verify-patched-binary.ts` applies the same rule: its factory checks capture
+  `fetchOverride`/`source` and backreference them (`\2==="compact"`, `\1=__calicoCompactWrapFetch(\1)`),
+  and the body-policy wrap-inject count matches by shape instead of the exact `o`/`n` string
+- regression coverage: the `model:n,fetchOverride:r` swapped-locals shape is tested in
+  `tests/active-turn-prompt-id.test.js`, `tests/compact-request-source.test.js`, and
+  `tests/compact-body-policy.test.js`, plus a composed renamed-`source` fixture that keeps the
+  verifier's header-order check from re-pinning `o`
 
 ### `statusline-committed-usage`
 

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -249,6 +249,27 @@ Minified locals differ ACROSS PLATFORMS for the same version — matchers must n
   `tests/compact-body-policy.test.js`, plus a composed renamed-`source` fixture that keeps the
   verifier's header-order check from re-pinning `o`
 
+The same cross-platform local swap also hit `custom-context-window`, and there the
+`scripts/verify-patched-binary.ts` MARKER — not just the patcher — embedded a minified local:
+
+- the effective-window function is `function NAME(e,t){let A=Math.min(F(e),G),B=H()?t:void 0,{window:C}=I(e,B);return C-A}`.
+  On macos-arm64/linux-x64/windows-x64 the reserve local A is `r` and the ctx local B is `n`
+  (`return o-r`); on linux-arm64 and windows-arm64 they are swapped (A=`n`, B=`r`, `return o-n`).
+  The patcher pinned `let r=Math.min(...),n=...;return o-r`, so it matched 4/4 candidates on the
+  three non-arm64 platforms but only 3/4 on the two arm64 builds. Because `patched === candidates`,
+  `--assert-all` did NOT catch it — a silent candidate-count drop, the same failure shape that hid
+  the thinking-streaming regression. The patcher now captures the reserve/ctx/window locals and
+  backreferences the ctx local inside `I(e,B)`
+- the verifier's `custom-context-window` check listed the literal marker `CALICO_MODEL_CONTEXT_WINDOWS?o:o-r`.
+  After the patcher fix, arm64 emits `?o:o-n`, so the pinned marker failed verification (this is
+  where CI actually broke — on the verifier, not the patcher). A verifier marker is a matcher too:
+  it must anchor on structure, never on a minified local. The check now uses
+  `/CALICO_MODEL_CONTEXT_WINDOWS\?([A-Za-z_$][\w$]*):\1-[A-Za-z_$][\w$]*/`, backreferencing the
+  window local and accepting any reserve local
+- regression coverage: the swapped `let n=Math.min(...),r=...;return w-n` shape (window local also
+  renamed to `w`) is tested in `tests/statusline-committed-usage.test.js`, asserting patched 4/4,
+  the `?w:w-n` gate, and verifier acceptance
+
 ### `statusline-committed-usage`
 
 Intent:

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -66,6 +66,14 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   macos/linux-x64/windows-x64 and `model` on the arm64 Linux and Windows builds — had the matcher
   succeeded there, it would have wrapped the model string as if it were a fetch function. The matcher
   failing was luck, not protection.
+- **A captured identifier must never be interpolated into a replacement string.** `$` sequences
+  expand there — `$1`-`$9` and `$&`/`$$`/`` $` ``/`$'` against a regex searchValue, and `$&`/`$$`/
+  `` $` ``/`$'` even against a plain string one — and this bundle's identifier grammar
+  (`[A-Za-z_$][\w$]*`) lets a minifier hand back a name containing any of them. A source local named
+  `$1e` turned an injected classifier call into a reference to the wrong capture group instead of the
+  real parameter. Build the replacement text as usual, then pass it to `.replace` through a callback
+  (`.replace(pattern, () => text)`) so it is emitted verbatim; a callback's return value never goes
+  through `$` substitution.
 - **Minified locals differ across platforms for the same version.** The same rule that protects
   against upstream rebuilds also has to hold across the five release platforms; a matcher validated
   on one bundle proves nothing about the others. Verify against every platform's bundle before

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2896,7 +2896,7 @@ function patchActiveTurnPromptIdentity(content) {
   // Main-session requests use the live prompt id; agent requests prefer the
   // value frozen at their AsyncLocalStorage entry point.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:([A-Za-z_$][\w$]*)(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;
@@ -2920,13 +2920,17 @@ function patchActiveTurnPromptIdentity(content) {
     // `...u,` → `...d,`). Capture the three local names and the extra-header
     // spread name instead of pinning `c`/`u`/`p`/`u`, so a future rename does
     // not silently drop this site.
-    const localsPattern =
-      /,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(i\)\?void 0:i,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)=\{/;
+    const sourceParam = clientStartMatch[2];
+    const contextParam = clientStartMatch[3];
+    const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const contextRe = escapeRegExp(contextParam);
+    const localsPattern = new RegExp(
+      `,([A-Za-z_$][\\w$]*)=([A-Za-z_$][\\w$]*)\\(${contextRe}\\)\\?void 0:${contextRe},([A-Za-z_$][\\w$]*)=([A-Za-z_$][\\w$]*)\\(\\),([A-Za-z_$][\\w$]*)=\\{`
+    );
     const localsMatch = segment.match(localsPattern);
     if (!localsMatch) {
       continue;
     }
-    const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const contextLocal = localsMatch[1];
     const sanitizer = localsMatch[2];
     const extraHeadersLocal = localsMatch[3];
@@ -2935,7 +2939,7 @@ function patchActiveTurnPromptIdentity(content) {
 
     let nextSegment = segment.replace(
       localsPattern,
-      `,${contextLocal}=${sanitizer}(i)?void 0:i,__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(o),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
+      `,${contextLocal}=${sanitizer}(${contextParam})?void 0:${contextParam},__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(${sourceParam}),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
     );
     nextSegment = nextSegment.replace(
       new RegExp(
@@ -2987,7 +2991,7 @@ function patchCompactRequestSource(content) {
 
   // Same Zie-shaped client factory active-turn targets: owns source + agentContext.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:([A-Za-z_$][\w$]*)(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;
@@ -3020,9 +3024,10 @@ function patchCompactRequestSource(content) {
     );
     // Inject after Session-Id + custom-header spread (...u,). Works with or
     // without a subsequent active-turn __calicoPromptId spread.
+    const sourceParam = clientStartMatch[2];
     nextSegment = nextSegment.replace(
       /("X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,)/,
-      '$1...process.env.REMORA_ACTIVE==="1"&&o==="compact"&&{"x-calico-request-source":"compact"},'
+      `$1...process.env.REMORA_ACTIVE==="1"&&${sourceParam}==="compact"&&{"x-calico-request-source":"compact"},`
     );
     if (nextSegment === segment) {
       continue;
@@ -3081,11 +3086,12 @@ function __calicoCompactStripContentLength(e){if(e==null)return e;if(typeof Head
 
   let candidates = 0;
   let patched = 0;
+  let injectedWrap = null;
   let output = content;
 
   // Same Zie-shaped client factory: wrap fetchOverride when this client is for compact.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:([A-Za-z_$][\w$]*)(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;
@@ -3095,14 +3101,16 @@ function __calicoCompactStripContentLength(e){if(e==null)return e;if(typeof Head
     const segment = output.slice(start, end);
     if (
       !segment.includes('"X-Claude-Code-Session-Id"') ||
-      segment.includes("__calicoCompactWrapFetch(n)")
+      segment.includes("__calicoCompactWrapFetch(")
     ) {
       continue;
     }
 
     candidates += 1;
+    const fetchOverrideParam = clientStartMatch[1];
+    const sourceParam = clientStartMatch[2];
     const inject =
-      'if(process.env.REMORA_ACTIVE==="1"&&o==="compact"){n=__calicoCompactWrapFetch(n)}';
+      `if(process.env.REMORA_ACTIVE==="1"&&${sourceParam}==="compact"){${fetchOverrideParam}=__calicoCompactWrapFetch(${fetchOverrideParam})}`;
     const nextSegment =
       clientStartMatch[0] + inject + segment.slice(clientStartMatch[0].length);
     if (nextSegment === segment) {
@@ -3110,17 +3118,18 @@ function __calicoCompactStripContentLength(e){if(e==null)return e;if(typeof Head
     }
 
     patched += 1;
+    injectedWrap = inject;
     output = output.slice(0, start) + nextSegment + output.slice(end);
     clientStartPattern.lastIndex = start + nextSegment.length;
   }
 
-  if (candidates !== 1 || patched !== 1) {
+  if (candidates !== 1 || patched !== 1 || injectedWrap === null) {
     return { content: original, candidates, patched: 0 };
   }
 
-  // Inject helpers once immediately before the patched Zie factory.
-  const wrapNeedle =
-    'if(process.env.REMORA_ACTIVE==="1"&&o==="compact"){n=__calicoCompactWrapFetch(n)}';
+  // Inject helpers once immediately before the patched Zie factory. The wrap
+  // needle carries the captured source/fetchOverride locals for this bundle.
+  const wrapNeedle = injectedWrap;
   const wrapIndex = output.indexOf(wrapNeedle);
   if (wrapIndex === -1) {
     return { content: original, candidates, patched: 0 };

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1865,14 +1865,18 @@ function patchCustomContextWindows(content) {
   // Claude's stock pipeline subtracts an output reserve and may precompute at
   // a separate buffer fraction. In opt-in Calico mode, use the raw mapped
   // window and the explicit percentage as the single compact boundary.
+  // The reserve local (Math.min result) and the ctx local are swapped on some
+  // platform builds of the same version (arm64: `let n=Math.min(...),r=...`
+  // → `return o-n`; elsewhere `let r=Math.min(...),n=...` → `return o-r`), so
+  // capture the window and reserve locals instead of pinning `o`/`r`.
   const effectiveWindowPattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{let r=Math\.min\([A-Za-z_$][\w$]*\(e\),[A-Za-z_$][\w$]*\),n=[A-Za-z_$][\w$]*\(\)\?t:void 0,\{window:o\}=[A-Za-z_$][\w$]*\(e,n\);return )(o-r)(\})/g;
+    /(function [A-Za-z_$][\w$]*\(e,t\)\{let ([A-Za-z_$][\w$]*)=Math\.min\([A-Za-z_$][\w$]*\(e\),[A-Za-z_$][\w$]*\),([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\)\?t:void 0,\{window:([A-Za-z_$][\w$]*)\}=[A-Za-z_$][\w$]*\(e,\3\);return )(\4-\2)(\})/g;
   output = output.replace(
     effectiveWindowPattern,
-    (full, prefix, originalReturn, suffix) => {
+    (full, prefix, reserveLocal, ctxLocal, windowLocal, originalReturn, suffix) => {
       candidates += 1;
       patched += 1;
-      return `${prefix}process.env.CALICO_MODEL_CONTEXT_WINDOWS?o:${originalReturn}${suffix}`;
+      return `${prefix}process.env.CALICO_MODEL_CONTEXT_WINDOWS?${windowLocal}:${originalReturn}${suffix}`;
     }
   );
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -256,7 +256,12 @@ function patchWriteCreateDiffColors(content) {
       continue;
     }
 
-    const nextCreateSegment = createSegment.replace(before, after);
+    // `after` interpolates captured minified locals (fileVar, contentVar,
+    // styleVar, …), which may themselves contain `$`. A callback return value
+    // is emitted verbatim; passing `after` as a plain string here would let
+    // String.replace's `$&`/`$$` expansion corrupt it if a captured name ever
+    // contains one of those sequences.
+    const nextCreateSegment = createSegment.replace(before, () => after);
     if (nextCreateSegment !== createSegment) {
       patched += 1;
       output = output.slice(0, createStart) + nextCreateSegment + output.slice(updateStart);
@@ -942,8 +947,11 @@ function patchThinkingStreaming(content) {
       };
     }
 
+    // `after` interpolates captured event/setter/helper locals, so it must
+    // reach the string engine only through a callback — a plain-string 2nd
+    // argument would let `$$`/`$&` in a captured name expand.
     return {
-      segment: segment.replace(before, after),
+      segment: segment.replace(before, () => after),
       changed: true,
     };
   };
@@ -1406,7 +1414,9 @@ function patchThinkingStreaming(content) {
           for (const [before, after] of wg6Replacements) {
             if (nextWg6Segment.includes(before)) {
               candidates += 1;
-              nextWg6Segment = nextWg6Segment.replace(before, after);
+              // `after` interpolates captured wg6 locals; go through a
+              // callback so `$$`/`$&` inside a captured name is not expanded.
+              nextWg6Segment = nextWg6Segment.replace(before, () => after);
               if (nextWg6Segment.includes(after)) {
                 patched += 1;
               }
@@ -2050,12 +2060,16 @@ function patchBackgroundAgentUsage(content) {
   const progressReplacement = `${eventName}(${progressMatch[1]},${progressMatch[2]},${progressMatch[3]},${progressMatch[4]}.options.tools),__calicoRefreshAgentUsage(${progressMatch[1]},${completionTranscript}),${progressMatch[5]}(${progressOwner},${summaryName}(${progressMatch[1]}),${progressStatus});`;
   const completionRefresh = `__calicoRefreshAgentUsage(${progressMatch[1]},${completionResult}),${progressMatch[5]}(${progressOwner},${summaryName}(${progressMatch[1]}),${progressStatus});`;
 
-  let output = original.replace(trackerPattern, trackerReplacement);
-  output = output.replace(accountingPattern, eventReplacement);
-  output = output.replace(progressPattern, progressReplacement);
+  // Every *Replacement string below interpolates captured minified locals
+  // (trackerName, eventVar, usageVar, progressMatch[...], …), so each must
+  // reach .replace only via a callback — a plain-string 2nd argument would
+  // let `$$`/`$&`/`$1`-`$9` in a captured name expand against these regexes.
+  let output = original.replace(trackerPattern, () => trackerReplacement);
+  output = output.replace(accountingPattern, () => eventReplacement);
+  output = output.replace(progressPattern, () => progressReplacement);
   output = output.replace(
     completionMatch.match[0],
-    completionMatch.match[0] + completionRefresh
+    () => completionMatch.match[0] + completionRefresh
   );
 
   if (
@@ -2332,11 +2346,14 @@ function patchStatuslineCommittedUsage(content) {
   const selectorMatch = selectorMatches[0];
   const selectorReplacement = `${selectorMatch[1]}=${reducerName}(__calicoStatuslineMessages(${selectorMatch[2]})),${selectorMatch[3]}=${selectorMatch[4]}(${selectorMatch[5]},${selectorMatch[6]}())`;
 
-  let output = original.replace(wrapperMatch.match[0], wrapperReplacement);
-  output = output.replace(terminalPattern, terminalReplacement);
+  // wrapperReplacement/terminalReplacement/cloneSyncReplacement interpolate
+  // captured minified locals (terminalItem, terminalArray, cloneSyncSource,
+  // …); route them through callbacks so a captured `$$`/`$&` cannot expand.
+  let output = original.replace(wrapperMatch.match[0], () => wrapperReplacement);
+  output = output.replace(terminalPattern, () => terminalReplacement);
   let cloneIndex = 0;
   output = output.replace(cloneRegistrationPattern, () => cloneReplacements[cloneIndex++]);
-  output = output.replace(cloneSyncPattern, cloneSyncReplacement);
+  output = output.replace(cloneSyncPattern, () => cloneSyncReplacement);
 
   const selectorOutputMatch = [...output.matchAll(selectorPattern)][0];
   const selectorIndex = selectorOutputMatch?.index ?? -1;
@@ -2347,7 +2364,7 @@ function patchStatuslineCommittedUsage(content) {
 
   output =
     output.slice(0, functionStart) + accountingHelper + output.slice(functionStart);
-  output = output.replace(selectorPattern, selectorReplacement);
+  output = output.replace(selectorPattern, () => selectorReplacement);
 
   if (
     output.split(wrapperReplacement).length - 1 !== 1 ||
@@ -2485,8 +2502,11 @@ function patchStatuslineRateLimitWindows(content) {
     .join(",")}}`;
   const guardReplacement = `...Object.keys(${guardLocal}).length>0&&{rate_limits:${guardLocal}}`;
 
-  let output = original.replace(projectionPattern, projectionReplacement);
-  output = output.replace(guardPattern, guardReplacement);
+  // projectionReplacement/guardReplacement interpolate the captured
+  // projectionLocal/guardLocal names; use callbacks so a captured `$1`-style
+  // name cannot be read back as a backreference against these regexes.
+  let output = original.replace(projectionPattern, () => projectionReplacement);
+  output = output.replace(guardPattern, () => guardReplacement);
 
   if (
     output.split(projectionReplacement).length - 1 !== 1 ||
@@ -2941,9 +2961,16 @@ function patchActiveTurnPromptIdentity(content) {
     const extraHeadersFactory = localsMatch[4];
     const headerObjectLocal = localsMatch[5];
 
+    // This replacement interpolates sourceParam, contextParam, contextLocal,
+    // sourceClassifier, promptGetter, and the other captured locals above —
+    // all minified names that may legally contain `$`. localsPattern is a
+    // regex with 5 capture groups, so a captured name like `$1e` would be
+    // read back as a backreference if passed as a plain string; go through a
+    // callback so it is emitted verbatim instead.
     let nextSegment = segment.replace(
       localsPattern,
-      `,${contextLocal}=${sanitizer}(${contextParam})?void 0:${contextParam},__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(${sourceParam}),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
+      () =>
+        `,${contextLocal}=${sanitizer}(${contextParam})?void 0:${contextParam},__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(${sourceParam}),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
     );
     nextSegment = nextSegment.replace(
       new RegExp(
@@ -3029,9 +3056,16 @@ function patchCompactRequestSource(content) {
     // Inject after Session-Id + custom-header spread (...u,). Works with or
     // without a subsequent active-turn __calicoPromptId spread.
     const sourceParam = clientStartMatch[2];
+    // sourceParam is a captured minified local, so it may itself begin with
+    // `$1` (or contain any `$` sequence). This regex has one capture group,
+    // so a plain-string replacement would let `$1`-in-sourceParam expand as
+    // a backreference to the entire matched header prefix instead of naming
+    // the source param — go through a callback so the capture is threaded
+    // explicitly and sourceParam is emitted verbatim.
     nextSegment = nextSegment.replace(
       /("X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,)/,
-      `$1...process.env.REMORA_ACTIVE==="1"&&${sourceParam}==="compact"&&{"x-calico-request-source":"compact"},`
+      (_full, headerPrefix) =>
+        `${headerPrefix}...process.env.REMORA_ACTIVE==="1"&&${sourceParam}==="compact"&&{"x-calico-request-source":"compact"},`
     );
     if (nextSegment === segment) {
       continue;

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2089,8 +2089,14 @@ function patchStatuslineCommittedUsage(content) {
   // bracketed block (`ueo([ia],…)`) and whose message carries no `usage:`;
   // the two fallback sites use `ueo(<var>.content,…)` plus `usage:B5e(…)`
   // and cannot match this shape.
+  //
+  // 2.1.238 appends a fifth argument to the content builder call
+  // (`Gio([Ga],n,i.agentId,{requestId:Te??void 0,messageId:Gr.id},i.storageV5)`),
+  // so the trailing `,<identifier-or-member>` is matched optionally to keep both
+  // 2.1.237 (no fifth arg) and 2.1.238 (one appended arg) matching, and to
+  // tolerate a further appended argument without another edit.
   const batchWrapperPattern = new RegExp(
-    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
+    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
     "g"
   );
   const terminalPattern = new RegExp(
@@ -2890,7 +2896,7 @@ function patchActiveTurnPromptIdentity(content) {
   // Main-session requests use the live prompt id; agent requests prefer the
   // value frozen at their AsyncLocalStorage entry point.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;
@@ -2908,19 +2914,33 @@ function patchActiveTurnPromptIdentity(content) {
       continue;
     }
 
+    // 2.1.238 appends `,credentials:s` to the parameter object, which consumes
+    // the `s` binding and shifts every following minified local by one letter
+    // (2.1.237 `c=…,u=…,p={` → 2.1.238 `u=…,d=…,f={`, and the header spread
+    // `...u,` → `...d,`). Capture the three local names and the extra-header
+    // spread name instead of pinning `c`/`u`/`p`/`u`, so a future rename does
+    // not silently drop this site.
     const localsPattern =
-      /,c=([A-Za-z_$][\w$]*)\(i\)\?void 0:i,u=([A-Za-z_$][\w$]*)\(\),p=\{/;
+      /,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(i\)\?void 0:i,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)=\{/;
     const localsMatch = segment.match(localsPattern);
     if (!localsMatch) {
       continue;
     }
+    const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const contextLocal = localsMatch[1];
+    const sanitizer = localsMatch[2];
+    const extraHeadersLocal = localsMatch[3];
+    const extraHeadersFactory = localsMatch[4];
+    const headerObjectLocal = localsMatch[5];
 
     let nextSegment = segment.replace(
       localsPattern,
-      `,c=$1(i)?void 0:i,__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(o),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(c?.__calicoPromptId??${promptGetter}()):void 0,u=$2(),p={`
+      `,${contextLocal}=${sanitizer}(i)?void 0:i,__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(o),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
     );
     nextSegment = nextSegment.replace(
-      /(\"X-Claude-Code-Session-Id\":[A-Za-z_$][\w$]*\(\),)(\.\.\.u,)/,
+      new RegExp(
+        `("X-Claude-Code-Session-Id":[A-Za-z_$][\\w$]*\\(\\),)(\\.\\.\\.${escapeRegExp(extraHeadersLocal)},)`
+      ),
       '$1$2...__calicoPromptId&&{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"},'
     );
     if (nextSegment === segment) {
@@ -2967,7 +2987,7 @@ function patchCompactRequestSource(content) {
 
   // Same Zie-shaped client factory active-turn targets: owns source + agentContext.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;
@@ -2989,9 +3009,14 @@ function patchCompactRequestSource(content) {
     // request-source header from custom headers so ANTHROPIC_CUSTOM_HEADERS
     // cannot spoof compact. Re-add the lowercase value only for true compact.
     // Single let-binding only — reassignment would be a SyntaxError in `let`.
+    // 2.1.238's `credentials:s` rename shifts the extra-header local and the
+    // header-object local (2.1.237 `u=…(),p={` → 2.1.238 `d=…(),f={`), so both
+    // names are captured. The IIFE parameter stays the literal `u` regardless,
+    // because the wrap-needle lookup below matches on `((u)=>…`.
     let nextSegment = segment.replace(
-      /,u=([A-Za-z_$][\w$]*)\(\),p=\{/,
-      ',u=((u)=>process.env.REMORA_ACTIVE==="1"?__calicoOmitHeader(u,"x-calico-request-source"):u)($1()),p={'
+      /,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)=\{/,
+      (full, extraLocal, factory, headerLocal) =>
+        `,${extraLocal}=((u)=>process.env.REMORA_ACTIVE==="1"?__calicoOmitHeader(u,"x-calico-request-source"):u)(${factory}()),${headerLocal}={`
     );
     // Inject after Session-Id + custom-header spread (...u,). Works with or
     // without a subsequent active-turn __calicoPromptId spread.
@@ -3060,7 +3085,7 @@ function __calicoCompactStripContentLength(e){if(e==null)return e;if(typeof Head
 
   // Same Zie-shaped client factory: wrap fetchOverride when this client is for compact.
   const clientStartPattern =
-    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i\}\)\{/g;
+    /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{/g;
   let clientStartMatch;
   while ((clientStartMatch = clientStartPattern.exec(output)) !== null) {
     const start = clientStartMatch.index;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -453,8 +453,12 @@ const CHECKS: Check[] = [
       }
       // Sanitize + compact header must be live code inside the Zie factory, not
       // merely present as string/comment text elsewhere in the bundle.
+      // 2.1.238 appends `,credentials:s` to the factory parameter object and
+      // shifts the extra-header local and header-object local by one letter
+      // (`u=…(),p={` → `d=…(),f={`); the signature tail and both locals are
+      // matched generically. The IIFE parameter stays the literal `u`.
       const ownedFactory =
-        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i\}\)\{(?:if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\})?let [\s\S]*?u=\(\(u\)=>process\.env\.REMORA_ACTIVE==="1"\?__calicoOmitHeader\(u,"x-calico-request-source"\):u\)\([A-Za-z_$][\w$]*\(\)\),p=\{[\s\S]*?"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,\.\.\.process\.env\.REMORA_ACTIVE==="1"&&o==="compact"&&\{"x-calico-request-source":"compact"\}/;
+        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{(?:if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\})?let [\s\S]*?[A-Za-z_$][\w$]*=\(\(u\)=>process\.env\.REMORA_ACTIVE==="1"\?__calicoOmitHeader\(u,"x-calico-request-source"\):u\)\([A-Za-z_$][\w$]*\(\)\),[A-Za-z_$][\w$]*=\{[\s\S]*?"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,\.\.\.process\.env\.REMORA_ACTIVE==="1"&&o==="compact"&&\{"x-calico-request-source":"compact"\}/;
       if (!ownedFactory.test(content)) {
         return "compact request-source sanitize/header inject is not owned by Zie factory";
       }
@@ -493,8 +497,10 @@ const CHECKS: Check[] = [
         [policyHelper, rewriteHelper, wrapHelper, stripHelper].join("\n") + "\n";
       const wrapInject =
         'if(process.env.REMORA_ACTIVE==="1"&&o==="compact"){n=__calicoCompactWrapFetch(n)}';
+      // 2.1.238 appends `,credentials:s` to the factory parameter object; the
+      // signature tail after `agentContext:i` is matched generically.
       const ownedFactory =
-        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i\}\)\{if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\}/;
+        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\}/;
       const factoryMatch = ownedFactory.exec(content);
       if (!factoryMatch || factoryMatch.index === undefined) {
         return "compact fetch wrap is not owned by the Zie client factory";
@@ -756,8 +762,11 @@ const CHECKS: Check[] = [
       );
       // 2.1.236+ batch tool-use destructured wrapper; see the matching
       // pattern in patch-claude-display.ts for the canonical/fallback split.
+      // 2.1.238 appends a fifth argument to the content builder call
+      // (`…messageId:Gr.id},i.storageV5)`), matched optionally so the patched
+      // 2.1.237 and 2.1.238 binaries both verify.
       const batchWrapperPattern = new RegExp(
-        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
         "g"
       );
       const wrapperMatches = [

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -415,7 +415,7 @@ const CHECKS: Check[] = [
       // Compact request-source may inject between custom headers and active-turn
       // Calico-owned headers when both modules apply (default module order).
       const protectedHeaderOrder =
-        /"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,(?:\.\.\.process\.env\.REMORA_ACTIVE==="1"&&o==="compact"&&\{"x-calico-request-source":"compact"\},)?\.\.\.__calicoPromptId&&\{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"\}/;
+        /"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,(?:\.\.\.process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*==="compact"&&\{"x-calico-request-source":"compact"\},)?\.\.\.__calicoPromptId&&\{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"\}/;
       return protectedHeaderOrder.test(content)
         ? null
         : "Calico-owned headers are missing or can be overridden by custom headers";
@@ -458,7 +458,7 @@ const CHECKS: Check[] = [
       // (`u=…(),p={` → `d=…(),f={`); the signature tail and both locals are
       // matched generically. The IIFE parameter stays the literal `u`.
       const ownedFactory =
-        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{(?:if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\})?let [\s\S]*?[A-Za-z_$][\w$]*=\(\(u\)=>process\.env\.REMORA_ACTIVE==="1"\?__calicoOmitHeader\(u,"x-calico-request-source"\):u\)\([A-Za-z_$][\w$]*\(\)\),[A-Za-z_$][\w$]*=\{[\s\S]*?"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,\.\.\.process\.env\.REMORA_ACTIVE==="1"&&o==="compact"&&\{"x-calico-request-source":"compact"\}/;
+        /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:[A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{(?:if\(process\.env\.REMORA_ACTIVE==="1"&&\2==="compact"\)\{\1=__calicoCompactWrapFetch\(\1\)\})?let [\s\S]*?[A-Za-z_$][\w$]*=\(\(u\)=>process\.env\.REMORA_ACTIVE==="1"\?__calicoOmitHeader\(u,"x-calico-request-source"\):u\)\([A-Za-z_$][\w$]*\(\)\),[A-Za-z_$][\w$]*=\{[\s\S]*?"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,\.\.\.process\.env\.REMORA_ACTIVE==="1"&&\2==="compact"&&\{"x-calico-request-source":"compact"\}/;
       if (!ownedFactory.test(content)) {
         return "compact request-source sanitize/header inject is not owned by Zie factory";
       }
@@ -495,17 +495,22 @@ const CHECKS: Check[] = [
       // single newline separator and a trailing newline before the factory.
       const helperBlock =
         [policyHelper, rewriteHelper, wrapHelper, stripHelper].join("\n") + "\n";
-      const wrapInject =
-        'if(process.env.REMORA_ACTIVE==="1"&&o==="compact"){n=__calicoCompactWrapFetch(n)}';
+      // Minified locals differ per platform build of the same version (e.g.
+      // 2.1.238 macos-arm64 destructures fetchOverride into `n`, linux/windows
+      // arm64 into `r`), so the inject is matched by shape with the source and
+      // fetchOverride locals captured, never pinned.
+      const wrapInjectPattern =
+        /if\(process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*==="compact"\)\{([A-Za-z_$][\w$]*)=__calicoCompactWrapFetch\(\1\)\}/g;
       // 2.1.238 appends `,credentials:s` to the factory parameter object; the
       // signature tail after `agentContext:i` is matched generically.
       const ownedFactory =
-        /async function [A-Za-z_$][\w$]*\(\{apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{if\(process\.env\.REMORA_ACTIVE==="1"&&o==="compact"\)\{n=__calicoCompactWrapFetch\(n\)\}/;
+        /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:[A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{if\(process\.env\.REMORA_ACTIVE==="1"&&\2==="compact"\)\{\1=__calicoCompactWrapFetch\(\1\)\}/;
       const factoryMatch = ownedFactory.exec(content);
       if (!factoryMatch || factoryMatch.index === undefined) {
         return "compact fetch wrap is not owned by the Zie client factory";
       }
-      if (countOccurrences(content, wrapInject) !== 1) {
+      const wrapInjectMatches = content.match(wrapInjectPattern) ?? [];
+      if (wrapInjectMatches.length !== 1) {
         return "expected exactly one compact fetch wrap inject at Zie factory";
       }
       const factoryIndex = factoryMatch.index;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1067,11 +1067,22 @@ const CHECKS: Check[] = [
         "CALICO_CONTEXT_DISPLAY_PERCENT",
         "__calico_context_window",
         "__calico_display_window",
-        "CALICO_MODEL_CONTEXT_WINDOWS?o:o-r",
         "if(process.env.CALICO_MODEL_CONTEXT_WINDOWS)return",
       ];
       const missing = required.filter((marker) => !content.includes(marker));
-      return missing.length > 0 ? `missing marker(s): ${missing.join(", ")}` : null;
+      if (missing.length > 0) {
+        return `missing marker(s): ${missing.join(", ")}`;
+      }
+      // The effective-window gate reads `CALICO_MODEL_CONTEXT_WINDOWS?<window>:<window>-<reserve>`,
+      // where both are minified locals that differ per platform build of the
+      // same version (arm64 swaps the reserve/ctx bindings, yielding `?o:o-n`
+      // instead of `?o:o-r`). Match the shape with the window local
+      // backreferenced instead of pinning `o`/`r`.
+      const effectiveGate =
+        /CALICO_MODEL_CONTEXT_WINDOWS\?([A-Za-z_$][\w$]*):\1-[A-Za-z_$][\w$]*/;
+      return effectiveGate.test(content)
+        ? null
+        : "missing effective-window gate (CALICO_MODEL_CONTEXT_WINDOWS?<window>:<window>-<reserve>)";
     },
   },
   {

--- a/tests/active-turn-prompt-id.test.js
+++ b/tests/active-turn-prompt-id.test.js
@@ -27,6 +27,18 @@ async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agent
 async function Next(){}
 `;
 
+// 2.1.238 appends `,credentials:s` to the Zie parameter object, which consumes
+// the `s` binding and shifts the following minified locals by one letter
+// (`c=…,u=…,p={` → `u=…,d=…,f={`, and the header spread `...u,` → `...d,`).
+const fixture238 = fixture
+  .replace("source:o,agentContext:i}", "source:o,agentContext:i,credentials:cred}")
+  .replace("c=$pe(i)?void 0:i,u=kAi(),p={", "u=$pe(i)?void 0:i,d=kAi(),f={")
+  .replace('"X-Claude-Code-Session-Id":xt(),...u,', '"X-Claude-Code-Session-Id":xt(),...d,')
+  .replace(
+    '...c?.agentId&&{"x-claude-code-agent-id":bhi(c.agentId)},...c?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(c.parentAgentId)}};return p}',
+    '...u?.agentId&&{"x-claude-code-agent-id":bhi(u.agentId)},...u?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(u.parentAgentId)}};return f}'
+  );
+
 test("freezes an agent prompt id and emits it only for remora", async () => {
   const result = patchActiveTurnPromptIdentity(fixture);
   assert.equal(result.candidates, 2);
@@ -108,6 +120,30 @@ test("plain Calico launch does not mutate agent context", () => {
   const agent = { agentType: "subagent", agentId: "agent-a" };
   context.iK(agent, () => undefined);
   assert.equal(agent.__calicoPromptId, undefined);
+});
+
+test("emits the prompt id on the 2.1.238 credentials/shifted-local shape", async () => {
+  const result = patchActiveTurnPromptIdentity(fixture238);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 2);
+  assert.equal(evaluatePatchModule("active-turn-prompt-id", result.content), null);
+
+  const context = { process: { env: { REMORA_ACTIVE: "1" } } };
+  vm.createContext(context);
+  vm.runInContext(result.content, context);
+
+  const mainHeaders = await context.Zie({
+    source: "repl_main_thread",
+    agentContext: { agentType: "main", agentId: "session-a" },
+  });
+  assert.equal(mainHeaders["x-calico-prompt-id"], "turn-a");
+  assert.equal(mainHeaders["x-calico-active-turn-version"], "1");
+
+  const auxHeaders = await context.Zie({
+    source: "quota_check",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(auxHeaders["x-calico-prompt-id"], undefined);
 });
 
 test("fails atomically when either required anchor is missing", () => {

--- a/tests/active-turn-prompt-id.test.js
+++ b/tests/active-turn-prompt-id.test.js
@@ -146,6 +146,32 @@ test("emits the prompt id on the 2.1.238 credentials/shifted-local shape", async
   assert.equal(auxHeaders["x-calico-prompt-id"], undefined);
 });
 
+// linux-arm64 and windows-arm64 builds of 2.1.238 swap the minified locals
+// for model/fetchOverride (`model:n,fetchOverride:r`) in the same factory;
+// the signature matcher captures locals instead of pinning them.
+const fixtureSwapped = fixture238.replace(
+  "model:r,fetchOverride:n,",
+  "model:n,fetchOverride:r,"
+);
+
+test("emits the prompt id when model/fetchOverride locals are swapped", async () => {
+  const result = patchActiveTurnPromptIdentity(fixtureSwapped);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 2);
+  assert.equal(evaluatePatchModule("active-turn-prompt-id", result.content), null);
+
+  const context = { process: { env: { REMORA_ACTIVE: "1" } } };
+  vm.createContext(context);
+  vm.runInContext(result.content, context);
+
+  const mainHeaders = await context.Zie({
+    source: "repl_main_thread",
+    agentContext: { agentType: "main", agentId: "session-a" },
+  });
+  assert.equal(mainHeaders["x-calico-prompt-id"], "turn-a");
+  assert.equal(mainHeaders["x-calico-active-turn-version"], "1");
+});
+
 test("fails atomically when either required anchor is missing", () => {
   const withoutAgentBoundary = fixture.replace(
     'function iK(e,t){return Pkr.run(e,t)}',

--- a/tests/compact-body-policy.test.js
+++ b/tests/compact-body-policy.test.js
@@ -16,6 +16,14 @@ async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agent
 async function Next(){}
 `;
 
+// 2.1.238 appends `,credentials:s` to the Zie parameter object. The body-policy
+// wrap is injected at the signature boundary and reads only `o`/`n`, so the
+// extra destructured binding is all that must be tolerated here.
+const fixture238 = fixture.replace(
+  "source:o,agentContext:i}",
+  "source:o,agentContext:i,credentials:cred}"
+);
+
 function runPatched(content, env = { REMORA_ACTIVE: "1" }) {
   const context = {
     process: { env: { ...env } },
@@ -165,6 +173,21 @@ test("composes with compact-request-source header module", async () => {
   const rewritten = JSON.parse(calls[0].init.body);
   assert.equal(rewritten.output_config.effort, "medium");
   assert.deepEqual(rewritten.thinking, { type: "adaptive" });
+});
+
+test("wraps and rewrites on the 2.1.238 credentials signature shape", async () => {
+  const result = patchCompactBodyPolicy(fixture238);
+  assert.equal(result.candidates, 1);
+  assert.equal(result.patched, 1);
+
+  const context = runPatched(result.content);
+  const { calls } = await callWrappedFetch(context, "compact", {
+    model: "gpt-5.6-sol",
+    output_config: { effort: "xhigh" },
+    thinking: { type: "adaptive" },
+  });
+  const rewritten = JSON.parse(calls[0].init.body);
+  assert.equal(rewritten.output_config.effort, "medium");
 });
 
 test("fails atomically when Zie anchor is missing", () => {

--- a/tests/compact-body-policy.test.js
+++ b/tests/compact-body-policy.test.js
@@ -6,6 +6,7 @@ const {
   patchCompactBodyPolicy,
   patchCompactRequestSource,
 } = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
 
 // Zie shape matches compact-request-source / active-turn anchors (Session-Id is a call).
 // Returns headers plus the (possibly wrapped) fetch for body-rewrite assertions.
@@ -190,10 +191,39 @@ test("wraps and rewrites on the 2.1.238 credentials signature shape", async () =
   assert.equal(rewritten.output_config.effort, "medium");
 });
 
+// linux-arm64 and windows-arm64 builds of 2.1.238 swap the minified locals
+// for model/fetchOverride (`model:n,fetchOverride:r`). The wrap must follow
+// the captured fetchOverride local; a pinned `n` would wrap the model string.
+const fixtureSwapped = fixture238
+  .replace("model:r,fetchOverride:n,", "model:n,fetchOverride:r,")
+  .replace("return{headers:p,fetch:n}", "return{headers:p,fetch:r}");
+
+test("wraps the swapped fetchOverride local on cross-platform builds", async () => {
+  const result = patchCompactBodyPolicy(fixtureSwapped);
+  assert.equal(result.candidates, 1);
+  assert.equal(result.patched, 1);
+  assert.equal(evaluatePatchModule("compact-body-policy", result.content), null);
+  assert.match(
+    result.content,
+    /&&o==="compact"\)\{r=__calicoCompactWrapFetch\(r\)\}/
+  );
+
+  const context = runPatched(result.content);
+  const { calls } = await callWrappedFetch(context, "compact", {
+    model: "gpt-5.6-sol",
+    output_config: { effort: "xhigh" },
+  });
+  const rewritten = JSON.parse(calls[0].init.body);
+  assert.equal(rewritten.output_config.effort, "medium");
+  assert.equal(rewritten.model, "gpt-5.6-sol");
+});
+
 test("fails atomically when Zie anchor is missing", () => {
+  // Rename the destructured property itself; renaming only the minified
+  // local must NOT break the anchor (that varies per platform build).
   const broken = fixture.replace(
     "source:o,agentContext:i",
-    "source:querySource,agentContext:i"
+    "src:o,agentContext:i"
   );
   const result = patchCompactBodyPolicy(broken);
   assert.equal(result.patched, 0);

--- a/tests/compact-request-source.test.js
+++ b/tests/compact-request-source.test.js
@@ -6,6 +6,7 @@ const {
   patchCompactRequestSource,
   patchActiveTurnPromptIdentity,
 } = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
 
 const fixture = `
 var Pt={promptId:"turn-a"},lastContext;
@@ -133,6 +134,31 @@ test("composes with active-turn without dropping either header set", async () =>
   assert.equal(mainHeaders["x-calico-request-source"], undefined);
 });
 
+// No shipped build has renamed the `source` local yet, but the lesson from the
+// model/fetchOverride swap is that any minified local can differ per platform
+// build. Rename it here so the composed header-order verifier check cannot
+// silently re-pin `o`.
+const fixtureRenamedSource = fixture.replace(
+  "fetchOverride:n,source:o,agentContext:i",
+  "fetchOverride:n,source:q,agentContext:i"
+);
+
+test("composed verifier check accepts a renamed source local", async () => {
+  const withActive = patchActiveTurnPromptIdentity(fixtureRenamedSource);
+  assert.equal(withActive.patched, 2);
+  const withBoth = patchCompactRequestSource(withActive.content);
+  assert.equal(withBoth.patched, 1);
+  assert.equal(evaluatePatchModule("active-turn-prompt-id", withBoth.content), null);
+  assert.equal(evaluatePatchModule("compact-request-source", withBoth.content), null);
+
+  const context = runPatched(withBoth.content);
+  const compactHeaders = await context.Zie({
+    source: "compact",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(compactHeaders["x-calico-request-source"], "compact");
+});
+
 test("owns the compact header on the 2.1.238 credentials/shifted-local shape", async () => {
   const result = patchCompactRequestSource(fixture238);
   assert.equal(result.candidates, 1);
@@ -158,10 +184,34 @@ test("owns the compact header on the 2.1.238 credentials/shifted-local shape", a
   assert.equal(mainHeaders["X-Calico-Request-Source"], undefined);
 });
 
+// linux-arm64 and windows-arm64 builds of 2.1.238 destructure the same
+// factory with the model/fetchOverride locals swapped
+// (`model:n,fetchOverride:r`); locals are captured, never pinned.
+const fixtureSwapped = fixture238.replace(
+  "model:r,fetchOverride:n,",
+  "model:n,fetchOverride:r,"
+);
+
+test("owns the compact header when model/fetchOverride locals are swapped", async () => {
+  const result = patchCompactRequestSource(fixtureSwapped);
+  assert.equal(result.candidates, 1);
+  assert.equal(result.patched, 1);
+  assert.equal(evaluatePatchModule("compact-request-source", result.content), null);
+
+  const context = runPatched(result.content);
+  const compactHeaders = await context.Zie({
+    source: "compact",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(compactHeaders["x-calico-request-source"], "compact");
+});
+
 test("fails atomically when the client factory anchor is missing", () => {
+  // Rename the destructured property itself; renaming only the minified
+  // local must NOT break the anchor (that varies per platform build).
   const broken = fixture.replace(
     "source:o,agentContext:i",
-    "source:querySource,agentContext:i"
+    "src:o,agentContext:i"
   );
   const result = patchCompactRequestSource(broken);
   assert.equal(result.patched, 0);

--- a/tests/compact-request-source.test.js
+++ b/tests/compact-request-source.test.js
@@ -25,6 +25,18 @@ async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agent
 async function Next(){}
 `;
 
+// 2.1.238 appends `,credentials:s` to the Zie parameter object, which consumes
+// the `s` binding and shifts the following minified locals by one letter
+// (`c=…,u=…,p={` → `u=…,d=…,f={`, and the header spread `...u,` → `...d,`).
+const fixture238 = fixture
+  .replace("source:o,agentContext:i}", "source:o,agentContext:i,credentials:cred}")
+  .replace("c=$pe(i)?void 0:i,u=kAi(),p={", "u=$pe(i)?void 0:i,d=kAi(),f={")
+  .replace('"X-Claude-Code-Session-Id":xt(),...u,', '"X-Claude-Code-Session-Id":xt(),...d,')
+  .replace(
+    '...c?.agentId&&{"x-claude-code-agent-id":bhi(c.agentId)},...c?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(c.parentAgentId)}};return p}',
+    '...u?.agentId&&{"x-claude-code-agent-id":bhi(u.agentId)},...u?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(u.parentAgentId)}};return f}'
+  );
+
 function runPatched(content, env = { REMORA_ACTIVE: "1" }) {
   const context = { process: { env: { ...env } } };
   vm.createContext(context);
@@ -119,6 +131,31 @@ test("composes with active-turn without dropping either header set", async () =>
   });
   assert.equal(mainHeaders["x-calico-prompt-id"], "turn-a");
   assert.equal(mainHeaders["x-calico-request-source"], undefined);
+});
+
+test("owns the compact header on the 2.1.238 credentials/shifted-local shape", async () => {
+  const result = patchCompactRequestSource(fixture238);
+  assert.equal(result.candidates, 1);
+  assert.equal(result.patched, 1);
+
+  const context = runPatched(result.content);
+  context.customHeaders = {
+    "X-Calico-Request-Source": "compact",
+    "x-keep": "1",
+  };
+  const compactHeaders = await context.Zie({
+    source: "compact",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(compactHeaders["x-calico-request-source"], "compact");
+  assert.equal(compactHeaders["x-keep"], "1");
+
+  const mainHeaders = await context.Zie({
+    source: "repl_main_thread",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(mainHeaders["x-calico-request-source"], undefined);
+  assert.equal(mainHeaders["X-Calico-Request-Source"], undefined);
 });
 
 test("fails atomically when the client factory anchor is missing", () => {

--- a/tests/dollar-identifier-replacement-safety.test.js
+++ b/tests/dollar-identifier-replacement-safety.test.js
@@ -1,0 +1,130 @@
+// Regression tests for the class of bug where a captured minified identifier
+// is interpolated into a String.replace REPLACEMENT string. `$` sequences in
+// that string are special to the replace engine (`$1`-`$9` against a regex
+// searchValue's capture groups, and `$$`/`$&` against both regex and string
+// searchValues), and this bundle's identifier grammar
+// (`[A-Za-z_$][\w$]*`) allows minifiers to hand back names containing `$`.
+//
+// Each fixture below binds a captured local to a name chosen to trigger one
+// of those expansions, then asserts the INJECTED CODE actually reads that
+// exact identifier at runtime — not merely that the patcher's own regex
+// still matched.
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  patchActiveTurnPromptIdentity,
+  patchCompactRequestSource,
+} = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
+
+const baseFixture = `
+var Pt={promptId:"turn-a"},lastContext;
+var currentContext;
+var Pkr={getStore:()=>currentContext,run:(context,callback)=>{let previous=currentContext;lastContext=context;currentContext=context;try{return callback()}finally{currentContext=previous}}};
+function xht(){return Pt.promptId}function $$t(e){Pt.promptId=e}
+function TN(e){if(e===void 0)return;if(e.startsWith("repl_main_thread")||e==="sdk")return"main";if(e.startsWith("agent:")||e==="hook_agent")return"subagent";return"auxiliary"}
+function iK(e,t){return Pkr.run(e,t)}function c_(){return{agentType:"main",agentId:xt()}}
+function $pe(e){return e.agentType==="main"}
+function kAi(){return customHeaders}
+var customHeaders={};
+function bs(){return false}
+function dfe(){return"fixture"}
+function xt(){return"session-a"}
+function bhi(e){return e}
+async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i}){let s=process.env.CLAUDE_CODE_CONTAINER_ID,a=process.env.CLAUDE_CODE_REMOTE_SESSION_ID,l=process.env.CLAUDE_AGENT_SDK_CLIENT_APP,c=$pe(i)?void 0:i,u=kAi(),p={"x-app":bs()?"cli-bg":"cli","User-Agent":dfe(),"X-Claude-Code-Session-Id":xt(),...u,...s&&{"x-claude-remote-container-id":s},...a&&{"x-claude-remote-session-id":a},...l&&{"x-client-app":l},...c?.agentId&&{"x-claude-code-agent-id":bhi(c.agentId)},...c?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(c.parentAgentId)}};return p}
+async function Next(){}
+`;
+
+function runPatched(content, env = { REMORA_ACTIVE: "1" }) {
+  const context = { process: { env: { ...env } } };
+  vm.createContext(context);
+  vm.runInContext(content, context);
+  return context;
+}
+
+// --- Site: patchActiveTurnPromptIdentity's localsPattern replace ----------
+// localsPattern is a REGEX with 5 capture groups, so both the `$1`-`$9`
+// backreference rule and the `$$` collapse rule apply. sourceParam is bound
+// to `$1e` (group 1 of localsPattern is contextLocal `c`) and agentContext's
+// param is bound to `$$x`, exercising both rules in one fixture.
+const dollarSourceFixture = baseFixture
+  .replace("source:o,agentContext:i}", "source:$1e,agentContext:$$x}")
+  .replace("c=$pe(i)?void 0:i,", "c=$pe($$x)?void 0:$$x,");
+
+test("active-turn injection binds a $1e-named source and $$x-named context verbatim", async () => {
+  const result = patchActiveTurnPromptIdentity(dollarSourceFixture);
+  assert.equal(result.candidates, 2);
+  assert.equal(result.patched, 2);
+  assert.equal(evaluatePatchModule("active-turn-prompt-id", result.content), null);
+
+  const context = runPatched(result.content);
+
+  const agent = { agentType: "subagent", agentId: "agent-a" };
+  context.iK(agent, () => undefined);
+  assert.equal(agent.__calicoPromptId, "turn-a");
+
+  // If `$1e` were read back as a backreference, the injected call would
+  // reference `ce` (contextLocal `c` + literal `e`) instead of the real
+  // `$1e` parameter, throwing a ReferenceError instead of classifying the
+  // main-thread source and emitting the prompt id.
+  const mainHeaders = await context.Zie({
+    source: "repl_main_thread",
+    agentContext: { agentType: "main", agentId: "session-a" },
+  });
+  assert.equal(mainHeaders["x-calico-prompt-id"], "turn-a");
+  assert.equal(mainHeaders["x-calico-active-turn-version"], "1");
+
+  // Auxiliary sources must still be excluded — this only holds if the
+  // classifier call actually reads the live `$1e` parameter value.
+  const auxHeaders = await context.Zie({
+    source: "quota_check",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(auxHeaders["x-calico-prompt-id"], undefined);
+
+  // If `$$x` had collapsed to `$x` anywhere in the injected text, `$x`
+  // would be an undefined reference and this call would throw instead of
+  // resolving the agent context.
+  const agentHeaders = await context.Zie({
+    source: "agent:custom:executor",
+    agentContext: agent,
+  });
+  assert.equal(agentHeaders["x-calico-prompt-id"], "turn-a");
+});
+
+// --- Site: patchCompactRequestSource's header-spread replace --------------
+// This site's searchValue is a regex with exactly ONE capture group, so a
+// sourceParam literally named `$1` is the sharpest possible probe: if
+// interpolated into a plain replacement string, `$1` expands to the entire
+// captured "X-Claude-Code-Session-Id":xt(),...u, header-spread prefix
+// instead of naming the source parameter.
+const dollarOneSourceFixture = baseFixture.replace(
+  "source:o,agentContext:i}",
+  "source:$1,agentContext:i}"
+);
+
+test("compact-request-source injection binds a $1-named source verbatim", async () => {
+  const result = patchCompactRequestSource(dollarOneSourceFixture);
+  assert.equal(result.candidates, 1);
+  assert.equal(result.patched, 1);
+  assert.equal(evaluatePatchModule("compact-request-source", result.content), null);
+
+  const context = runPatched(result.content);
+
+  // If `$1` had expanded to the header-spread prefix, the guard would not
+  // compile to a comparison against the real parameter, and this would
+  // either throw or silently fail to ever emit the compact header.
+  const compactHeaders = await context.Zie({
+    source: "compact",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(compactHeaders["x-calico-request-source"], "compact");
+
+  const mainHeaders = await context.Zie({
+    source: "repl_main_thread",
+    agentContext: { agentType: "main" },
+  });
+  assert.equal(mainHeaders["x-calico-request-source"], undefined);
+});

--- a/tests/statusline-committed-usage.test.js
+++ b/tests/statusline-committed-usage.test.js
@@ -54,6 +54,16 @@ function batchCommittedUsageFixture(source = committedUsageFixture) {
     );
 }
 
+function storageV5BatchFixture(source = committedUsageFixture) {
+  // 2.1.238 appends a fifth argument (the storage V5 handle) to the content
+  // builder call inside the batch wrapper:
+  // `ZJr([Zr],n,i.agentId,{...,messageId:wo.id},i.storageV5)`.
+  return batchCommittedUsageFixture(source).replace(
+    ",messageId:wo.id}),n),Kn=",
+    ",messageId:wo.id},i.storageV5),n),Kn="
+  );
+}
+
 const modelsUsedCompletionSignal =
   "function backgroundCompletionSignal(){let ie=BBg(s,e,g),de=Yns(ie,e,{...n,modelsUsed:_},{suppressTelemetry:re});__calicoRefreshAgentUsage(re,ie),Z0u(e,a9r(re),s);return de}";
 
@@ -398,6 +408,27 @@ test("matches the 2.1.236 batch tool-use destructured wrapper", () => {
   const { context, result } = loadCommittedFixture(source);
   const completed = context.query(usage(210, 31), "end_turn");
 
+  assert.match(
+    result.content,
+    /__calicoUsageState:\{committed:!1,usage:null\},\.\.\._&&\{advisorModel:_\},\.\.\.Ie!==void 0&&\{effort:Ie\}/
+  );
+  assert.equal(completed[0].__calicoUsageState.committed, true);
+  assert.deepEqual(readStatuslineUsage(context, completed), usage(210, 31));
+  assert.equal(
+    evaluatePatchModule(
+      "statusline-committed-usage",
+      result.content + modelsUsedCompletionSignal
+    ),
+    null
+  );
+});
+
+test("matches the 2.1.238 batch wrapper with the appended storageV5 argument", () => {
+  const source = storageV5BatchFixture();
+  const { context, result } = loadCommittedFixture(source);
+  const completed = context.query(usage(210, 31), "end_turn");
+
+  assert.match(result.content, /messageId:wo\.id\},i\.storageV5\)/);
   assert.match(
     result.content,
     /__calicoUsageState:\{committed:!1,usage:null\},\.\.\._&&\{advisorModel:_\},\.\.\.Ie!==void 0&&\{effort:Ie\}/

--- a/tests/statusline-committed-usage.test.js
+++ b/tests/statusline-committed-usage.test.js
@@ -370,6 +370,41 @@ test("custom context window display percentage composes with statusline payload"
   );
 });
 
+// arm64 builds of the same version swap the effective-window body locals:
+// `let n=Math.min(...),r=...;return o-n` instead of `let r=...,n=...;return o-r`.
+// The matcher must capture the window/reserve locals, and the verifier marker
+// must not pin `?o:o-r`. Renamed the window local to `w` too, so nothing can
+// re-pin `o` in either the patcher or the verifier.
+const customContextFixtureArm = customContextFixture.replace(
+  "function effective(e,t){let r=Math.min(resolve(e),t),n=precomputeGate()?t:void 0,{window:o}=derive(e,n);return o-r}",
+  "function effective(e,t){let n=Math.min(resolve(e),t),r=precomputeGate()?t:void 0,{window:w}=derive(e,r);return w-n}"
+);
+
+test("custom context window matches swapped arm64 effective-window locals", () => {
+  const result = patchCustomContextWindows(customContextFixtureArm);
+  assert.equal(result.candidates, 4);
+  assert.equal(result.patched, 4);
+  assert.match(result.content, /CALICO_MODEL_CONTEXT_WINDOWS\?w:w-n/);
+
+  assert.equal(evaluatePatchModule("custom-context-window", result.content), null);
+
+  const context = {
+    process: {
+      env: {
+        CALICO_MODEL_CONTEXT_WINDOWS: JSON.stringify({ "gpt-5.6-sol": 372000 }),
+        CALICO_CONTEXT_DISPLAY_PERCENT: "95",
+      },
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(result.content, context);
+  assert.equal(context.resolve("gpt-5.6-sol", []), 372000);
+  assert.equal(
+    context.status((_usage, windowValue) => windowValue, {}, 372000).context_window,
+    353400
+  );
+});
+
 test("matches renamed wrapper, terminal, selector, and clone locals", () => {
   const renamed = renamedCommittedUsageFixture();
   const { context, result } = loadCommittedFixture(renamed);


### PR DESCRIPTION
Restores four patch modules broken by upstream 2.1.238 and stops three classes of matcher fragility that let them break silently.

CI has published no patched release since 2.1.235 on 2026-08-18. **This branch has been dispatched through the full pipeline and all five platforms pass**; the 2.1.238 releases visible on this repo were produced by that run.

## What upstream changed

**A fifth argument on the content builder** — breaks `statusline-committed-usage`:

```js
// 2.1.237
Gio([Ga],n,i.agentId,{requestId:Te??void 0,messageId:Gr.id})
// 2.1.238
Gio([Ga],n,i.agentId,{requestId:Te??void 0,messageId:Gr.id},i.storageV5)
```

**A `credentials` parameter on the shared client factory** — breaks the three remora adapters. Appending it consumed a name and shifted every following body local by one letter:

```js
// 2.1.237
Zie({apiKey:e,…,source:o,agentContext:i}){…,c=…(i)?void 0:i,u=…(),p={…,...u,…}}
// 2.1.238
Tme({apiKey:e,…,source:o,agentContext:i,credentials:s}){…,u=…(i)?void 0:i,d=…(),f={…,...d,…}}
```

## The part that was not a version problem

The same version produces **different minified locals per platform**:

```js
// macos-arm64
async function Tme({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i,credentials:s})
// linux-arm64 and win32-arm64
async function _me({apiKey:e,maxRetries:t,model:n,fetchOverride:r,source:o,agentContext:i,credentials:s})
```

`model` and `fetchOverride` are swapped. A fix validated only on macos-arm64 passes CI on three platforms and fails on two — which is exactly what happened between the first and second commits here.

**The dangerous instance was not a matcher.** `compact-body-policy` injected code around a hardcoded `n`. That is `fetchOverride` on three platforms and `model` on the two arm64 builds, so a successful match there would have wrapped the model string as if it were a fetch function. The matcher failing on those platforms was luck, not protection.

## The fourth instance was in the verifier

`custom-context-window` passed the patcher and failed verification:

```
FAIL custom-context-window
missing marker(s): CALICO_MODEL_CONTEXT_WINDOWS?o:o-r
```

The marker string itself embedded minified locals. Investigating it also found the patcher matching **3/4** candidates on the two arm64 platforms rather than 4/4 — one site silently unmatched because its pattern pinned `let r=Math.min(...)`, where `r` and `n` are swapped on those builds. `patched == candidates` meant `--assert-all` never complained. That is the same shape that let a broken `thinking-streaming` ship for three days.

## Verification

Every module against every platform bundle, before and after:

| Module | 237-mac | 238-mac | 238-lx64 | 238-larm | 238-wx64 | 238-warm |
|---|---|---|---|---|---|---|
| GatewayFastMode | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 |
| ActiveTurnPromptIdentity | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 |
| CompactRequestSource | 1/1 | 1/1 | 1/1 | 1/1 | 1/1 | 1/1 |
| CompactBodyPolicy | 1/1 | 1/1 | 1/1 | 1/1 | 1/1 | 1/1 |
| BackgroundAgentUsage | 4/4 | 4/4 | 4/4 | 4/4 | 4/4 | 4/4 |
| StatuslineCommittedUsage | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 |
| StatuslineRateLimitWindows | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 |
| CustomContextWindows | 4/4 | 4/4 | 4/4 | 4/4 | 4/4 | 4/4 |

Before this branch, the four broken modules read `1/0`, `0/0`, `0/0` and `5/0` on every 2.1.238 bundle, and `CustomContextWindows` read `3/3` on the two arm64 platforms.

`npm test` 113. Every new test was mutation-checked — one mutation initially produced no failure at all (a verifier widening had nothing guarding it), and a test was added before that widening was accepted.

**Full pipeline, all five platforms green**, which is what actually produced the 2.1.238 releases. This is the check I skipped before merging #7, and it is why #7 looked complete while `main` still could not build a release.

## Playbook

Three rules added, covering what the existing ones did not: injected code may never name a minified local; the same rule holds across platforms, not just across versions; and a falling candidate count is silent, so a changed count must be explained rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeGTwEV8Xdgj9ngxHPjptK
