### PR TITLE
fix(patch): restore native patching for the chunked 2.1.242+ bundle

### DIFF
--- a/.github/workflows/patch-claude.yml
+++ b/.github/workflows/patch-claude.yml
@@ -211,6 +211,30 @@ jobs:
           CONFIG_DIR="$(mktemp -d)"
           export CLAUDE_CONFIG_DIR="$CONFIG_DIR"
 
+          # Seed onboarding and folder-trust state so the launch reaches the main
+          # renderer. Without this the TUI stops at the theme picker and the
+          # fullscreen renderer never mounts, which is where a 2.1.245 build died
+          # with "__cc_streamingThinkingSelector is not defined" while this smoke
+          # test still passed: an injected helper had landed in the wrong Bun
+          # chunk, and nothing before the main renderer touches it.
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.argv[1], JSON.stringify({
+              hasCompletedOnboarding: true,
+              theme: "dark",
+              numStartups: 9,
+              installMethod: "native",
+              projects: {
+                [process.argv[2]]: {
+                  hasTrustDialogAccepted: true,
+                  hasCompletedProjectOnboarding: true,
+                  allowedTools: [],
+                  history: [],
+                },
+              },
+            }));
+          ' "$CONFIG_DIR/.claude.json" "$PWD"
+
           # Launch the patched TUI under a pseudo-terminal so the welcome banner
           # renders. BSD (macOS) and util-linux `script` take different arguments.
           if [ "$RUNNER_OS" = "macOS" ]; then
@@ -264,6 +288,14 @@ jobs:
           # -a: the pty capture may contain control bytes that trip binary detection.
           if ! grep -aqiE "Calico ?Claude" "$CLEAN"; then
             echo "PTY smoke test failed: 'Calico Claude' branding not found in TUI output." >&2
+            exit 1
+          fi
+
+          # Branding alone renders before the main renderer mounts. The shortcut
+          # hint is drawn by the main renderer's status line, so it is what
+          # proves the fullscreen UI actually came up.
+          if ! grep -aqiE "for ?shortcuts" "$CLEAN"; then
+            echo "PTY smoke test failed: main renderer did not mount (no status-line hint)." >&2
             exit 1
           fi
 

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -83,7 +83,42 @@ These rules are not style preferences. They are what keeps the patcher alive acr
 - **A falling candidate count is silent.** `--assert-all` only fails a module at `patched == 0`, so a
   matcher that quietly stops matching one of its sites still ships. Four separate defects have hidden
   this way. When a count changes, find out why before assuming the bundle changed rather than the
-  matcher.
+  matcher. In 2.1.245 two of these turned out to be real breakage that only
+  `scripts/verify-patched-binary.ts` caught: `thinking-streaming` at 11/11 with the renderer prop
+  missing entirely, and `welcome-badge` at 8/8 with the branding gone.
+- **The bundle is many ES module scopes, not one.** From 2.1.242 upstream ships `/$bunfs/root/cli`
+  as a loader over ~1,380 `chunk-*.js` modules. `scripts/native-bun.ts` joins them into the single
+  text the patcher sees, but they are still separate scopes when the binary runs. Three consequences,
+  each of which produced a defect that every text-level check reported as success:
+  - **An injected helper must be reachable from where it is called.** A `function __calicoX(){}`
+    declared in one chunk is undefined in another. `custom-context-window` declared
+    `__calico_display_window` at the resolver site and called it at the status-line site, which
+    upstream now places in a different chunk. Declare the helper in the chunk that uses it, or hang
+    it off `globalThis` — `globalThis.__calicoX` is the convention here, and `native-bun.ts` fails
+    the write when a chunk references a bare `__calico*` it does not declare.
+  - **A minified name captured at one site cannot be emitted at another.** Chunks import each other
+    under per-chunk aliases, so the same helper is `po` in one chunk and `a` in the next. Anything
+    that captures a name at site A and writes it at site B is broken by construction. Route it
+    through a `globalThis.__calico*` published at the declaration instead — that is what
+    `active-turn-prompt-id` does for the prompt getter and the query-source classifier.
+  - **Minified names are no longer unique.** 2.1.245 declares an unrelated `function Bne(` while the
+    status-line chunk imports the usage reducer *as* `Bne`, so looking a callee up by name finds the
+    wrong function. Cross-site name equalities are not reconstructible from the joined text; re-anchor
+    on structure and consumption instead (`statusline-committed-usage` now pins the selector by its
+    position after the `?.outputStyle||` assignment and by its result feeding `context_window:`).
+    Where the equality is still worth keeping, `verify-patched-binary.ts` has `inSameModule`, which
+    uses the boundary markers to enforce it only between sites that share a module.
+- **A compiler-cached call site needs its own cache slot.** Some 2.1.245 renderer call sites sit
+  inside a React-compiler memo cache (`let ju=v(19);…if(ju[13]!==ph)qu=o(C,{…}),ju[13]=ph,ju[15]=qu`).
+  Adding a prop there is not enough: the element is only rebuilt when a compared slot changes, so an
+  injected value that occupies no slot leaves the renderer showing a stale element forever while the
+  patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
+  slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **The JSX factory and the React hooks are destructured now.** `Ag.jsx(C,props)` is `o(C,props)`,
+  `Pw.useMemo(...)` is `te(...)`, `crypto.randomUUID()` is `ESe()`, and a module-level singleton
+  `br.requestJournal` is `n().requestJournal`. Six modules broke on exactly this. Never require the
+  member form: capture the whole callee expression, emit it back verbatim, and anchor on the prop
+  names or call shape around it.
 
 ## Native Patching Flow
 
@@ -92,11 +127,19 @@ These rules are not style preferences. They are what keeps the patcher alive acr
 - resolves `--input` and `--output`
 - copies the input binary to the output path when patching out-of-place
 - loads `scripts/native-bun.ts`
-- extracts the embedded JS from the Bun container, including 2.1.233 `/root/cli` entry modules
+- extracts every JavaScript module from the Bun container (selected by loader tag, not by name, so
+  nothing depends on upstream's chunk naming) and joins them with
+  `\n/*@@calico-bun-module-boundary@@*/\n`. Before 2.1.242 that is the `/root/cli` bundle plus five
+  small worker stubs; from 2.1.242 it is the cli loader plus ~1,380 `chunk-*.js` modules.
 - writes that JS to a temp `content.js`
 - invokes `node patch-claude-display.ts --file <temp-content.js>`
 - reads the patched temp file back
-- writes it into the output binary with the platform-specific native writer
+- splits it on the same boundary marker, failing if the section count changed, and rejects any module
+  that references a bare `__calico*` identifier it does not itself declare (see the ES module scope
+  rule above)
+- writes each module's content back into the output binary with the platform-specific native writer.
+  `rebuildBunData` recomputes every module's offset and length from the rebuilt layout, so per-module
+  contents are free to change size and the module table needs no separate fixup.
 
 Important behavior:
 

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -93,9 +93,23 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   - **An injected helper must be reachable from where it is called.** A `function __calicoX(){}`
     declared in one chunk is undefined in another. `custom-context-window` declared
     `__calico_display_window` at the resolver site and called it at the status-line site, which
-    upstream now places in a different chunk. Declare the helper in the chunk that uses it, or hang
-    it off `globalThis` — `globalThis.__calicoX` is the convention here, and `native-bun.ts` fails
-    the write when a chunk references a bare `__calico*` it does not declare.
+    upstream now places in a different chunk. `native-bun.ts` fails the write when a chunk
+    references a bare `__calico*`/`__cc_*` it does not itself declare.
+  - **`globalThis` does not fix that on its own — evaluation order does.** Publishing a helper as
+    `globalThis.__calicoX=…` in one chunk and reading it from another only works if the reading
+    chunk statically imports the publishing one, transitively; otherwise the publisher may not have
+    run yet. Only **8 of 1,384** modules in 2.1.245 are statically reachable from the cli entry —
+    every other chunk arrives through dynamic `import()` — so "it will have been evaluated by then"
+    is never a safe assumption. A build that published the gateway helpers from an unreachable
+    chunk threw `globalThis.__calicoGatewayFastApply is not a function` on **every request** and
+    produced no assistant output at all, while `--assert-all`, the module-scope guard and every
+    verifier marker check passed. **Prefer a self-contained copy per consuming chunk** — that is
+    what `gateway-fast-mode` (three copies, reconciled at runtime through
+    `CALICO_GATEWAY_FAST_STATE_FILE`) and `statusline-committed-usage` (two copies of the pure
+    predicates) now do, and it cannot be broken by re-chunking. Use `globalThis` only when the
+    helper wraps upstream code that cannot be copied, and rely on
+    `verify-patched-binary.ts`'s `cross-module-globals` check, which builds the static import graph
+    and fails the build when a consumer cannot reach its publisher.
   - **A minified name captured at one site cannot be emitted at another.** Chunks import each other
     under per-chunk aliases, so the same helper is `po` in one chunk and `a` in the next. Anything
     that captures a name at site A and writes it at site B is broken by construction. Route it
@@ -114,6 +128,12 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   injected value that occupies no slot leaves the renderer showing a stale element forever while the
   patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
   slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **A replacement must be anchored to the site you located, not to its text.** `output.replace(
+  "function kC(", …)` rewrites the *first* match in the whole joined bundle, and minified names are
+  not unique across chunks — `function kC(` occurs four times in 2.1.245. A `thinking-streaming`
+  build inserted its helper before an unrelated `kC` in another chunk and died at startup with
+  `__cc_streamingThinkingSelector is not defined`. Compute the enclosing region from the offsets you
+  already have, assert each edit target occurs exactly once inside it, and splice by index.
 - **The JSX factory and the React hooks are destructured now.** `Ag.jsx(C,props)` is `o(C,props)`,
   `Pw.useMemo(...)` is `te(...)`, `crypto.randomUUID()` is `ESe()`, and a module-level singleton
   `br.requestJournal` is `n().requestJournal`. Six modules broke on exactly this. Never require the

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -140,10 +140,10 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   slot in both the guard and the write-back, and assert that wiring in the verifier.
 - **Static checks cannot see a wrong-but-valid call.** Three of the defects in this episode
   produced a bundle where every text-level assertion passed and the feature was dead or the whole
-  turn was empty. The only thing that caught them was running the binary. `scratchpad/mockapi.js`
-  plus `tui.exp` drive the real TUI against a canned streaming response with no credentials and no
-  network, which reproduces this entire class locally — use it before claiming a rendering or
-  request-path module works.
+  turn was empty. The only thing that caught them was running the binary. `bash tools/local-verify/run.sh <binary>`
+  drives the real TUI against a canned streaming response, in a throwaway seeded config, with no
+  credentials and no network. It reproduces this entire class locally and exits non-zero when the
+  turn renders nothing — run it before claiming a rendering or request-path module works.
 - **A replacement must be anchored to the site you located, not to its text.** `output.replace(
   "function kC(", …)` rewrites the *first* match in the whole joined bundle, and minified names are
   not unique across chunks — `function kC(` occurs four times in 2.1.245. A `thinking-streaming`

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -115,6 +115,16 @@ These rules are not style preferences. They are what keeps the patcher alive acr
     that captures a name at site A and writes it at site B is broken by construction. Route it
     through a `globalThis.__calico*` published at the declaration instead — that is what
     `active-turn-prompt-id` does for the prompt getter and the query-source classifier.
+  - **A name captured at one site must be resolved again at the site that uses it.** This is the
+    same rule as above but it bites hardest with *upstream* names, which no `__calico*` guard covers.
+    `thinking-streaming` captured the create-message helper at the transcript-extras site (chunk 117
+    knows it as `Ah`) and emitted it into the stream reducer's chunk, which imports an unrelated
+    `ypd as Ah`. The reducer then called the wrong function on the first thinking block, and every
+    turn that produced thinking rendered **no assistant output at all** — no error surfaced anywhere,
+    `--assert-all` passed, and the verifier passed. Resolve the helper from its own declaration and
+    require it to be in the same module as the injection: `patch-claude-display.ts` has
+    `inSameModule` for exactly this, and returns null (skipping the injection) rather than emitting a
+    name from another module.
   - **Minified names are no longer unique.** 2.1.245 declares an unrelated `function Bne(` while the
     status-line chunk imports the usage reducer *as* `Bne`, so looking a callee up by name finds the
     wrong function. Cross-site name equalities are not reconstructible from the joined text; re-anchor
@@ -128,6 +138,12 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   injected value that occupies no slot leaves the renderer showing a stale element forever while the
   patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
   slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **Static checks cannot see a wrong-but-valid call.** Three of the defects in this episode
+  produced a bundle where every text-level assertion passed and the feature was dead or the whole
+  turn was empty. The only thing that caught them was running the binary. `scratchpad/mockapi.js`
+  plus `tui.exp` drive the real TUI against a canned streaming response with no credentials and no
+  network, which reproduces this entire class locally — use it before claiming a rendering or
+  request-path module works.
 - **A replacement must be anchored to the site you located, not to its text.** `output.replace(
   "function kC(", …)` rewrites the *first* match in the whole joined bundle, and minified names are
   not unique across chunks — `function kC(` occurs four times in 2.1.245. A `thinking-streaming`

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -887,6 +887,52 @@ function patchThinkingStreaming(content) {
       return full;
     }
   );
+  // 2.1.245 hoists the display guard into its own local
+  // (`ws=so&&hh()&&fUr(d),Zr=ws?n.display:void 0`) instead of inlining it in
+  // the display assignment, so neither branch above reaches it. Without this
+  // the request enables thinking but never asks for summarized text, the API
+  // returns signature-only thinking blocks, and the UI shows the collapsed
+  // placeholder row with no thinking content at all.
+  const thinkingDisplayHoistedGuardPattern = new RegExp(
+    `(${identifierPattern})=(${identifierPattern})\\(process\\.env\\.CLAUDE_CODE_DISABLE_THINKING\\),` +
+      `(${identifierPattern})=(${identifierPattern})\\.type!=="disabled"&&!\\1,` +
+      `((${identifierPattern})=\\3&&${identifierPattern}\\(\\)&&${identifierPattern}\\(${identifierPattern}\\)),` +
+      `(${identifierPattern})=\\6\\?\\4\\.display(?:\\?\\?void 0)?:void 0,` +
+      `(${identifierPattern})=void 0;`,
+    "g"
+  );
+  output = output.replace(
+    thinkingDisplayHoistedGuardPattern,
+    (
+      full,
+      disableThinkingVar,
+      envFlagHelper,
+      enabledVar,
+      thinkingConfigVar,
+      guardAssignment,
+      guardVar,
+      displayVar,
+      requestVar
+    ) => {
+      displayCandidates += 1;
+      if (full.includes('display??"summarized"')) {
+        return full;
+      }
+
+      const replacement =
+        `${disableThinkingVar}=${envFlagHelper}(process.env.CLAUDE_CODE_DISABLE_THINKING),` +
+        `${enabledVar}=${thinkingConfigVar}.type!=="disabled"&&!${disableThinkingVar},` +
+        `${guardAssignment},` +
+        `${displayVar}=${guardVar}?${thinkingConfigVar}.display??"summarized":void 0,` +
+        `${requestVar}=void 0;`;
+      if (replacement !== full) {
+        displayPatched += 1;
+        return replacement;
+      }
+      return full;
+    }
+  );
+
   candidates += displayCandidates;
   patched += displayPatched;
 
@@ -2562,10 +2608,12 @@ function patchStatuslineCommittedUsage(content) {
     return { content: original, candidates, patched: 0 };
   }
 
+  const predicateHelpers =
+    'function __calicoUsageHasAccountingSignal(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)}' +
+    'function __calicoUsageIsExactAllZero(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)}';
   const accountingHelper =
-    'globalThis.__calicoUsageHasAccountingSignal=function(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)};' +
-    'globalThis.__calicoUsageIsExactAllZero=function(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)};' +
-    'globalThis.__calicoStatuslineMessages=function(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&globalThis.__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})};';
+    predicateHelpers +
+    'function __calicoStatuslineMessages(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})}';
   const wrapperStateNeedle = ",...!1,";
   const wrapperReplacement = wrapperMatch.match[0].replace(
     wrapperStateNeedle,
@@ -2577,7 +2625,7 @@ function patchStatuslineCommittedUsage(content) {
   ) {
     return { content: original, candidates, patched: 0 };
   }
-  const terminalReplacement = `for(let ${terminalItem} of ${terminalArray})${terminalItem}.message.usage=${terminalUsage},${terminalItem}.message.stop_reason=${terminalStop},${terminalItem}.message.stop_details=${terminalRawEvent}.delta.stop_details??null,${terminalStop}!=null&&!globalThis.__calicoUsageIsExactAllZero(${terminalRawEvent}.usage)&&globalThis.__calicoUsageHasAccountingSignal(${terminalUsage})&&(${terminalItem}.__calicoUsageState.committed=!0,${terminalItem}.__calicoUsageState.usage=${terminalUsage});`;
+  const terminalReplacement = `for(let ${terminalItem} of ${terminalArray})${terminalItem}.message.usage=${terminalUsage},${terminalItem}.message.stop_reason=${terminalStop},${terminalItem}.message.stop_details=${terminalRawEvent}.delta.stop_details??null,${terminalStop}!=null&&!__calicoUsageIsExactAllZero(${terminalRawEvent}.usage)&&__calicoUsageHasAccountingSignal(${terminalUsage})&&(${terminalItem}.__calicoUsageState.committed=!0,${terminalItem}.__calicoUsageState.usage=${terminalUsage});`;
   const cloneReplacements = cloneMatches.map(
     (match) => `${cloneArray}.push({src:${match[1]},dst:${match[2]}})`
   );
@@ -2588,7 +2636,7 @@ function patchStatuslineCommittedUsage(content) {
   // The reducer is called through whatever local name this chunk imported it
   // under (selectorMatch[3]), not the name captured at its declaration site.
   const selectorReplacement =
-    `${selectorMatch[1]}${selectorMatch[2]}=${selectorMatch[3]}(globalThis.__calicoStatuslineMessages(${selectorMatch[4]}))` +
+    `${selectorMatch[1]}${selectorMatch[2]}=${selectorMatch[3]}(__calicoStatuslineMessages(${selectorMatch[4]}))` +
     `,${selectorMatch[5]}=${selectorMatch[6]}(${selectorMatch[7]},${selectorMatch[8]}())`;
 
   // wrapperReplacement/terminalReplacement/cloneSyncReplacement interpolate
@@ -2607,8 +2655,25 @@ function patchStatuslineCommittedUsage(content) {
     return { content: original, candidates, patched: 0 };
   }
 
-  output =
-    output.slice(0, functionStart) + accountingHelper + output.slice(functionStart);
+  // The terminal-commit loop calls the two predicates from a different Bun
+  // chunk than the status-line payload builder that carries the helper block,
+  // and neither chunk statically imports the other, so a single shared
+  // definition is not reliably evaluated first. Give that site its own copy of
+  // the two pure predicates; __calicoStatuslineMessages stays single because it
+  // is only called from the selector, in this same function.
+  const terminalCommitIndex = output.indexOf(terminalReplacement);
+  const terminalHelperStart =
+    terminalCommitIndex === -1 ? -1 : output.lastIndexOf("function ", terminalCommitIndex);
+  if (terminalHelperStart === -1) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  for (const [insertAt, helpers] of [
+    [functionStart, accountingHelper],
+    [terminalHelperStart, predicateHelpers],
+  ].sort((a, b) => b[0] - a[0])) {
+    output = output.slice(0, insertAt) + helpers + output.slice(insertAt);
+  }
   output = output.replace(selectorPattern, () => selectorReplacement);
 
   if (
@@ -2617,9 +2682,9 @@ function patchStatuslineCommittedUsage(content) {
     cloneReplacements.some((replacement) => output.split(replacement).length - 1 !== 1) ||
     output.split(cloneSyncReplacement).length - 1 !== 1 ||
     output.split(selectorReplacement).length - 1 !== 1 ||
-    output.split("globalThis.__calicoUsageHasAccountingSignal=").length - 1 !== 1 ||
-    output.split("globalThis.__calicoUsageIsExactAllZero=").length - 1 !== 1 ||
-    output.split("globalThis.__calicoStatuslineMessages=").length - 1 !== 1
+    output.split("function __calicoUsageHasAccountingSignal").length - 1 !== 2 ||
+    output.split("function __calicoUsageIsExactAllZero").length - 1 !== 2 ||
+    output.split("function __calicoStatuslineMessages").length - 1 !== 1
   ) {
     return { content: original, candidates, patched: 0 };
   }
@@ -3042,8 +3107,8 @@ function __calicoGatewayFastRestore(e,t){if(e)process.env.CLAUDE_CODE_EXTRA_BODY
 function __calicoGatewayFastPublish(e,t,r,n){let o=__calicoGatewayFastEnsure();if(!o.path)throw Error("gateway fast state is unavailable");let i=__calicoGatewayFastNode,s=i.path.dirname(o.path),a=i.path.basename(o.path)+"."+process.pid+"."+i.crypto.randomBytes(8).toString("hex")+".tmp",l=i.path.join(s,a),c=!1;try{i.fs.writeFileSync(l,e,{encoding:"utf8",mode:0o600,flag:"wx"});c=!0;i.fs.chmodSync(l,0o600);process.env.CLAUDE_CODE_EXTRA_BODY=t;i.fs.renameSync(l,o.path)}catch(u){__calicoGatewayFastRestore(r,n);if(c)try{i.fs.unlinkSync(l)}catch{}throw u}}
 function __calicoGatewayFastCommandValue(e){let t=typeof e==="string"?e.trim().toLowerCase():"";if(t!==""&&t!=="on"&&t!=="off")return'Unknown argument "'+t+'". Use: /fast [on|off]';try{let r=__calicoGatewayFastRead(),n=Object.prototype.hasOwnProperty.call(process.env,"CLAUDE_CODE_EXTRA_BODY"),o=process.env.CLAUDE_CODE_EXTRA_BODY,i=__calicoGatewayFastParse(o),s;if(t==="on")s="on";else if(t==="off")s="off";else if(r==="on")s="off";else if(r==="off")s="on";else s=__calicoGatewayFastTier(i)?"off":"on";if(s==="on"){__calicoGatewayFastTier(i);i.service_tier="priority"}else delete i.service_tier;let a=JSON.stringify(i);__calicoGatewayFastPublish(s,a,n,o);return s==="on"?"Gateway priority mode ON (this session only)":"Gateway priority mode OFF (this session only)"}catch(r){return"Gateway priority mode error: "+(r&&r.message?r.message:String(r))}}
 function __calicoGatewayFastInteractive(e,t){e(__calicoGatewayFastCommandValue(t));return null}
-globalThis.__calicoGatewayFastThin=function(e){return{type:"text",value:__calicoGatewayFastCommandValue(e)}};
-globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};
+function __calicoGatewayFastThin(e){return{type:"text",value:__calicoGatewayFastCommandValue(e)}}
+function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};
 `;
 
   const interactiveReplacement = interactive[0].replace(
@@ -3052,7 +3117,7 @@ globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="
   );
   const thinReplacement = thin[0].replace(
     `if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`,
-    `if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin(${thin[2]});if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`
+    `if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(${thin[2]});if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`
   );
 
   const jsxDescription =
@@ -3077,7 +3142,7 @@ globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="
 
   const builderReplacement = builderSegment.replace(
     betaMergeNeedle,
-    `${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});${betaMergeNeedle}`
+    `${builder[4]}=__calicoGatewayFastApply(${builder[4]});${betaMergeNeedle}`
   );
   const workerReplacement =
     worker[0] +
@@ -3102,21 +3167,37 @@ globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="
   output = output.replace(builderSegment, builderReplacement);
   output = output.replace(worker[0], workerReplacement);
 
-  const helperIndex = output.indexOf(interactiveReplacement);
-  if (helperIndex === -1) {
+  // The three consumers of these helpers — the interactive handler, the thin
+  // handler and the request extra-body builder — are in three different Bun
+  // chunks on 2.1.242+, and none of them statically imports the others, so a
+  // single shared definition is not reliably evaluated before it is used. A
+  // 2.1.245 build published them on globalThis and died on every request with
+  // "globalThis.__calicoGatewayFastApply is not a function". Each consumer
+  // therefore gets its own module-scoped copy: the block is self-contained, and
+  // the copies reconcile through CALICO_GATEWAY_FAST_STATE_FILE and the state
+  // file itself, so whichever runs first creates the state and the rest adopt
+  // it. On a pre-2.1.242 monolith all three land in one scope, where repeated
+  // function and `var` declarations are legal and Ensure() is idempotent.
+  const helperIndexes = [interactiveReplacement, thinReplacement, builderReplacement].map(
+    (replacement) => output.indexOf(replacement)
+  );
+  if (helperIndexes.some((index) => index === -1)) {
     return { content: original, candidates, patched: 0 };
   }
-  output = output.slice(0, helperIndex) + helperBlock + output.slice(helperIndex);
+  // Insert from the last offset backwards so the earlier offsets stay valid.
+  for (const helperIndex of [...helperIndexes].sort((a, b) => b - a)) {
+    output = output.slice(0, helperIndex) + helperBlock + output.slice(helperIndex);
+  }
 
   if (
-    output.split("function __calicoGatewayFastEnsure").length - 1 !== 1 ||
-    output.split("function __calicoGatewayFastParse").length - 1 !== 1 ||
-    output.split("function __calicoGatewayFastCommandValue").length - 1 !== 1 ||
-    output.split("globalThis.__calicoGatewayFastApply=").length - 1 !== 1 ||
+    output.split("function __calicoGatewayFastEnsure").length - 1 !== 3 ||
+    output.split("function __calicoGatewayFastParse").length - 1 !== 3 ||
+    output.split("function __calicoGatewayFastCommandValue").length - 1 !== 3 ||
+    output.split("function __calicoGatewayFastApply").length - 1 !== 3 ||
     output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastInteractive').length - 1 !== 1 ||
-    output.split('if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin').length - 1 !== 1 ||
+    output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin').length - 1 !== 1 ||
     output.split(`CALICO_GATEWAY_FAST_STATE_FILE:${worker[1]}.CALICO_GATEWAY_FAST_STATE_FILE`).length - 1 !== 1 ||
-    output.split(`${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});`).length - 1 !== 1
+    output.split(`${builder[4]}=__calicoGatewayFastApply(${builder[4]});`).length - 1 !== 1
   ) {
     return { content: original, candidates, patched: 0 };
   }

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -531,6 +531,41 @@ function patchRedactedThinkingSummaries(content) {
   };
 }
 
+// The joined bundle carries a marker between Bun modules (see
+// scripts/native-bun.ts). A minified name captured at one site is a different
+// binding at another when a boundary separates them, because 2.1.242+ chunks
+// import each other under per-chunk aliases.
+const BUN_MODULE_BOUNDARY = "\n/*@@calico-bun-module-boundary@@*/\n";
+
+function inSameModule(content, first, second) {
+  if (first < 0 || second < 0) {
+    return false;
+  }
+  const [low, high] = first <= second ? [first, second] : [second, first];
+  return !content.slice(low, high).includes(BUN_MODULE_BOUNDARY);
+}
+
+// Upstream's "build a virtual message" helper, matched by its own destructured
+// option names rather than by a name captured elsewhere. On 2.1.245 the
+// transcript-extras site (chunk 117) knows it as `Ah` while the stream
+// reducer's chunk imports an unrelated `ypd as Ah`, so passing the captured
+// name into the reducer injected a call to the wrong function: every turn that
+// produced a thinking block rendered no assistant output at all, with no error
+// surfaced anywhere. Resolving the declaration and requiring it to be in the
+// reducer's own module makes the name correct by construction, and returns
+// null — skipping the injection — rather than emitting a cross-module name.
+const VIRTUAL_MESSAGE_DECLARATION_PATTERN =
+  /function ([A-Za-z_$][\w$]*)\(\{content:[A-Za-z_$][\w$]*,usage:[A-Za-z_$][\w$]*,isVirtual:[A-Za-z_$][\w$]*,now:[A-Za-z_$][\w$]*,uuid:[A-Za-z_$][\w$]*\}\)\{/g;
+
+function virtualMessageHelperAt(content, index) {
+  for (const match of content.matchAll(VIRTUAL_MESSAGE_DECLARATION_PATTERN)) {
+    if (inSameModule(content, match.index ?? -1, index)) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 function patchThinkingStreaming(content) {
   let output = content;
   let candidates = 0;
@@ -1160,6 +1195,10 @@ function patchThinkingStreaming(content) {
       const eventParam = destructuredMatch[1];
       const optionsParam = destructuredMatch[2];
       const props = destructuredMatch[3];
+      const reducerMessageHelper = virtualMessageHelperAt(output, destructuredMatch.index ?? -1);
+      if (reducerMessageHelper === null) {
+        continue;
+      }
       const propVar = (name) => {
         const match = props.match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`));
         return match?.[1] ?? null;
@@ -1203,7 +1242,7 @@ function patchThinkingStreaming(content) {
       const thinkingStartAfter = `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
         eventParam,
         setStreamingThinkingParam,
-        createVirtualMessageHelper
+        reducerMessageHelper
       )},${setModeParam}("thinking");return;`;
 
       const textStartBefore = `case"text":${setModeParam}("responding");return;`;
@@ -1220,7 +1259,7 @@ function patchThinkingStreaming(content) {
       const thinkingDeltaBody = buildStreamingThinkingDeltaStatement(
         eventParam,
         setStreamingThinkingParam,
-        createVirtualMessageHelper
+        reducerMessageHelper
       );
       const thinkingDeltaAfter = `case"thinking_delta":{${thinkingDeltaBody}return;}`;
       const thinkingDeltaProgressPattern = new RegExp(
@@ -1297,6 +1336,13 @@ function patchThinkingStreaming(content) {
       const optionsParam = missingStreamingThinkingMatch[2];
       const props = missingStreamingThinkingMatch[3];
       const declarationSeparator = missingStreamingThinkingMatch[4];
+      const reducerMessageHelper = virtualMessageHelperAt(
+        output,
+        missingStreamingThinkingMatch.index ?? -1
+      );
+      if (reducerMessageHelper === null) {
+        continue;
+      }
       if (props.includes("onStreamingThinking:")) {
         continue;
       }
@@ -1336,7 +1382,7 @@ function patchThinkingStreaming(content) {
       const thinkingDeltaBody = buildStreamingThinkingDeltaStatement(
         eventParam,
         setStreamingThinkingParam,
-        createVirtualMessageHelper
+        reducerMessageHelper
       );
 
       const replacements = [
@@ -1365,7 +1411,7 @@ function patchThinkingStreaming(content) {
           `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
             eventParam,
             setStreamingThinkingParam,
-            createVirtualMessageHelper
+            reducerMessageHelper
           )},${setModeParam}?.("thinking");return;`,
         ],
         [
@@ -1373,7 +1419,7 @@ function patchThinkingStreaming(content) {
           `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
             eventParam,
             setStreamingThinkingParam,
-            createVirtualMessageHelper
+            reducerMessageHelper
           )},${setModeParam}?.("thinking");return;`,
         ],
         [

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -578,7 +578,7 @@ function patchThinkingStreaming(content) {
       const searchStart = Math.max(0, anchor - 50000);
       const searchSegment = output.slice(searchStart, anchor);
       const statePattern = new RegExp(
-        `\\[(${identifierPattern}),${escapeRegExp(setStreamingThinkingVar)}\\]=${identifierPattern}\\.useState\\(null\\)`,
+        `\\[(${identifierPattern}),${escapeRegExp(setStreamingThinkingVar)}\\]=${identifierPattern}(?:\\.useState)?\\(null\\)`,
         "g"
       );
       let stateMatch;
@@ -697,6 +697,110 @@ function patchThinkingStreaming(content) {
       injectStreamingThinking
     );
     output = output.replace(jsxTranscriptRendererPropsPattern, injectStreamingThinking);
+
+    // 2.1.245 rewrote the main renderer call site: instead of an explicit prop
+    // list it spreads a rest object and reads the streaming state through store
+    // selectors, inside a React-compiler memo cache:
+    //
+    //   function kC(lh){let ju=v(19);…
+    //     let mh=Do(Wu,NC)??!1,ph=Do(Wu?.stream,EC)??_i,…
+    //     let qu;if(ju[10]!==Vu||…||ju[14]!==fh)
+    //       qu=o(Rh,{...nn,messages:Vu,isLoading:mh,streamingToolUses:ph,
+    //               onRateLimitAutoQueueContinue:fh}),
+    //       ju[10]=Vu,…,ju[14]=fh,ju[15]=qu;else qu=ju[15];
+    //
+    // Adding the prop alone is not enough: the cached element is only rebuilt
+    // when one of the compared slots changes, so a streamingThinking value that
+    // updates on its own would never reach the renderer. The injection
+    // therefore also claims one new cache slot — growing the allocation the way
+    // the compiler itself would — and adds it to both the guard and the
+    // write-back. `streamingThinking` is read through its own module-scoped
+    // selector declared beside the component, so the selector identity is
+    // stable across renders and nothing crosses a chunk scope.
+    // Not gated on the earlier prop patterns having failed: the spread call
+    // site is a distinct shape that simply does not exist on pre-2.1.245
+    // bundles, so it self-selects and pre-2.1.245 builds keep their counts.
+    {
+      const storeSelectorPattern = new RegExp(
+        `(${identifierPattern})=(${identifierPattern})\\((${identifierPattern})\\?\\.stream,${identifierPattern}\\)\\?\\?${identifierPattern},`,
+        "g"
+      );
+
+      for (const selectorRead of [...output.matchAll(storeSelectorPattern)]) {
+        const toolUsesLocal = selectorRead[1];
+        const storeHook = selectorRead[2];
+        const turnLocal = selectorRead[3];
+        const escapedToolUses = escapeRegExp(toolUsesLocal);
+        const memoCallPattern = new RegExp(
+          `let (${identifierPattern});if\\((${identifierPattern})\\[\\d+\\]!==[^)]*?\\)\\1=${identifierPattern}\\(${identifierPattern},\\{\\.\\.\\.${identifierPattern},[^{}]*streamingToolUses:${escapedToolUses}[^{}]*\\}\\),[^;]*?,\\2\\[(\\d+)\\]=\\1;`
+        );
+        const memoCall = output.slice(selectorRead.index).match(memoCallPattern);
+        if (!memoCall || memoCall[0].includes("streamingThinking:")) {
+          continue;
+        }
+
+        const cacheLocal = memoCall[2];
+        const cacheAllocPattern = new RegExp(
+          `let ${escapeRegExp(cacheLocal)}=(${identifierPattern})\\((\\d+)\\)([,;])`
+        );
+        const functionStart = output.lastIndexOf("function ", selectorRead.index);
+        const cacheAlloc =
+          functionStart === -1
+            ? null
+            : output.slice(functionStart, selectorRead.index).match(cacheAllocPattern);
+        if (!cacheAlloc) {
+          continue;
+        }
+
+        const cacheSize = Number(cacheAlloc[2]);
+        const resultSlot = Number(memoCall[3]);
+        if (!Number.isInteger(cacheSize) || resultSlot >= cacheSize) {
+          continue;
+        }
+
+        propCandidates += 1;
+
+        const thinkingLocal = "__cc_streamingThinking";
+        const selectorName = "__cc_streamingThinkingSelector";
+        const grownCall = memoCall[0]
+          .replace(
+            new RegExp(`\\)${escapeRegExp(memoCall[1])}=`),
+            () => `||${cacheLocal}[${cacheSize}]!==${thinkingLocal})${memoCall[1]}=`
+          )
+          .replace(
+            new RegExp(`streamingToolUses:${escapedToolUses}`),
+            () => `streamingToolUses:${toolUsesLocal},streamingThinking:${thinkingLocal}`
+          )
+          .replace(
+            new RegExp(`,${escapeRegExp(cacheLocal)}\\[${resultSlot}\\]=${escapeRegExp(memoCall[1])};$`),
+            () => `,${cacheLocal}[${cacheSize}]=${thinkingLocal},${cacheLocal}[${resultSlot}]=${memoCall[1]};`
+          );
+
+        const nextOutput = output
+          .replace(
+            cacheAlloc[0],
+            () => `let ${cacheLocal}=${cacheAlloc[1]}(${cacheSize + 1})${cacheAlloc[3]}`
+          )
+          .replace(
+            selectorRead[0],
+            () =>
+              `${selectorRead[0]}${thinkingLocal}=${storeHook}(${turnLocal}?.stream,${selectorName})??null,`
+          )
+          .replace(memoCall[0], () => grownCall)
+          .replace(
+            `function ${output.slice(functionStart + "function ".length).match(/^[A-Za-z_$][\w$]*/)[0]}(`,
+            () =>
+              `function ${selectorName}(e){return e.streamingThinking}` +
+              `function ${output.slice(functionStart + "function ".length).match(/^[A-Za-z_$][\w$]*/)[0]}(`
+          );
+
+        if (nextOutput !== output) {
+          output = nextOutput;
+          propPatched += 1;
+        }
+        break;
+      }
+    }
   }
 
   candidates += propCandidates;
@@ -842,11 +946,11 @@ function patchThinkingStreaming(content) {
     return `let ${visibleVar}=!!(${streamVar}&&${streamVar}.isStreaming)`;
   });
   const promptLingerPattern =
-    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.useMemo\(\(\)=>\{if\(!([A-Za-z_$][\w$]*)\)return!1;if\(\3\.isStreaming\)return!0;if\(\3\.streamingEndedAt\)return Date\.now\(\)-\3\.streamingEndedAt<30000;return!1\},\[\3\]\)/g;
-  output = output.replace(promptLingerPattern, (_full, visibleVar, reactNs, streamVar) => {
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(\(\)=>\{if\(!([A-Za-z_$][\w$]*)\)return!1;if\(\3\.isStreaming\)return!0;if\(\3\.streamingEndedAt\)return Date\.now\(\)-\3\.streamingEndedAt<30000;return!1\},\[\3\]\)/g;
+  output = output.replace(promptLingerPattern, (_full, visibleVar, useMemoCallee, streamVar) => {
     lingerCandidates += 1;
     lingerPatched += 1;
-    return `${visibleVar}=${reactNs}.useMemo(()=>!!(${streamVar}&&${streamVar}.isStreaming),[${streamVar}])`;
+    return `${visibleVar}=${useMemoCallee}(()=>!!(${streamVar}&&${streamVar}.isStreaming),[${streamVar}])`;
   });
   candidates += lingerCandidates;
   patched += lingerPatched;
@@ -885,13 +989,13 @@ function patchThinkingStreaming(content) {
     let inlineThinkingCandidates = 0;
     let inlineThinkingPatched = 0;
     const inlineThinkingPattern =
-      /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.useMemo\(\(\)=>([A-Za-z_$][\w$]*)\.flatMap\(\(([A-Za-z_$][\w$]*)\)=>\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\{content:\[\4\.contentBlock\]\}\);return \5\.uuid=([A-Za-z_$][\w$]*)\(\4\.contentBlock\.id,0\),([A-Za-z_$][\w$]*)\(\[\5\]\)\}\),\[\3\]\)/g;
+      /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(\(\)=>([A-Za-z_$][\w$]*)\.flatMap\(\(([A-Za-z_$][\w$]*)\)=>\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\{content:\[\4\.contentBlock\]\}\);return \5\.uuid=([A-Za-z_$][\w$]*)\(\4\.contentBlock\.id,0\),([A-Za-z_$][\w$]*)\(\[\5\]\)\}\),\[\3\]\)/g;
     output = output.replace(
       inlineThinkingPattern,
       (
         _full,
         extrasVar,
-        reactNs,
+        useMemoCallee,
         streamingToolUsesVar,
         toolUseEntryVar,
         toolUseMessageVar,
@@ -902,7 +1006,7 @@ function patchThinkingStreaming(content) {
         inlineThinkingCandidates += 1;
         inlineThinkingPatched += 1;
         createVirtualMessageHelper = createMessageHelper;
-        return `${extrasVar}=${reactNs}.useMemo(()=>{let __cc_streamingToolUseExtras=${streamingToolUsesVar}.map((${toolUseEntryVar})=>{let ${toolUseMessageVar}=${createMessageHelper}({content:[${toolUseEntryVar}.contentBlock]});return ${toolUseMessageVar}.uuid=${createUUIDHelper}(${toolUseEntryVar}.contentBlock.id,0),{index:${toolUseEntryVar}.index??9007199254740991,messages:${normalizeMessagesHelper}([${toolUseMessageVar}])}}),__cc_streamingThinkingExtras=(${transcriptStreamingThinkingVar}?.messages??[]).map((__cc_entry,__cc_index)=>({index:__cc_entry.index??9007199254740991+__cc_index,messages:${normalizeMessagesHelper}([__cc_entry.message??__cc_entry])}));return[...__cc_streamingToolUseExtras,...__cc_streamingThinkingExtras].sort((__cc_a,__cc_b)=>__cc_a.index===__cc_b.index?0:__cc_a.index-__cc_b.index).flatMap((__cc_entry)=>__cc_entry.messages)},[${streamingToolUsesVar},${transcriptStreamingThinkingVar}])`;
+        return `${extrasVar}=${useMemoCallee}(()=>{let __cc_streamingToolUseExtras=${streamingToolUsesVar}.map((${toolUseEntryVar})=>{let ${toolUseMessageVar}=${createMessageHelper}({content:[${toolUseEntryVar}.contentBlock]});return ${toolUseMessageVar}.uuid=${createUUIDHelper}(${toolUseEntryVar}.contentBlock.id,0),{index:${toolUseEntryVar}.index??9007199254740991,messages:${normalizeMessagesHelper}([${toolUseMessageVar}])}}),__cc_streamingThinkingExtras=(${transcriptStreamingThinkingVar}?.messages??[]).map((__cc_entry,__cc_index)=>({index:__cc_entry.index??9007199254740991+__cc_index,messages:${normalizeMessagesHelper}([__cc_entry.message??__cc_entry])}));return[...__cc_streamingToolUseExtras,...__cc_streamingThinkingExtras].sort((__cc_a,__cc_b)=>__cc_a.index===__cc_b.index?0:__cc_a.index-__cc_b.index).flatMap((__cc_entry)=>__cc_entry.messages)},[${streamingToolUsesVar},${transcriptStreamingThinkingVar}])`;
       }
     );
     candidates += inlineThinkingCandidates;

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -215,8 +215,15 @@ function patchWriteCreateDiffColors(content) {
       continue;
     }
 
+    // Claude 2.1.242 split the bundle into ES module chunks, so the JSX factory
+    // arrives destructured (`o(Component,props)`) instead of namespace-qualified
+    // (`iv.jsx(Component,props)`). Capture the whole callee expression and emit
+    // it back verbatim rather than requiring a `.jsx`/`.createElement` suffix,
+    // and anchor on the distinctive `{filePath,content,verbose}` prop triple —
+    // the factory's local name is exactly the kind of minified binding that
+    // differs per platform build and must never be pinned.
     const createReturnMatch = createSegment.match(
-      /return ([A-Za-z_$][\w$]*)\.(createElement|jsx|jsxs)\(([A-Za-z_$][\w$]*),\{filePath:([A-Za-z_$][\w$]*),content:([A-Za-z_$][\w$]*),verbose:([A-Za-z_$][\w$]*)\}\)/
+      /return ([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{filePath:([A-Za-z_$][\w$]*),content:([A-Za-z_$][\w$]*),verbose:([A-Za-z_$][\w$]*)\}\)/
     );
     if (!createReturnMatch) {
       index = updateStart + updateNeedle.length;
@@ -224,7 +231,7 @@ function patchWriteCreateDiffColors(content) {
     }
 
     const updateRendererMatch = updateSegment.match(
-      /(?:createElement|jsx|jsxs)\(([A-Za-z_$][\w$]*),\{filePath:[^}]*structuredPatch:[^}]*style:([A-Za-z_$][\w$]*),verbose:[A-Za-z_$][\w$]*/
+      /\(([A-Za-z_$][\w$]*),\{filePath:[^}]*structuredPatch:[^}]*style:([A-Za-z_$][\w$]*),verbose:[A-Za-z_$][\w$]*/
     );
     if (!updateRendererMatch) {
       index = updateStart + updateNeedle.length;
@@ -233,23 +240,22 @@ function patchWriteCreateDiffColors(content) {
 
     candidates += 1;
 
-    const reactNs = createReturnMatch[1];
-    const jsxFactory = createReturnMatch[2];
-    const fileVar = createReturnMatch[4];
-    const contentVar = createReturnMatch[5];
-    const verboseVar = createReturnMatch[6];
+    const jsxCallee = createReturnMatch[1];
+    const fileVar = createReturnMatch[3];
+    const contentVar = createReturnMatch[4];
+    const verboseVar = createReturnMatch[5];
     const diffRenderer = updateRendererMatch[1];
     const styleVar = updateRendererMatch[2];
 
     const lineCounterMatch = createSegment.match(
-      /let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\);return [A-Za-z_$][\w$]*\.(?:createElement|jsxs)\([A-Za-z_$][\w$]*,(?:null,|\{children:\[)"Wrote "/
+      /let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\);return [A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,(?:null,|\{children:\[)"Wrote "/
     );
     const lineCountExpr = lineCounterMatch
       ? `${lineCounterMatch[1]}(${contentVar})`
       : `${contentVar}===""?0:${contentVar}.split(\`\\n\`).length`;
 
     const before = createReturnMatch[0];
-    const after = `return ${reactNs}.${jsxFactory}(${diffRenderer},{filePath:${fileVar},structuredPatch:[{oldStart:1,oldLines:0,newStart:1,newLines:${lineCountExpr},lines:${contentVar}===""?[]:${contentVar}.split(\`\\n\`).map((__cc_line)=>"+"+__cc_line)}],firstLine:${contentVar}.split(\`\\n\`)[0]??null,fileContent:"",style:${styleVar},verbose:${verboseVar},previewHint:void 0})`;
+    const after = `return ${jsxCallee}(${diffRenderer},{filePath:${fileVar},structuredPatch:[{oldStart:1,oldLines:0,newStart:1,newLines:${lineCountExpr},lines:${contentVar}===""?[]:${contentVar}.split(\`\\n\`).map((__cc_line)=>"+"+__cc_line)}],firstLine:${contentVar}.split(\`\\n\`)[0]??null,fileContent:"",style:${styleVar},verbose:${verboseVar},previewHint:void 0})`;
 
     if (!createSegment.includes(before)) {
       index = updateStart + updateNeedle.length;
@@ -394,8 +400,13 @@ function patchThinkingCase(content, ctx = {}) {
         return `;${" ".repeat(Math.max(0, full.length - 1))}`;
       }
     );
+    // The callee is `Ag.jsx(...)` on a monolithic bundle and a destructured
+    // `o(...)` on 2.1.242+ ES module chunks, so match any component call shape
+    // rather than the factory name. Loosening it is safe here because the body
+    // only rewrites props literally named isTranscriptMode/hideInTranscript and
+    // returns the match untouched when neither is present.
     nextSegment = nextSegment.replace(
-      /((?:createElement|jsx|jsxs)\([A-Za-z_$][\w$]*,\{)([^}]*)\}/g,
+      /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,\{)([^}]*)\}/g,
       (full, prefix, props) => {
         let nextProps = props;
         nextProps = nextProps.replace(/isTranscriptMode:[^,}]+/g, (entry) => {
@@ -465,10 +476,11 @@ function patchRedactedThinkingSummaries(content) {
     const redactedSegment = output.slice(redactedStart, thinkingStart);
     const thinkingSegment = output.slice(thinkingStart, thinkingEnd);
 
+    // Confirm the redacted case actually renders a component before replacing
+    // it. On 2.1.242+ chunks the JSX factory is a destructured local, so match
+    // the call-with-props shape instead of a `jsx(`/`createElement(` literal.
     const hasRedactedRendererCall =
-      redactedSegment.includes("createElement(") ||
-      redactedSegment.includes("jsx(") ||
-      redactedSegment.includes("jsxs(");
+      /[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,\{[^}]*\}\)/.test(redactedSegment);
     if (
       thinkingStart - redactedStart > maxRendererGap ||
       thinkingEnd - thinkingStart > maxRendererGap ||
@@ -480,18 +492,17 @@ function patchRedactedThinkingSummaries(content) {
     }
 
     const thinkingRendererMatch = thinkingSegment.match(
-      /([A-Za-z_$][\w$]*)\.(createElement|jsx|jsxs)\(([A-Za-z_$][\w$]*),\{addMargin:([A-Za-z_$][\w$]*),param:([A-Za-z_$][\w$]*),isTranscriptMode:[^,}]+,verbose:[^,}]+(?:,hideInTranscript:[^}]+)?\}\)/
+      /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{addMargin:([A-Za-z_$][\w$]*),param:([A-Za-z_$][\w$]*),isTranscriptMode:[^,}]+,verbose:[^,}]+(?:,hideInTranscript:[^}]+)?\}\)/
     );
     if (!thinkingRendererMatch) {
       index = redactedStart + redactedNeedle.length;
       continue;
     }
 
-    const reactNs = thinkingRendererMatch[1];
-    const jsxFactory = thinkingRendererMatch[2];
-    const thinkingComponent = thinkingRendererMatch[3];
-    const addMarginVar = thinkingRendererMatch[4];
-    const paramVar = thinkingRendererMatch[5];
+    const jsxCallee = thinkingRendererMatch[1];
+    const thinkingComponent = thinkingRendererMatch[2];
+    const addMarginVar = thinkingRendererMatch[3];
+    const paramVar = thinkingRendererMatch[4];
     const hideInTranscriptProp = thinkingRendererMatch[0].includes("hideInTranscript:")
       ? ",hideInTranscript:!1"
       : "";
@@ -499,7 +510,7 @@ function patchRedactedThinkingSummaries(content) {
     candidates += 1;
 
     const replacement =
-      `case"redacted_thinking":{return ${reactNs}.${jsxFactory}(${thinkingComponent},{` +
+      `case"redacted_thinking":{return ${jsxCallee}(${thinkingComponent},{` +
       `addMargin:${addMarginVar},param:{type:"thinking",thinking:${paramVar}.data??""},` +
       `isTranscriptMode:!0,verbose:!0${hideInTranscriptProp}})}`;
 
@@ -1812,11 +1823,14 @@ function patchWelcomePatchedBadge(content) {
   let patched = 0;
   let output = content;
 
+  // 2.1.242+ chunks destructure the JSX factory, so the callee is a bare local
+  // (`o(T,…)`) rather than `ns.createElement(...)`/`ns.jsx(...)`. Capture the
+  // whole callee expression and emit it back verbatim.
   output = output.replace(
-    /([A-Za-z_$][\w$]*)\.createElement\(([A-Za-z_$][\w$]*),\{bold:!0\},"Claude Code"\)/g,
-    (full, reactVar, textComponent) => {
+    /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{bold:!0\},"Claude Code"\)/g,
+    (full, jsxCallee, textComponent) => {
       candidates += 1;
-      const replacement = `${reactVar}.createElement(${textComponent},{bold:!0},"Calico Claude")`;
+      const replacement = `${jsxCallee}(${textComponent},{bold:!0},"Calico Claude")`;
       if (replacement !== full) {
         patched += 1;
         return replacement;
@@ -1826,10 +1840,10 @@ function patchWelcomePatchedBadge(content) {
   );
 
   output = output.replace(
-    /([A-Za-z_$][\w$]*)\.(jsx|jsxs)\(([A-Za-z_$][\w$]*),\{bold:!0,children:"Claude Code"\}\)/g,
-    (full, reactVar, jsxFactory, textComponent) => {
+    /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{bold:!0,children:"Claude Code"\}\)/g,
+    (full, jsxCallee, textComponent) => {
       candidates += 1;
-      const replacement = `${reactVar}.${jsxFactory}(${textComponent},{bold:!0,children:"Calico Claude"})`;
+      const replacement = `${jsxCallee}(${textComponent},{bold:!0,children:"Calico Claude"})`;
       if (replacement !== full) {
         patched += 1;
         return replacement;
@@ -2176,11 +2190,11 @@ function patchStatuslineCommittedUsage(content) {
     "g"
   );
   const legacyWrapperPattern = new RegExp(
-    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\}\\};`,
+    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\}\\};`,
     "g"
   );
   const effortWrapperPattern = new RegExp(
-    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
+    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
     "g"
   );
   // 2.1.236+: batch tool-use destructuring wraps the content builder. The
@@ -2195,7 +2209,7 @@ function patchStatuslineCommittedUsage(content) {
   // 2.1.237 (no fifth arg) and 2.1.238 (one appended arg) matching, and to
   // tolerate a further appended argument without another edit.
   const batchWrapperPattern = new RegExp(
-    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
+    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
     "g"
   );
   const terminalPattern = new RegExp(
@@ -2208,9 +2222,24 @@ function patchStatuslineCommittedUsage(content) {
   );
   const reducerMatches = [...content.matchAll(reducerPattern)];
   const reducerName = reducerMatches[0]?.[1];
+  // The reducer used to be identified at its call site by the name captured at
+  // its definition. That stopped working on 2.1.242+: the bundle is split into
+  // ES module chunks that import each other under per-chunk aliases, so the
+  // statusline function calls the reducer as `Bne` while it is declared as
+  // `Eze` elsewhere — and, worse, an unrelated chunk-local `Eze` exists, so
+  // minified names are no longer unique across the joined text and pinning one
+  // can match the wrong site entirely.
+  //
+  // Anchor on structure instead: the selector sits immediately after the
+  // `<local>=<settings>?.outputStyle||<default>,` assignment in the statusline
+  // payload builder, inside the one function that emits `context_window:`, and
+  // require exactly one such site. That is weaker than the name equality it
+  // replaces — it locates the call rather than proving its callee — but a name
+  // captured in another chunk cannot identify anything here, so position plus
+  // the surviving `exactly one reducer declaration` gate is what is left.
   const selectorPattern = reducerName
     ? new RegExp(
-        `(${identifierPattern})=${escapeRegExp(reducerName)}\\((${identifierPattern})\\),(${identifierPattern})=(${identifierPattern})\\((${identifierPattern}),(${identifierPattern})\\(\\)\\)`,
+        `(${identifierPattern}=${identifierPattern}\\?\\.outputStyle\\|\\|[^,]{1,40},)(${identifierPattern})=(${identifierPattern})\\((${identifierPattern})\\),(${identifierPattern})=(${identifierPattern})\\((${identifierPattern}),(${identifierPattern})\\(\\)\\)`,
         "g"
       )
     : null;
@@ -2284,7 +2313,15 @@ function patchStatuslineCommittedUsage(content) {
     const functionStart = content.lastIndexOf("function ", index);
     const functionEnd = content.indexOf("function ", index + match[0].length);
     const segment = content.slice(functionStart, functionEnd === -1 ? content.length : functionEnd);
-    return segment.includes("context_window:");
+    // Require the selected usage and the computed window to be exactly the two
+    // arguments the payload's `context_window:` is built from. This replaces
+    // the name equality with the reducer that chunking made uncheckable: it
+    // does not prove the callee is the reducer, but it does prove this site's
+    // result is what the status line reports, which is what the patch is for.
+    const consumption = new RegExp(
+      `context_window:${identifierPattern}\\(${escapeRegExp(match[2])},${escapeRegExp(match[5])}\\)`
+    );
+    return segment.includes("context_window:") && consumption.test(segment);
   });
   const cloneArray = cloneSyncMatches[0]?.[3];
   const cloneRegistrationPattern = cloneArray
@@ -2403,9 +2440,9 @@ function patchStatuslineCommittedUsage(content) {
   }
 
   const accountingHelper =
-    'function __calicoUsageHasAccountingSignal(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)}' +
-    'function __calicoUsageIsExactAllZero(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)}' +
-    'function __calicoStatuslineMessages(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})}';
+    'globalThis.__calicoUsageHasAccountingSignal=function(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)};' +
+    'globalThis.__calicoUsageIsExactAllZero=function(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)};' +
+    'globalThis.__calicoStatuslineMessages=function(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&globalThis.__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})};';
   const wrapperStateNeedle = ",...!1,";
   const wrapperReplacement = wrapperMatch.match[0].replace(
     wrapperStateNeedle,
@@ -2417,7 +2454,7 @@ function patchStatuslineCommittedUsage(content) {
   ) {
     return { content: original, candidates, patched: 0 };
   }
-  const terminalReplacement = `for(let ${terminalItem} of ${terminalArray})${terminalItem}.message.usage=${terminalUsage},${terminalItem}.message.stop_reason=${terminalStop},${terminalItem}.message.stop_details=${terminalRawEvent}.delta.stop_details??null,${terminalStop}!=null&&!__calicoUsageIsExactAllZero(${terminalRawEvent}.usage)&&__calicoUsageHasAccountingSignal(${terminalUsage})&&(${terminalItem}.__calicoUsageState.committed=!0,${terminalItem}.__calicoUsageState.usage=${terminalUsage});`;
+  const terminalReplacement = `for(let ${terminalItem} of ${terminalArray})${terminalItem}.message.usage=${terminalUsage},${terminalItem}.message.stop_reason=${terminalStop},${terminalItem}.message.stop_details=${terminalRawEvent}.delta.stop_details??null,${terminalStop}!=null&&!globalThis.__calicoUsageIsExactAllZero(${terminalRawEvent}.usage)&&globalThis.__calicoUsageHasAccountingSignal(${terminalUsage})&&(${terminalItem}.__calicoUsageState.committed=!0,${terminalItem}.__calicoUsageState.usage=${terminalUsage});`;
   const cloneReplacements = cloneMatches.map(
     (match) => `${cloneArray}.push({src:${match[1]},dst:${match[2]}})`
   );
@@ -2425,7 +2462,11 @@ function patchStatuslineCommittedUsage(content) {
   const cloneSyncDestination = cloneSyncMatches[0][2];
   const cloneSyncReplacement = `for(let{src:${cloneSyncSource},dst:${cloneSyncDestination}}of ${cloneArray})${cloneSyncDestination}.message.usage=${cloneSyncSource}.message.usage,${cloneSyncDestination}.message.stop_reason=${cloneSyncSource}.message.stop_reason,${cloneSyncDestination}.message.stop_details=${cloneSyncSource}.message.stop_details,${cloneSyncDestination}.__calicoUsageState=${cloneSyncSource}.__calicoUsageState;`;
   const selectorMatch = selectorMatches[0];
-  const selectorReplacement = `${selectorMatch[1]}=${reducerName}(__calicoStatuslineMessages(${selectorMatch[2]})),${selectorMatch[3]}=${selectorMatch[4]}(${selectorMatch[5]},${selectorMatch[6]}())`;
+  // The reducer is called through whatever local name this chunk imported it
+  // under (selectorMatch[3]), not the name captured at its declaration site.
+  const selectorReplacement =
+    `${selectorMatch[1]}${selectorMatch[2]}=${selectorMatch[3]}(globalThis.__calicoStatuslineMessages(${selectorMatch[4]}))` +
+    `,${selectorMatch[5]}=${selectorMatch[6]}(${selectorMatch[7]},${selectorMatch[8]}())`;
 
   // wrapperReplacement/terminalReplacement/cloneSyncReplacement interpolate
   // captured minified locals (terminalItem, terminalArray, cloneSyncSource,
@@ -2453,9 +2494,9 @@ function patchStatuslineCommittedUsage(content) {
     cloneReplacements.some((replacement) => output.split(replacement).length - 1 !== 1) ||
     output.split(cloneSyncReplacement).length - 1 !== 1 ||
     output.split(selectorReplacement).length - 1 !== 1 ||
-    output.split("function __calicoUsageHasAccountingSignal").length - 1 !== 1 ||
-    output.split("function __calicoUsageIsExactAllZero").length - 1 !== 1 ||
-    output.split("function __calicoStatuslineMessages").length - 1 !== 1
+    output.split("globalThis.__calicoUsageHasAccountingSignal=").length - 1 !== 1 ||
+    output.split("globalThis.__calicoUsageIsExactAllZero=").length - 1 !== 1 ||
+    output.split("globalThis.__calicoStatuslineMessages=").length - 1 !== 1
   ) {
     return { content: original, candidates, patched: 0 };
   }
@@ -2952,15 +2993,19 @@ function patchActiveTurnPromptIdentity(content) {
   const legacyPromptGetterMatch = output.match(
     /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\.promptId\}function [A-Za-z_$][\w$]*\(e\)\{\2\.promptId=e\}/
   );
+  // 2.1.242 chunking turned the module-level journal singleton into a lazy
+  // accessor call, so the receiver went from `br.requestJournal.` to
+  // `n().requestJournal.`. Accept either an identifier or a no-argument call as
+  // the head of the accessor chain; the backreference still pins the getter and
+  // setter to the same receiver expression.
   const journalPromptGetterMatch = output.match(
-    /function ([A-Za-z_$][\w$]*)\(\)\{return ((?:[A-Za-z_$][\w$]*\.)+)promptId\(\)\}function [A-Za-z_$][\w$]*\(e\)\{\2replacePromptId\(e\)\}/
+    /function ([A-Za-z_$][\w$]*)\(\)\{return ((?:[A-Za-z_$][\w$]*\(\)|[A-Za-z_$][\w$]*)(?:\.[A-Za-z_$][\w$]*)*\.)promptId\(\)\}function [A-Za-z_$][\w$]*\(e\)\{\2replacePromptId\(e\)\}/
   );
   if (!legacyPromptGetterMatch && !journalPromptGetterMatch) {
     return { content: original, candidates: 0, patched: 0 };
   }
-  const promptGetter = legacyPromptGetterMatch
-    ? legacyPromptGetterMatch[1]
-    : journalPromptGetterMatch[1];
+  const promptGetterMatch = legacyPromptGetterMatch ?? journalPromptGetterMatch;
+  const promptGetter = promptGetterMatch[1];
 
   // Reuse Claude's own query-source classifier so quota checks, token counts,
   // compaction, side queries, and other auxiliary traffic cannot enter the
@@ -2973,6 +3018,33 @@ function patchActiveTurnPromptIdentity(content) {
   }
   const sourceClassifier = sourceClassifierMatch[1];
 
+  // Both helpers are discovered at their definition sites and called from two
+  // other sites, and upstream 2.1.242+ puts all three in different Bun chunks
+  // (the getter, the AsyncLocalStorage entry point and the client factory land
+  // in separate chunks on 2.1.245). Chunks are separate ES module scopes that
+  // import each other under per-chunk aliases, so emitting the captured local
+  // name at another site references an identifier that does not exist there —
+  // and, because the prompt-getter call sits behind the REMORA_ACTIVE gate,
+  // neither the PTY smoke test nor the --print E2E test would reach it.
+  // Publish both through globalThis at their definition sites and call them
+  // through globalThis everywhere else, which also brings them under
+  // native-bun's module-scope guard.
+  const publish = (matchedText, globalName, localName) => {
+    if (output.includes(`globalThis.${globalName}=`)) {
+      return;
+    }
+    // matchedText and localName are minified names that may contain `$`, which
+    // String.replace would expand in a plain replacement string.
+    output = output.replace(
+      matchedText,
+      () => `${matchedText}globalThis.${globalName}=${localName};`
+    );
+  };
+  publish(promptGetterMatch[0], "__calicoPromptIdGet", promptGetter);
+  publish(sourceClassifierMatch[0], "__calicoQuerySource", sourceClassifier);
+  const promptGetterCall = "globalThis.__calicoPromptIdGet()";
+  const querySourceRef = "globalThis.__calicoQuerySource";
+
   // Every spawned agent enters the same AsyncLocalStorage boundary. Freeze
   // the current prompt id there so a background agent keeps its spawning turn
   // even after the main session accepts another user prompt.
@@ -2983,7 +3055,7 @@ function patchActiveTurnPromptIdentity(content) {
     (full, prefix, storage, suffix) => {
       agentCandidates += 1;
       agentPatched += 1;
-      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetter}()),${storage}.run(e,t)${suffix}`;
+      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall}),${storage}.run(e,t)${suffix}`;
     }
   );
   const attributedAgentContextPattern =
@@ -2993,7 +3065,7 @@ function patchActiveTurnPromptIdentity(content) {
     (full, prefix, attribution, storage, run, suffix) => {
       agentCandidates += 1;
       agentPatched += 1;
-      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetter}());${attribution}${storage}${run}${suffix}`;
+      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall});${attribution}${storage}${run}${suffix}`;
     }
   );
 
@@ -3051,7 +3123,7 @@ function patchActiveTurnPromptIdentity(content) {
     let nextSegment = segment.replace(
       localsPattern,
       () =>
-        `,${contextLocal}=${sanitizer}(${contextParam})?void 0:${contextParam},__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${sourceClassifier}(${sourceParam}),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetter}()):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
+        `,${contextLocal}=${sanitizer}(${contextParam})?void 0:${contextParam},__calicoActiveTurnAdapter="calico-active-turn-adapter:v1",__calicoQueryKind=${querySourceRef}(${sourceParam}),__calicoPromptId=process.env.REMORA_ACTIVE==="1"&&(__calicoQueryKind==="main"||__calicoQueryKind==="subagent")?(${contextLocal}?.__calicoPromptId??${promptGetterCall}):void 0,${extraHeadersLocal}=${extraHeadersFactory}(),${headerObjectLocal}={`
     );
     nextSegment = nextSegment.replace(
       new RegExp(

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2778,7 +2778,7 @@ function patchGatewayFastMode(content) {
     "g"
   );
   const localJsxPattern =
-    /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",get immediate\(\)\{return ([A-Za-z_$][\w$]*)\(\)\},requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
+    /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",(?:get immediate\(\)\{return [A-Za-z_$][\w$]*\(\)\}|immediate:!0),requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
   const localPattern =
     /([A-Za-z_$][\w$]*)=\{type:"local",name:"fast",supportsNonInteractive:!0,get description\(\)\{return`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},argumentHint:"\[on\|off\]",isEnabled:\(\)=>([A-Za-z_$][\w$]*)\(\),get isHidden\(\)\{return!([A-Za-z_$][\w$]*)\(\)\}/g;
   const builderPattern = new RegExp(
@@ -2832,11 +2832,17 @@ function patchGatewayFastMode(content) {
   const builder = builderMatches[0];
   const worker = workerMatches[0];
 
-  if (
-    interactive[5] !== thin[4] ||
-    interactive[6] !== thin[5] ||
-    local[3] !== local[4]
-  ) {
+  // The interactive and thin handlers used to be required to name the same
+  // availability helper and the same unavailable-message helper. On 2.1.242+
+  // they live in different chunks and reach those helpers through per-chunk
+  // import aliases (2.1.245: `po`/`q` against `a`/`n`), so the names differ
+  // while the target is the same and the equality can no longer be evaluated.
+  // What still holds is that each handler shape pins the literal
+  // "Fast mode is not available" and is required to occur exactly once in the
+  // whole bundle, and each site's replacement only re-emits identifiers it
+  // captured at that same site, so nothing crosses a chunk scope.
+  // local[3]/local[4] are both inside one object literal and stay checkable.
+  if (local[3] !== local[4]) {
     return { content: original, candidates, patched: 0 };
   }
 
@@ -2856,7 +2862,10 @@ function patchGatewayFastMode(content) {
     !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
     !interactiveSegment.includes(".getAppState") ||
     !interactiveSegment.includes(".setAppState") ||
-    !interactiveSegment.includes(".jsx(")
+    // Confirms the interactive handler renders a component. On 2.1.242+ the JSX
+    // factory is a destructured local, so match the call-with-props shape
+    // instead of a `.jsx(` literal.
+    !/[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,\{[^}]*\}\)/.test(interactiveSegment)
   ) {
     return { content: original, candidates, patched: 0 };
   }
@@ -2869,7 +2878,12 @@ function patchGatewayFastMode(content) {
   if (
     thinStart === -1 ||
     !thinAction ||
-    thinAction !== interactiveAction ||
+    // Both handlers must reach the same apply-fast-mode action, but on 2.1.242+
+    // they are in different chunks and call it through different import
+    // aliases (2.1.245: `go` interactive, `i` thin), so the names cannot be
+    // compared. Each handler is still pinned by its own `"shortcut"` /
+    // `"bridge"` call shape plus the app-state and argument markers below, and
+    // neither capture is used outside the check itself.
     !thinSegment.includes(".options.fastMode") ||
     !thinSegment.includes("Unknown argument") ||
     !thinSegment.includes(".getAppState") ||
@@ -2961,6 +2975,12 @@ function patchGatewayFastMode(content) {
   }
   const dispatchRecord = dispatchRecords[0];
   const dispatchRecordLocal = dispatchRecord.match[1];
+  // 2.1.239 appended arguments to the dispatch call
+  // (`_0c(K)` became `_0c(K,!1,Date.now(),s)`), which is why this module has
+  // applied 0 changes since that release. Accept a trailing argument list, one
+  // level of call nesting deep so `Date.now()` does not terminate it early. The
+  // record local is still the required first argument.
+  const dispatchArguments = "(?:,(?:[^()]|\\([^()]*\\))*)?";
   const awaitedDispatchPattern = new RegExp(
     "\\},\\[,(" +
       identifier +
@@ -2968,12 +2988,13 @@ function patchGatewayFastMode(content) {
       identifier +
       ")\\(" +
       dispatchRecordLocal +
+      dispatchArguments +
       "\\)\\]\\)",
     "g"
   );
   const awaitedDispatches = [...workerSegment.matchAll(awaitedDispatchPattern)];
   const directDispatchPattern = new RegExp(
-    "(" + identifier + ")\\(" + dispatchRecordLocal + "\\)",
+    "(" + identifier + ")\\(" + dispatchRecordLocal + dispatchArguments + "\\)",
     "g"
   );
   const directDispatches = [...workerSegment.matchAll(directDispatchPattern)];
@@ -3002,8 +3023,8 @@ function __calicoGatewayFastRestore(e,t){if(e)process.env.CLAUDE_CODE_EXTRA_BODY
 function __calicoGatewayFastPublish(e,t,r,n){let o=__calicoGatewayFastEnsure();if(!o.path)throw Error("gateway fast state is unavailable");let i=__calicoGatewayFastNode,s=i.path.dirname(o.path),a=i.path.basename(o.path)+"."+process.pid+"."+i.crypto.randomBytes(8).toString("hex")+".tmp",l=i.path.join(s,a),c=!1;try{i.fs.writeFileSync(l,e,{encoding:"utf8",mode:0o600,flag:"wx"});c=!0;i.fs.chmodSync(l,0o600);process.env.CLAUDE_CODE_EXTRA_BODY=t;i.fs.renameSync(l,o.path)}catch(u){__calicoGatewayFastRestore(r,n);if(c)try{i.fs.unlinkSync(l)}catch{}throw u}}
 function __calicoGatewayFastCommandValue(e){let t=typeof e==="string"?e.trim().toLowerCase():"";if(t!==""&&t!=="on"&&t!=="off")return'Unknown argument "'+t+'". Use: /fast [on|off]';try{let r=__calicoGatewayFastRead(),n=Object.prototype.hasOwnProperty.call(process.env,"CLAUDE_CODE_EXTRA_BODY"),o=process.env.CLAUDE_CODE_EXTRA_BODY,i=__calicoGatewayFastParse(o),s;if(t==="on")s="on";else if(t==="off")s="off";else if(r==="on")s="off";else if(r==="off")s="on";else s=__calicoGatewayFastTier(i)?"off":"on";if(s==="on"){__calicoGatewayFastTier(i);i.service_tier="priority"}else delete i.service_tier;let a=JSON.stringify(i);__calicoGatewayFastPublish(s,a,n,o);return s==="on"?"Gateway priority mode ON (this session only)":"Gateway priority mode OFF (this session only)"}catch(r){return"Gateway priority mode error: "+(r&&r.message?r.message:String(r))}}
 function __calicoGatewayFastInteractive(e,t){e(__calicoGatewayFastCommandValue(t));return null}
-function __calicoGatewayFastThin(e){return{type:"text",value:__calicoGatewayFastCommandValue(e)}}
-function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r}
+globalThis.__calicoGatewayFastThin=function(e){return{type:"text",value:__calicoGatewayFastCommandValue(e)}};
+globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};
 `;
 
   const interactiveReplacement = interactive[0].replace(
@@ -3012,7 +3033,7 @@ function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e
   );
   const thinReplacement = thin[0].replace(
     `if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`,
-    `if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(${thin[2]});if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`
+    `if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin(${thin[2]});if(!${thin[4]}())return{type:"text",value:${thin[5]}()??"Fast mode is not available"};`
   );
 
   const jsxDescription =
@@ -3037,7 +3058,7 @@ function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e
 
   const builderReplacement = builderSegment.replace(
     betaMergeNeedle,
-    `${builder[4]}=__calicoGatewayFastApply(${builder[4]});${betaMergeNeedle}`
+    `${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});${betaMergeNeedle}`
   );
   const workerReplacement =
     worker[0] +
@@ -3072,11 +3093,11 @@ function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e
     output.split("function __calicoGatewayFastEnsure").length - 1 !== 1 ||
     output.split("function __calicoGatewayFastParse").length - 1 !== 1 ||
     output.split("function __calicoGatewayFastCommandValue").length - 1 !== 1 ||
-    output.split("function __calicoGatewayFastApply").length - 1 !== 1 ||
+    output.split("globalThis.__calicoGatewayFastApply=").length - 1 !== 1 ||
     output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastInteractive').length - 1 !== 1 ||
-    output.split('if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin').length - 1 !== 1 ||
+    output.split('if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin').length - 1 !== 1 ||
     output.split(`CALICO_GATEWAY_FAST_STATE_FILE:${worker[1]}.CALICO_GATEWAY_FAST_STATE_FILE`).length - 1 !== 1 ||
-    output.split(`${builder[4]}=__calicoGatewayFastApply(${builder[4]});`).length - 1 !== 1
+    output.split(`${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});`).length - 1 !== 1
   ) {
     return { content: original, candidates, patched: 0 };
   }

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1939,7 +1939,13 @@ function patchCustomContextWindows(content) {
     candidates += 1;
     const helpers =
       'function __calico_context_window(e){try{let t=process.env.CALICO_MODEL_CONTEXT_WINDOWS;if(!t)return null;let r=JSON.parse(t);if(!r||typeof r!=="object"||Array.isArray(r)||!Object.hasOwn(r,e))return null;let n=r[e];if(!Number.isInteger(n)||n<100000||n>1000000)return null;return n}catch{return null}}' +
-      'function __calico_display_window(e){let t=Number(process.env.CALICO_CONTEXT_DISPLAY_PERCENT??100);if(!Number.isFinite(t)||t<1||t>100)return e;return Math.floor(e*t/100)}';
+      // __calico_display_window is declared here but called from the status-line
+      // site below, which upstream 2.1.242+ places in a different Bun chunk.
+      // Chunks are separate ES module scopes, so this one helper has to live on
+      // globalThis; a bare declaration resolves at patch time and is undefined
+      // at runtime. __calico_context_window stays local because it is only
+      // called from the resolver body injected immediately after it.
+      'globalThis.__calico_display_window=function(e){let t=Number(process.env.CALICO_CONTEXT_DISPLAY_PERCENT??100);if(!Number.isFinite(t)||t<1||t>100)return e;return Math.floor(e*t/100)};';
     const replacement =
       `${helpers}${functionStart}let __calico_window=__calico_context_window(e);` +
       `if(__calico_window!==null)return __calico_window;${originalBody}`;
@@ -1986,7 +1992,7 @@ function patchCustomContextWindows(content) {
     (full, contextFn, usage, windowValue) => {
       candidates += 1;
       patched += 1;
-      return `context_window:${contextFn}(${usage},__calico_display_window(${windowValue})),exceeds_200k_tokens:`;
+      return `context_window:${contextFn}(${usage},globalThis.__calico_display_window(${windowValue})),exceeds_200k_tokens:`;
     }
   );
 

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -776,7 +776,26 @@ function patchThinkingStreaming(content) {
             () => `,${cacheLocal}[${cacheSize}]=${thinkingLocal},${cacheLocal}[${resultSlot}]=${memoCall[1]};`
           );
 
-        const nextOutput = output
+        // Every edit here is applied to the one enclosing function, spliced
+        // back by offset. A plain `output.replace(text, …)` would rewrite the
+        // FIRST occurrence in the whole joined bundle, and minified names are
+        // not unique across chunks: `function kC(` occurs four times in
+        // 2.1.245, so the selector declaration landed in chunk 25 while its use
+        // stayed in chunk 117 and the binary died at startup with
+        // "__cc_streamingThinkingSelector is not defined". The uniqueness
+        // assertions below keep the in-region replaces honest.
+        const regionStart = functionStart;
+        const regionEnd = selectorRead.index + memoCall.index + memoCall[0].length;
+        const region = output.slice(regionStart, regionEnd);
+        if (
+          region.split(cacheAlloc[0]).length - 1 !== 1 ||
+          region.split(selectorRead[0]).length - 1 !== 1 ||
+          region.split(memoCall[0]).length - 1 !== 1
+        ) {
+          continue;
+        }
+
+        const patchedRegion = region
           .replace(
             cacheAlloc[0],
             () => `let ${cacheLocal}=${cacheAlloc[1]}(${cacheSize + 1})${cacheAlloc[3]}`
@@ -786,13 +805,13 @@ function patchThinkingStreaming(content) {
             () =>
               `${selectorRead[0]}${thinkingLocal}=${storeHook}(${turnLocal}?.stream,${selectorName})??null,`
           )
-          .replace(memoCall[0], () => grownCall)
-          .replace(
-            `function ${output.slice(functionStart + "function ".length).match(/^[A-Za-z_$][\w$]*/)[0]}(`,
-            () =>
-              `function ${selectorName}(e){return e.streamingThinking}` +
-              `function ${output.slice(functionStart + "function ".length).match(/^[A-Za-z_$][\w$]*/)[0]}(`
-          );
+          .replace(memoCall[0], () => grownCall);
+
+        const nextOutput =
+          output.slice(0, regionStart) +
+          `function ${selectorName}(e){return e.streamingThinking}` +
+          patchedRegion +
+          output.slice(regionEnd);
 
         if (nextOutput !== output) {
           output = nextOutput;

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -353,11 +353,30 @@ function joinClaudeJsModules(jsModules: BunJsModule[]): string {
 // identifier, so reject it here: a helper must either be declared in the same
 // chunk that references it, or be reached through globalThis.
 function assertInjectionsAreModuleScoped(parts: string[], jsModules: BunJsModule[]): void {
-  // A binding introduced by a patch: either a declaration keyword, or an
-  // assignment inside a declarator list (`let a=…,__calicoX=…`), which is how
-  // several patches introduce their locals.
-  const declarationPattern =
-    /(?:function|var|let|const|class)\s+(__calico[\w$]*)|[,;{(]\s*(__calico[\w$]*)\s*=(?!=)/g;
+  // Both prefixes this repo injects under. `__cc_` was missing here at first,
+  // which is how a `__cc_streamingThinkingSelector` declared in one chunk and
+  // referenced from another reached a built binary and killed it at startup.
+  // The prefix alone is not enough to identify our code: upstream generates a
+  // shell snippet containing `$__cc_name`, `__cc_set` and `read -r __cc_line`,
+  // so a name that already exists in the module's unpatched text is upstream's
+  // and is skipped below. That also narrows every check here to exactly what
+  // this patch run introduced into this module.
+  const injected = "(?:__calico|__cc_)[\\w$]*";
+  // A binding introduced by a patch: a declaration keyword, an assignment in a
+  // declarator list (`let a=…,__calicoX=…`), or a destructuring target
+  // (`{streamingThinking:__cc_state}=…`).
+  const declarationPattern = new RegExp(
+    `(?:function|var|let|const|class)\\s+(${injected})` +
+      `|[,;{(]\\s*(${injected})\\s*=(?!=)` +
+      `|:\\s*(${injected})\\s*(?=[,}])`,
+    "g"
+  );
+  // Arrow parameters bind too, but `(a,__cc_x)=>` and the call `f(a,__cc_x)`
+  // are textually identical up to the closing paren; the `=>` is the only thing
+  // separating a binding from a reference, and treating the second as the first
+  // is exactly the mistake this guard exists to catch, so require it.
+  const arrowParameterPattern = /\(([^()]*)\)\s*=>/g;
+  const injectedNamePattern = new RegExp(injected, "g");
   // A reference that has to resolve in this module's scope. Property positions
   // are excluded: a member access (`x.__calicoState`, and so also
   // `globalThis.__calicoHelper`) and an object key (`__calicoState:{…}`) name a
@@ -365,16 +384,27 @@ function assertInjectionsAreModuleScoped(parts: string[], jsModules: BunJsModule
   // `(?![\w$])` pins the name to its full extent first: without it the engine
   // backtracks a character at a time to satisfy the `:` lookahead, so
   // `__calicoUsageState:` would report a phantom `__calicoUsageStat` reference.
-  const referencePattern = /(?<![.\w$])(__calico[\w$]*)(?![\w$])(?!\s*:)/g;
+  const referencePattern = new RegExp(`(?<![.\\w$])(${injected})(?![\\w$])(?!\\s*:)`, "g");
 
   for (let index = 0; index < parts.length; index += 1) {
     const scoped = parts[index];
-    const declared = new Set(
-      Array.from(scoped.matchAll(declarationPattern), (match) => match[1] ?? match[2])
+    const preexisting = new Set(
+      Array.from(jsModules[index].content.matchAll(injectedNamePattern), (match) => match[0])
     );
+    const declared = new Set(
+      Array.from(
+        scoped.matchAll(declarationPattern),
+        (match) => match[1] ?? match[2] ?? match[3]
+      )
+    );
+    for (const parameterList of scoped.matchAll(arrowParameterPattern)) {
+      for (const parameter of parameterList[1].matchAll(injectedNamePattern)) {
+        declared.add(parameter[0]);
+      }
+    }
     const unresolved = new Set(
       Array.from(scoped.matchAll(referencePattern), (match) => match[1]).filter(
-        (name) => !declared.has(name)
+        (name) => !declared.has(name) && !preexisting.has(name)
       )
     );
 

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -353,14 +353,27 @@ function joinClaudeJsModules(jsModules: BunJsModule[]): string {
 // identifier, so reject it here: a helper must either be declared in the same
 // chunk that references it, or be reached through globalThis.
 function assertInjectionsAreModuleScoped(parts: string[], jsModules: BunJsModule[]): void {
-  const declarationPattern = /(?:function|var|let|const|class)\s+(__calico[\w$]*)/g;
-  const referencePattern = /__calico[\w$]*/g;
+  // A binding introduced by a patch: either a declaration keyword, or an
+  // assignment inside a declarator list (`let a=…,__calicoX=…`), which is how
+  // several patches introduce their locals.
+  const declarationPattern =
+    /(?:function|var|let|const|class)\s+(__calico[\w$]*)|[,;{(]\s*(__calico[\w$]*)\s*=(?!=)/g;
+  // A reference that has to resolve in this module's scope. Property positions
+  // are excluded: a member access (`x.__calicoState`, and so also
+  // `globalThis.__calicoHelper`) and an object key (`__calicoState:{…}`) name a
+  // property, not a binding, so they are legal wherever they appear.
+  // `(?![\w$])` pins the name to its full extent first: without it the engine
+  // backtracks a character at a time to satisfy the `:` lookahead, so
+  // `__calicoUsageState:` would report a phantom `__calicoUsageStat` reference.
+  const referencePattern = /(?<![.\w$])(__calico[\w$]*)(?![\w$])(?!\s*:)/g;
 
   for (let index = 0; index < parts.length; index += 1) {
-    const scoped = parts[index].replace(/globalThis\.__calico[\w$]*/g, "");
-    const declared = new Set(Array.from(scoped.matchAll(declarationPattern), (match) => match[1]));
+    const scoped = parts[index];
+    const declared = new Set(
+      Array.from(scoped.matchAll(declarationPattern), (match) => match[1] ?? match[2])
+    );
     const unresolved = new Set(
-      Array.from(scoped.matchAll(referencePattern), (match) => match[0]).filter(
+      Array.from(scoped.matchAll(referencePattern), (match) => match[1]).filter(
         (name) => !declared.has(name)
       )
     );

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -42,9 +42,28 @@ type BunStorage =
       moduleStructSize: 36 | 52;
     };
 
+type BunJsModule = {
+  index: number;
+  name: string;
+  content: string;
+};
+
 type LIEFModule = typeof import("node-lief");
 
 const BUN_TRAILER = Buffer.from("\n---- Bun! ----\n");
+
+// Bun's loader tag for JavaScript module payloads. Claude 2.1.242 split the
+// single `/$bunfs/root/cli` bundle into ~1,380 `/$bunfs/root/chunk-*.js`
+// modules that the cli module now dynamically imports, so the patchable source
+// is spread across every JS module rather than living in one of them.
+const BUN_LOADER_JS = 1;
+
+// Joins the JS modules into the single text the patcher consumes, and marks
+// where to cut it back apart. A comment keeps the joined text parseable, and
+// the split asserts the marker count so a patch that ate one fails loudly
+// instead of silently merging two modules.
+const BUN_MODULE_BOUNDARY = "\n/*@@calico-bun-module-boundary@@*/\n";
+
 const ELF_PT_LOAD = 1;
 const ELF_SHT_NOBITS = 8;
 const ELF_SHF_ALLOC = 0x2;
@@ -279,29 +298,107 @@ function parseElfBunStorage(binary: import("node-lief").ELF.Binary): BunStorage 
   };
 }
 
-function findClaudeModuleContent(storage: BunStorage): Buffer {
+// Collect every JavaScript module in the container. Selecting on the loader tag
+// rather than on module names deliberately makes no assumption about upstream's
+// chunk naming: it returns the whole cli bundle on pre-2.1.242 binaries and the
+// cli loader plus all of its chunks on 2.1.242+, and survives upstream renaming
+// the chunk scheme again. The Claude entry-point name is still required so that
+// canNativeBunHandle keeps rejecting unrelated Bun binaries.
+function readClaudeJsModules(storage: BunStorage): BunJsModule[] {
   const moduleTable = sliceRange(storage.bunData, storage.bunOffsets.modulesPtr);
   const moduleCount = Math.floor(moduleTable.length / storage.moduleStructSize);
+  const jsModules: BunJsModule[] = [];
+  let sawClaudeEntryPoint = false;
 
   for (let index = 0; index < moduleCount; index += 1) {
     const moduleOffset = index * storage.moduleStructSize;
     const moduleRecord = readBunModule(moduleTable, moduleOffset, storage.moduleStructSize);
     const moduleName = sliceRange(storage.bunData, moduleRecord.name).toString("utf8");
 
-    if (!isClaudeModuleName(moduleName)) {
+    if (isClaudeModuleName(moduleName)) {
+      sawClaudeEntryPoint = true;
+    }
+
+    if (moduleRecord.loader !== BUN_LOADER_JS) {
       continue;
     }
 
-    return sliceRange(storage.bunData, moduleRecord.contents);
+    jsModules.push({
+      index,
+      name: moduleName,
+      content: sliceRange(storage.bunData, moduleRecord.contents).toString("utf8"),
+    });
   }
 
-  throw new Error("Could not find Claude JavaScript module in native binary");
+  if (!sawClaudeEntryPoint || jsModules.length === 0) {
+    throw new Error("Could not find Claude JavaScript module in native binary");
+  }
+
+  return jsModules;
+}
+
+function joinClaudeJsModules(jsModules: BunJsModule[]): string {
+  for (const jsModule of jsModules) {
+    if (jsModule.content.includes(BUN_MODULE_BOUNDARY)) {
+      throw new Error(`Module boundary marker already present in ${jsModule.name}`);
+    }
+  }
+
+  return jsModules.map((jsModule) => jsModule.content).join(BUN_MODULE_BOUNDARY);
+}
+
+// Every chunk is its own ES module scope, so an injected helper declared in one
+// chunk is not visible from another. A patch that spans chunks still passes
+// every text-level check and then fails at runtime with an undefined
+// identifier, so reject it here: a helper must either be declared in the same
+// chunk that references it, or be reached through globalThis.
+function assertInjectionsAreModuleScoped(parts: string[], jsModules: BunJsModule[]): void {
+  const declarationPattern = /(?:function|var|let|const|class)\s+(__calico[\w$]*)/g;
+  const referencePattern = /__calico[\w$]*/g;
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const scoped = parts[index].replace(/globalThis\.__calico[\w$]*/g, "");
+    const declared = new Set(Array.from(scoped.matchAll(declarationPattern), (match) => match[1]));
+    const unresolved = new Set(
+      Array.from(scoped.matchAll(referencePattern), (match) => match[0]).filter(
+        (name) => !declared.has(name)
+      )
+    );
+
+    if (unresolved.size > 0) {
+      throw new Error(
+        `Patched module ${jsModules[index].name} references injected identifier(s) it does not ` +
+          `declare: ${Array.from(unresolved).sort().join(", ")}. Bun chunks are separate ES module ` +
+          "scopes, so declare the helper in the same chunk that uses it or hang it off globalThis."
+      );
+    }
+  }
+}
+
+function splitClaudeJsModules(
+  patchedContent: string,
+  jsModules: BunJsModule[]
+): Map<number, Buffer> {
+  const parts = patchedContent.split(BUN_MODULE_BOUNDARY);
+
+  if (parts.length !== jsModules.length) {
+    throw new Error(
+      `Patched content has ${parts.length} module section(s) but the binary has ` +
+        `${jsModules.length}; a patch consumed or introduced a module boundary marker`
+    );
+  }
+
+  assertInjectionsAreModuleScoped(parts, jsModules);
+
+  return new Map(
+    jsModules.map((jsModule, index) => [jsModule.index, Buffer.from(parts[index], "utf8")])
+  );
 }
 
 function rebuildBunData(
   bunData: Buffer,
   bunOffsets: BunOffsets,
-  replacementContent: Buffer,
+  replacementContents: Map<number, Buffer>,
   moduleStructSize: 36 | 52
 ): Buffer {
   const rawBuffers: Buffer[] = [];
@@ -324,11 +421,11 @@ function rebuildBunData(
   for (let index = 0; index < moduleCount; index += 1) {
     const moduleOffset = index * moduleStructSize;
     const moduleRecord = readBunModule(moduleTable, moduleOffset, moduleStructSize);
-    const moduleName = sliceRange(bunData, moduleRecord.name).toString("utf8");
 
-    const nextContents = isClaudeModuleName(moduleName)
-      ? replacementContent
-      : sliceRange(bunData, moduleRecord.contents);
+    // Offsets and lengths for every module are recomputed below from the
+    // rebuilt layout, so replacement contents are free to change size.
+    const nextContents =
+      replacementContents.get(index) ?? sliceRange(bunData, moduleRecord.contents);
 
     const nextModule = {
       name: sliceRange(bunData, moduleRecord.name),
@@ -882,13 +979,13 @@ function writeSectionBackedElfContent(
   writeBufferPreservingMode(binaryPath, nextBytes);
 }
 
-function writeElfBunContent(binaryPath: string, content: string): void {
+function writeElfBunContent(binaryPath: string, replacementContents: Map<number, Buffer>): void {
   const { binary } = parseElfBinary(binaryPath);
   const storage = parseElfBunStorage(binary);
   const rebuiltBunData = rebuildBunData(
     storage.bunData,
     storage.bunOffsets,
-    Buffer.from(content, "utf8"),
+    replacementContents,
     storage.moduleStructSize
   );
 
@@ -961,7 +1058,7 @@ function canNativeBunHandle(binaryPath: string): boolean {
   try {
     const { binary } = parseNativeBinary(binaryPath);
     const storage = parseNativeBunStorage(binary);
-    findClaudeModuleContent(storage);
+    readClaudeJsModules(storage);
     return true;
   } catch {
     return false;
@@ -971,7 +1068,7 @@ function canNativeBunHandle(binaryPath: string): boolean {
 function readNativeBunContent(binaryPath: string): string {
   const { binary } = parseNativeBinary(binaryPath);
   const storage = parseNativeBunStorage(binary);
-  return findClaudeModuleContent(storage).toString("utf8");
+  return joinClaudeJsModules(readClaudeJsModules(storage));
 }
 
 function writeMachOBunContent(
@@ -1025,15 +1122,16 @@ function writePeBunContent(
 function writeNativeBunContent(binaryPath: string, content: string): void {
   const { LIEF, binary } = parseNativeBinary(binaryPath);
   const storage = parseNativeBunStorage(binary);
+  const replacementContents = splitClaudeJsModules(content, readClaudeJsModules(storage));
   const rebuiltBunData = rebuildBunData(
     storage.bunData,
     storage.bunOffsets,
-    Buffer.from(content, "utf8"),
+    replacementContents,
     storage.moduleStructSize
   );
 
   if (binary.format === "ELF") {
-    writeElfBunContent(binaryPath, content);
+    writeElfBunContent(binaryPath, replacementContents);
     return;
   }
 
@@ -1050,4 +1148,8 @@ module.exports = {
   canNativeBunHandle,
   readNativeBunContent,
   writeNativeBunContent,
+  // Exported for tests: the join/split pair is the contract that keeps a
+  // chunked bundle reassemblable, and both failure modes are silent without it.
+  joinClaudeJsModules,
+  splitClaudeJsModules,
 };

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -1165,4 +1165,8 @@ module.exports = {
   // chunked bundle reassemblable, and both failure modes are silent without it.
   joinClaudeJsModules,
   splitClaudeJsModules,
+  // Exported so scripts/verify-patched-binary.ts can tell whether two sites in
+  // the joined text live in the same Bun module, and therefore whether a
+  // minified name captured at one is comparable at the other.
+  BUN_MODULE_BOUNDARY,
 };

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -1097,6 +1097,12 @@ function parseNativeBunStorage(
   };
 }
 
+function readClaudeJsModuleNames(binaryPath: string): string[] {
+  const { binary } = parseNativeBinary(binaryPath);
+  const storage = parseNativeBunStorage(binary);
+  return readClaudeJsModules(storage).map((jsModule) => jsModule.name);
+}
+
 function canNativeBunHandle(binaryPath: string): boolean {
   try {
     const { binary } = parseNativeBinary(binaryPath);
@@ -1199,4 +1205,8 @@ module.exports = {
   // the joined text live in the same Bun module, and therefore whether a
   // minified name captured at one is comparable at the other.
   BUN_MODULE_BOUNDARY,
+  // Module names in the same order joinClaudeJsModules emits their contents, so
+  // the verifier can resolve each chunk's import specifiers to a section of the
+  // joined text and reason about evaluation order.
+  readClaudeJsModuleNames,
 };

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1186,8 +1186,59 @@ const CHECKS: Check[] = [
         const rendererCallSites = [...content.matchAll(rendererCallSitePattern)].filter(
           (match) => match[1] !== "__cc_streamingThinking"
         );
-        if (rendererCallSites.length !== 1) {
+        // 2.1.245 replaced the explicit prop list at the main call site with a
+        // rest spread inside a React-compiler memo cache, so that shape is the
+        // second accepted form.
+        const compilerCallSitePattern =
+          /\{\.\.\.[A-Za-z_$][\w$]*,[^{}]*streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:__cc_streamingThinking[,}]/;
+        const usesCompilerCallSite = compilerCallSitePattern.test(content);
+        if (rendererCallSites.length !== 1 && !usesCompilerCallSite) {
           return `expected 1 renderer call-site streamingThinking prop, found ${rendererCallSites.length}`;
+        }
+
+        if (usesCompilerCallSite) {
+          // Passing the prop is not sufficient at a compiler-cached call site:
+          // the element is only rebuilt when one of the compared cache slots
+          // changes, so an injected value that occupies no slot would leave the
+          // renderer showing a stale element forever while every text-level
+          // check still passed. Pin the whole wiring — stable selector, one
+          // store read, and a guard slot that is written back and that lives
+          // inside a cache allocation grown to hold it.
+          if (
+            countOccurrences(
+              content,
+              "function __cc_streamingThinkingSelector(e){return e.streamingThinking}"
+            ) !== 1
+          ) {
+            return "expected exactly one stable __cc_streamingThinkingSelector declaration";
+          }
+          const storeReadPattern =
+            /__cc_streamingThinking=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\?\.stream,__cc_streamingThinkingSelector\)\?\?null,/g;
+          if ([...content.matchAll(storeReadPattern)].length !== 1) {
+            return "expected exactly one streamingThinking store read at the renderer call site";
+          }
+          const guards = [
+            ...content.matchAll(/([A-Za-z_$][\w$]*)\[(\d+)\]!==__cc_streamingThinking\)/g),
+          ];
+          if (guards.length !== 1) {
+            return `expected 1 memo-cache guard on __cc_streamingThinking, found ${guards.length}`;
+          }
+          const cacheLocal = guards[0][1];
+          const slot = Number(guards[0][2]);
+          if (countOccurrences(content, `${cacheLocal}[${slot}]=__cc_streamingThinking`) !== 1) {
+            return "expected the __cc_streamingThinking memo-cache slot to be written back";
+          }
+          const guardFunctionStart = content.lastIndexOf("function ", guards[0].index ?? -1);
+          const allocPattern = new RegExp(
+            `let ${cacheLocal.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}=[A-Za-z_$][\\w$]*\\((\\d+)\\)[,;]`
+          );
+          const alloc =
+            guardFunctionStart === -1
+              ? null
+              : content.slice(guardFunctionStart, guards[0].index).match(allocPattern);
+          if (!alloc || Number(alloc[1]) <= slot) {
+            return `expected the memo cache to be grown past slot ${slot} for __cc_streamingThinking`;
+          }
         }
         if (!content.includes("__cc_streamingThinkingExtras")) {
           return "expected inline streaming-thinking transcript extras";

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -36,6 +36,24 @@ type Check = {
   describe: string;
 };
 
+// A minified name captured at one site is only comparable at another when both
+// sites are in the same Bun module: 2.1.242+ splits the bundle into ES module
+// chunks that import each other under per-chunk aliases, so the same helper is
+// `po` in one chunk and `a` in the next. The joined text carries the module
+// boundaries, so cross-site name equalities stay enforced wherever they are
+// still meaningful and are skipped only where the names cannot match by
+// construction. On a pre-2.1.242 monolith every gateway site is in the cli
+// module, so every equality below applies exactly as it did before.
+const { BUN_MODULE_BOUNDARY } = require("./native-bun.ts") as { BUN_MODULE_BOUNDARY: string };
+
+function inSameModule(content: string, first: number, second: number): boolean {
+  if (first < 0 || second < 0) {
+    return false;
+  }
+  const [low, high] = first <= second ? [first, second] : [second, first];
+  return !content.slice(low, high).includes(BUN_MODULE_BOUNDARY);
+}
+
 function countOccurrences(content: string, needle: string): number {
   let count = 0;
   let index = content.indexOf(needle);
@@ -69,7 +87,7 @@ const CHECKS: Check[] = [
       const stateDeclaration =
         "var __calicoGatewayFastState={path:null,dir:null,owner:!1};";
       const applyHelper =
-        'function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r}';
+        'globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};';
 
       if (
         countOccurrences(content, nodeDeclaration) !== 1 ||
@@ -110,6 +128,12 @@ const CHECKS: Check[] = [
         }
       }
 
+      // __calicoGatewayFastThin and __calicoGatewayFastApply are the only two
+      // gateway helpers reached from a chunk other than the one carrying the
+      // helper block (2.1.245: declared in chunk 138, called from 1181 and
+      // 435), so they are installed on globalThis and every other helper stays
+      // a plain module-scoped declaration.
+      const globalHelpers = new Set(["__calicoGatewayFastThin", "__calicoGatewayFastApply"]);
       for (const name of [
         "__calicoGatewayFastEnsure",
         "__calicoGatewayFastRead",
@@ -122,8 +146,11 @@ const CHECKS: Check[] = [
         "__calicoGatewayFastThin",
         "__calicoGatewayFastApply",
       ]) {
-        if (countOccurrences(content, `function ${name}`) !== 1) {
-          return `expected one function declaration for ${name}`;
+        const declaration = globalHelpers.has(name)
+          ? `globalThis.${name}=`
+          : `function ${name}`;
+        if (countOccurrences(content, declaration) !== 1) {
+          return `expected one ${declaration.replace(name, "")}${name} declaration`;
         }
         const alternateBinding = new RegExp(
           `(?:var|let|const)\\s+${name}\\b|(?:^|[;,])${name}=`,
@@ -197,13 +224,17 @@ const CHECKS: Check[] = [
         !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
         !interactiveSegment.includes(".getAppState") ||
         !interactiveSegment.includes(".setAppState") ||
-        !interactiveSegment.includes(".jsx(")
+        // 2.1.242+ destructures the JSX factory, so match a component call
+        // shape rather than a `.jsx(` literal.
+        !/[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,\{[^}]*\}\)/.test(
+          interactiveSegment
+        )
       ) {
         return "interactive native Fast action, picker, or app-state fallback is missing";
       }
 
       const thinPattern = new RegExp(
-        `async function (${identifier})\\((${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return __calicoGatewayFastThin\\(\\2\\);if\\(!(${identifier})\\(\\)\\)return\\{type:"text",value:(${identifier})\\(\\)\\?\\?"Fast mode is not available"\\};`,
+        `async function (${identifier})\\((${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return globalThis\\.__calicoGatewayFastThin\\(\\2\\);if\\(!(${identifier})\\(\\)\\)return\\{type:"text",value:(${identifier})\\(\\)\\?\\?"Fast mode is not available"\\};`,
         "g"
       );
       const thinMatches = [...content.matchAll(thinPattern)];
@@ -222,10 +253,17 @@ const CHECKS: Check[] = [
       const thinAction = thinSegment.match(
         /await ([A-Za-z_$][\w$]*)\([^;]*?"bridge"/
       )?.[1];
+      const handlersShareModule = inSameModule(
+        content,
+        interactive.index ?? -1,
+        thin.index ?? -1
+      );
       if (
-        interactive[5] !== thin[4] ||
-        interactive[6] !== thin[5] ||
-        thinAction !== interactiveAction ||
+        !thinAction ||
+        (handlersShareModule &&
+          (interactive[5] !== thin[4] ||
+            interactive[6] !== thin[5] ||
+            thinAction !== interactiveAction)) ||
         !/\.options\.fastMode(?![A-Za-z0-9_$])/.test(thinSegment) ||
         !thinSegment.includes("Unknown argument") ||
         !thinSegment.includes(".getAppState") ||
@@ -235,7 +273,7 @@ const CHECKS: Check[] = [
       }
 
       const localJsxPattern =
-        /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?"Toggle gateway priority tier":`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?!1:!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",get immediate\(\)\{return ([A-Za-z_$][\w$]*)\(\)\},requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
+        /([A-Za-z_$][\w$]*)=\{type:"local-jsx",name:"fast",get description\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?"Toggle gateway priority tier":`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},get isHidden\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?!1:!([A-Za-z_$][\w$]*)\(\)\},argumentHint:"\[on\|off\]",(?:get immediate\(\)\{return [A-Za-z_$][\w$]*\(\)\}|immediate:!0),requires:\{ink:!0\},thinClientDispatch:"control-request"\}/g;
       const localPattern =
         /([A-Za-z_$][\w$]*)=\{type:"local",name:"fast",supportsNonInteractive:!0,get description\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?"Toggle gateway priority tier":`Toggle fast mode \(\$\{([A-Za-z_$][\w$]*)\(\)\}\)`\},argumentHint:"\[on\|off\]",isEnabled:\(\)=>process\.env\.REMORA_ACTIVE==="1"\|\|([A-Za-z_$][\w$]*)\(\),get isHidden\(\)\{return process\.env\.REMORA_ACTIVE==="1"\?!1:!([A-Za-z_$][\w$]*)\(\)\}/g;
       const localJsxMatches = [...content.matchAll(localJsxPattern)];
@@ -243,9 +281,14 @@ const CHECKS: Check[] = [
       if (localJsxMatches.length !== 1 || localMatches.length !== 1) {
         return "gateway-aware Fast command registrations are missing or duplicated";
       }
+      const registrationSharesInteractiveModule = inSameModule(
+        content,
+        localJsxMatches[0].index ?? -1,
+        interactive.index ?? -1
+      );
       if (
         localJsxMatches[0][2] !== localMatches[0][2] ||
-        localJsxMatches[0][3] !== interactive[5] ||
+        (registrationSharesInteractiveModule && localJsxMatches[0][3] !== interactive[5]) ||
         localMatches[0][3] !== localMatches[0][4]
       ) {
         return "Fast registrations changed native description or visibility gate ownership";
@@ -264,7 +307,7 @@ const CHECKS: Check[] = [
       const builderEndCandidate = content.indexOf("function ", builderStart + builder[0].length);
       const builderEnd = builderEndCandidate === -1 ? content.length : builderEndCandidate;
       const builderSegment = content.slice(builderStart, builderEnd);
-      const applyNeedle = `${builder[4]}=__calicoGatewayFastApply(${builder[4]});`;
+      const applyNeedle = `${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});`;
       const betaNeedle = `if(${builder[2]}&&${builder[2]}.length>0){`;
       const parseErrorIndex = builderSegment.indexOf(
         "Error parsing CLAUDE_CODE_EXTRA_BODY:"
@@ -364,13 +407,16 @@ const CHECKS: Check[] = [
       }
       const dispatchRecord = dispatchRecords[0];
       const dispatchRecordLocal = dispatchRecord.match[1];
+      // 2.1.239 appended arguments to the dispatch call; accept a trailing
+      // argument list one level of call nesting deep, matching the patcher.
+      const dispatchArguments = "(?:,(?:[^()]|\\([^()]*\\))*)?";
       const awaitedDispatchPattern = new RegExp(
-        `\\},\\[,(${identifier})\\]=await Promise\\.all\\(\\[(?:(?!\\]\\))[\\s\\S])*?,(${identifier})\\(${dispatchRecordLocal}\\)\\]\\)`,
+        `\\},\\[,(${identifier})\\]=await Promise\\.all\\(\\[(?:(?!\\]\\))[\\s\\S])*?,(${identifier})\\(${dispatchRecordLocal}${dispatchArguments}\\)\\]\\)`,
         "g"
       );
       const awaitedDispatches = [...workerSegment.matchAll(awaitedDispatchPattern)];
       const directDispatchPattern = new RegExp(
-        `(${identifier})\\(${dispatchRecordLocal}\\)`,
+        `(${identifier})\\(${dispatchRecordLocal}${dispatchArguments}\\)`,
         "g"
       );
       const directDispatches = [...workerSegment.matchAll(directDispatchPattern)];

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1407,6 +1407,30 @@ const CHECKS: Check[] = [
         if (!content.includes("__cc_streamingThinkingExtras")) {
           return "expected inline streaming-thinking transcript extras";
         }
+        // The stream reducer builds virtual thinking messages through
+        // upstream's create-message helper. That helper's name is a per-chunk
+        // import alias on 2.1.242+, so a name captured elsewhere resolves to a
+        // different function here: a 2.1.245 build called the wrong one and
+        // every turn with a thinking block rendered no assistant output, with
+        // no error surfaced. Require the called name to be declared in the
+        // reducer's own module.
+        const reducerCalls = [
+          ...content.matchAll(/__cc_streamingThinkingMessage=([A-Za-z_$][\w$]*)\(\{content:/g),
+        ];
+        // Presence is already covered by the threading and extras checks above;
+        // what this adds is that whatever the reducer calls resolves here.
+        for (const call of reducerCalls) {
+          const declaration = new RegExp(
+            `function ${call[1]}\\(\\{content:[A-Za-z_$][\\w$]*,usage:`,
+            "g"
+          );
+          const declared = [...content.matchAll(declaration)].some((match) =>
+            inSameModule(content, match.index ?? -1, call.index ?? -1)
+          );
+          if (!declared) {
+            return `stream reducer calls ${call[1]} to build virtual thinking messages, but that name is not the create-message helper declared in its own module`;
+          }
+        }
       }
       return null;
     },

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -401,9 +401,9 @@ const CHECKS: Check[] = [
         return `missing marker(s): ${missing.join(", ")}`;
       }
       const frozenAgentContext =
-        /process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*\.__calicoPromptId===void 0&&\([A-Za-z_$][\w$]*\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?[A-Za-z_$][\w$]*\(\)\),\1\.run\(/;
+        /process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*\.__calicoPromptId===void 0&&\([A-Za-z_$][\w$]*\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?globalThis\.__calicoPromptIdGet\(\)\),\1\.run\(/;
       const frozenJournalContext =
-        /function [A-Za-z_$][\w$]*\(e,t\)\{e&&process\.env\.REMORA_ACTIVE==="1"&&e\.__calicoPromptId===void 0&&\(e\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?[A-Za-z_$][\w$]*\(\)\);if\(!\("turnAttributionKey"in e\)\)e\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return \1\.run\(e,\(\)=>[A-Za-z_$][\w$]*\(e\.turnAttributionKey,t\)\)/;
+        /function [A-Za-z_$][\w$]*\(e,t\)\{e&&process\.env\.REMORA_ACTIVE==="1"&&e\.__calicoPromptId===void 0&&\(e\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?globalThis\.__calicoPromptIdGet\(\)\);if\(!\("turnAttributionKey"in e\)\)e\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return \1\.run\(e,\(\)=>[A-Za-z_$][\w$]*\(e\.turnAttributionKey,t\)\)/;
       if (!frozenAgentContext.test(content) && !frozenJournalContext.test(content)) {
         return "missing nested-agent prompt inheritance at AsyncLocalStorage boundary";
       }
@@ -704,20 +704,20 @@ const CHECKS: Check[] = [
     run: (content: string): string | null => {
       const identifier = "[A-Za-z_$][\\w$]*";
       const accountingSignalHelper =
-        'function __calicoUsageHasAccountingSignal(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)}';
+        'globalThis.__calicoUsageHasAccountingSignal=function(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)};';
       const exactZeroHelper =
-        'function __calicoUsageIsExactAllZero(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)}';
+        'globalThis.__calicoUsageIsExactAllZero=function(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)};';
       const statuslineHelper =
-        'function __calicoStatuslineMessages(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})}';
+        'globalThis.__calicoStatuslineMessages=function(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&globalThis.__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})};';
       const stateCell = "__calicoUsageState:{committed:!1,usage:null}";
       const helperMarkers: Array<[string, number]> = [
         [stateCell, 1],
         [accountingSignalHelper, 1],
         [exactZeroHelper, 1],
         [statuslineHelper, 1],
-        ["__calicoUsageHasAccountingSignal(", 3],
-        ["__calicoUsageIsExactAllZero(", 2],
-        ["__calicoStatuslineMessages(", 2],
+        ["globalThis.__calicoUsageHasAccountingSignal=", 1],
+        ["globalThis.__calicoUsageIsExactAllZero=", 1],
+        ["globalThis.__calicoStatuslineMessages=", 1],
       ];
       for (const [marker, expected] of helperMarkers) {
         const actual = countOccurrences(content, marker);
@@ -758,11 +758,11 @@ const CHECKS: Check[] = [
       }
 
       const legacyWrapperPattern = new RegExp(
-        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\}\\};`,
+        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\}\\};`,
         "g"
       );
       const effortWrapperPattern = new RegExp(
-        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
         "g"
       );
       // 2.1.236+ batch tool-use destructured wrapper; see the matching
@@ -771,7 +771,7 @@ const CHECKS: Check[] = [
       // (`…messageId:Gr.id},i.storageV5)`), matched optionally so the patched
       // 2.1.237 and 2.1.238 binaries both verify.
       const batchWrapperPattern = new RegExp(
-        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})\\.randomUUID\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
         "g"
       );
       const wrapperMatches = [
@@ -830,7 +830,7 @@ const CHECKS: Check[] = [
       const wrapperFunctionStart = content.lastIndexOf("function ", wrapperIndex);
 
       const terminalPattern = new RegExp(
-        `for\\(let (${identifier}) of (${identifier})\\)\\1\\.message\\.usage=(${identifier}),\\1\\.message\\.stop_reason=(${identifier}),\\1\\.message\\.stop_details=(${identifier})\\.delta\\.stop_details\\?\\?null,\\4!=null&&!__calicoUsageIsExactAllZero\\(\\5\\.usage\\)&&__calicoUsageHasAccountingSignal\\(\\3\\)&&\\(\\1\\.__calicoUsageState\\.committed=!0,\\1\\.__calicoUsageState\\.usage=\\3\\);`,
+        `for\\(let (${identifier}) of (${identifier})\\)\\1\\.message\\.usage=(${identifier}),\\1\\.message\\.stop_reason=(${identifier}),\\1\\.message\\.stop_details=(${identifier})\\.delta\\.stop_details\\?\\?null,\\4!=null&&!globalThis\\.__calicoUsageIsExactAllZero\\(\\5\\.usage\\)&&globalThis\\.__calicoUsageHasAccountingSignal\\(\\3\\)&&\\(\\1\\.__calicoUsageState\\.committed=!0,\\1\\.__calicoUsageState\\.usage=\\3\\);`,
         "g"
       );
       const terminalMatches = [...content.matchAll(terminalPattern)];
@@ -941,10 +941,12 @@ const CHECKS: Check[] = [
       if (usageReducerMatches.length !== 1) {
         return `expected 1 semantic statusline usage reducer, found ${usageReducerMatches.length}`;
       }
-      const usageReducer = usageReducerMatches[0][1];
-      const escapedUsageReducer = usageReducer.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // The reducer is called through a per-chunk import alias on 2.1.242+, so
+      // it cannot be pinned by the name captured at its declaration. Mirror the
+      // patcher: anchor on the `?.outputStyle||` assignment that precedes the
+      // selector, inside the function that emits `context_window:`.
       const selectorPattern = new RegExp(
-        `(${identifier})=${escapedUsageReducer}\\(__calicoStatuslineMessages\\((${identifier})\\)\\),(${identifier})=(${identifier})\\((${identifier}),(${identifier})\\(\\)\\)`,
+        `${identifier}=${identifier}\\?\\.outputStyle\\|\\|[^,]{1,40},(${identifier})=${identifier}\\(globalThis\\.__calicoStatuslineMessages\\((${identifier})\\)\\),(${identifier})=(${identifier})\\((${identifier}),(${identifier})\\(\\)\\)`,
         "g"
       );
       const selectorCandidates = [...content.matchAll(selectorPattern)];
@@ -956,7 +958,15 @@ const CHECKS: Check[] = [
           functionStart,
           functionEnd === -1 ? content.length : functionEnd
         );
-        return segment.includes("context_window:");
+        // The selected usage and the computed window must be the two arguments
+        // the payload's `context_window:` is built from. custom-context-window
+        // runs after this module and wraps the window argument, so tolerate
+        // that wrapper here.
+        const escape = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const consumption = new RegExp(
+          `context_window:${identifier}\\(${escape(match[1])},(?:globalThis\\.__calico_display_window\\()?${escape(match[3])}\\)`
+        );
+        return segment.includes("context_window:") && consumption.test(segment);
       });
       if (selectorMatches.length !== 1) {
         return `expected 1 reducer-bound statusline selector projection, found ${selectorMatches.length}`;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -54,6 +54,82 @@ function inSameModule(content: string, first: number, second: number): boolean {
   return !content.slice(low, high).includes(BUN_MODULE_BOUNDARY);
 }
 
+// Cross-chunk references through globalThis are only safe when the chunk doing
+// the reading statically imports (transitively) the chunk doing the writing:
+// only then is the publisher guaranteed to have been evaluated first. Of 1,384
+// modules in 2.1.245, exactly 8 are statically reachable from the cli entry —
+// everything else arrives through dynamic import — so "it will have been
+// evaluated by then" is never a safe assumption. A build that published the
+// gateway helpers from an unreachable chunk threw
+// "globalThis.__calicoGatewayFastApply is not a function" on every request and
+// produced no output at all, while every other check here passed.
+function unreachableGlobalPublications(content: string, moduleNames: string[]): string[] {
+  const modules = content.split(BUN_MODULE_BOUNDARY);
+  if (modules.length < 2 || modules.length !== moduleNames.length) {
+    return [];
+  }
+
+  const indexByName = new Map(moduleNames.map((name, index) => [name, index]));
+  const staticImportPattern = /import\s*(?:[^"';]*?from\s*)?"([^"]+\.js)"/g;
+  const dynamicImportPattern = /import\("([^"]+\.js)"\)/g;
+
+  const staticEdges = modules.map((module) => {
+    const dynamic = new Set(
+      Array.from(module.matchAll(dynamicImportPattern), (match) => match[1])
+    );
+    return Array.from(
+      new Set(Array.from(module.matchAll(staticImportPattern), (match) => match[1]))
+    )
+      .filter((target) => !dynamic.has(target))
+      .map((target) => indexByName.get(target))
+      .filter((index): index is number => index !== undefined);
+  });
+
+  const closures = new Map<number, Set<number>>();
+  const closureOf = (start: number): Set<number> => {
+    const cached = closures.get(start);
+    if (cached) {
+      return cached;
+    }
+    const seen = new Set([start]);
+    const stack = [start];
+    while (stack.length > 0) {
+      for (const next of staticEdges[stack.pop() as number]) {
+        if (!seen.has(next)) {
+          seen.add(next);
+          stack.push(next);
+        }
+      }
+    }
+    closures.set(start, seen);
+    return seen;
+  };
+
+  const publisherPattern = /globalThis\.((?:__calico|__cc_)[\w$]*)\s*=/g;
+  const publishers = new Map<string, number>();
+  modules.forEach((module, index) => {
+    for (const match of module.matchAll(publisherPattern)) {
+      publishers.set(match[1], index);
+    }
+  });
+
+  const problems: string[] = [];
+  for (const [name, publisher] of publishers) {
+    modules.forEach((module, index) => {
+      const uses = countOccurrences(module, `globalThis.${name}`);
+      const declares = countOccurrences(module, `globalThis.${name}=`);
+      if (uses - declares <= 0 || closureOf(index).has(publisher)) {
+        return;
+      }
+      problems.push(
+        `${name} is read in ${moduleNames[index]} but published in ${moduleNames[publisher]}, ` +
+          "which that module does not statically import, so it may not be evaluated first"
+      );
+    });
+  }
+  return problems;
+}
+
 function countOccurrences(content: string, needle: string): number {
   let count = 0;
   let index = content.indexOf(needle);
@@ -87,53 +163,82 @@ const CHECKS: Check[] = [
       const stateDeclaration =
         "var __calicoGatewayFastState={path:null,dir:null,owner:!1};";
       const applyHelper =
-        'globalThis.__calicoGatewayFastApply=function(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};';
+        'function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e;let t=__calicoGatewayFastRead(),r={...e};if(t==="on")r.service_tier="priority";else if(t==="off")delete r.service_tier;return r};';
 
+      // One self-contained copy per consuming chunk. The interactive handler,
+      // the thin handler and the request extra-body builder are in three Bun
+      // chunks that do not import one another, so a single shared definition is
+      // not reliably evaluated before it is used: a 2.1.245 build that shared
+      // them through globalThis threw "globalThis.__calicoGatewayFastApply is
+      // not a function" on every request. The copies reconcile at runtime
+      // through CALICO_GATEWAY_FAST_STATE_FILE.
+      const blockCount = 3;
+      const blockStarts: number[] = [];
+      for (let at = content.indexOf(nodeDeclaration); at !== -1; ) {
+        blockStarts.push(at);
+        at = content.indexOf(nodeDeclaration, at + nodeDeclaration.length);
+      }
       if (
-        countOccurrences(content, nodeDeclaration) !== 1 ||
-        countOccurrences(content, stateDeclaration) !== 1 ||
-        countOccurrences(content, applyHelper) !== 1
+        blockStarts.length !== blockCount ||
+        countOccurrences(content, stateDeclaration) !== blockCount ||
+        countOccurrences(content, applyHelper) !== blockCount
       ) {
-        return "gateway fast state or request helper is missing, duplicated, or not exact";
+        return `expected ${blockCount} gateway helper blocks, one per consuming chunk`;
       }
 
-      const helperStart = content.indexOf(nodeDeclaration);
-      const interactiveStartMarker = content.indexOf("\nasync function ", helperStart);
-      if (helperStart === -1 || interactiveStartMarker === -1) {
-        return "gateway helper block is not adjacent to the interactive handler";
+      const blocks = blockStarts.map((at) => {
+        const applyAt = content.indexOf(applyHelper, at);
+        return applyAt === -1 ? "" : content.slice(at, applyAt + applyHelper.length);
+      });
+      if (blocks.some((block) => block === "")) {
+        return "a gateway helper block is missing its request helper";
       }
-      const helperBlock = content.slice(helperStart, interactiveStartMarker);
-      if (!helperBlock.endsWith(applyHelper)) {
-        return "gateway helper block is commented, detached, or followed by alternate code";
+      if (blocks.some((block) => block !== blocks[0])) {
+        return "gateway helper blocks are not identical copies";
       }
+      // Each block must sit immediately before the function that uses it, so a
+      // detached or commented-out copy fails here.
+      for (const [index, at] of blockStarts.entries()) {
+        const after = content.slice(at + blocks[index].length).replace(/^\n/, "");
+        if (!after.startsWith("function ") && !after.startsWith("async function ")) {
+          return "a gateway helper block is commented, detached, or followed by alternate code";
+        }
+      }
+      const helperBlock = blocks[0];
 
-      const expectedReferences: Array<[string, number]> = [
-        ["__calicoGatewayFastNode", 4],
-        ["__calicoGatewayFastState", 10],
-        ["__calicoGatewayFastEnsure", 4],
-        ["__calicoGatewayFastRead", 3],
-        ["__calicoGatewayFastParse", 2],
-        ["__calicoGatewayFastTier", 3],
-        ["__calicoGatewayFastRestore", 2],
-        ["__calicoGatewayFastPublish", 2],
-        ["__calicoGatewayFastCommandValue", 3],
-        ["__calicoGatewayFastInteractive", 2],
-        ["__calicoGatewayFastThin", 2],
-        ["__calicoGatewayFastApply", 2],
+      // Per-block reference counts, plus the one external call site each of the
+      // three entry points has. Deriving the totals this way keeps the original
+      // no-stray-reference strength while staying copy-count agnostic.
+      const expectedReferences: Array<[string, number, number]> = [
+        ["__calicoGatewayFastNode", 4, 0],
+        ["__calicoGatewayFastState", 10, 0],
+        ["__calicoGatewayFastEnsure", 4, 0],
+        ["__calicoGatewayFastRead", 3, 0],
+        ["__calicoGatewayFastParse", 2, 0],
+        ["__calicoGatewayFastTier", 3, 0],
+        ["__calicoGatewayFastRestore", 2, 0],
+        ["__calicoGatewayFastPublish", 2, 0],
+        ["__calicoGatewayFastCommandValue", 3, 0],
+        ["__calicoGatewayFastInteractive", 1, 1],
+        ["__calicoGatewayFastThin", 1, 1],
+        ["__calicoGatewayFastApply", 1, 1],
       ];
-      for (const [name, expected] of expectedReferences) {
+      for (const [name, perBlock, external] of expectedReferences) {
+        if (countOccurrences(helperBlock, name) !== perBlock) {
+          return `expected ${perBlock} reference(s) to ${name} inside the helper block, found ${countOccurrences(helperBlock, name)}`;
+        }
+        const expected = perBlock * blockCount + external;
         const actual = countOccurrences(content, name);
         if (actual !== expected) {
           return `expected ${expected} total references to ${name}, found ${actual}`;
         }
       }
 
-      // __calicoGatewayFastThin and __calicoGatewayFastApply are the only two
-      // gateway helpers reached from a chunk other than the one carrying the
-      // helper block (2.1.245: declared in chunk 138, called from 1181 and
-      // 435), so they are installed on globalThis and every other helper stays
-      // a plain module-scoped declaration.
-      const globalHelpers = new Set(["__calicoGatewayFastThin", "__calicoGatewayFastApply"]);
+      for (const name of expectedReferences.map(([n]) => n)) {
+        if (countOccurrences(content, `function ${name}`) !== blockCount) {
+          continue;
+        }
+      }
       for (const name of [
         "__calicoGatewayFastEnsure",
         "__calicoGatewayFastRead",
@@ -146,11 +251,8 @@ const CHECKS: Check[] = [
         "__calicoGatewayFastThin",
         "__calicoGatewayFastApply",
       ]) {
-        const declaration = globalHelpers.has(name)
-          ? `globalThis.${name}=`
-          : `function ${name}`;
-        if (countOccurrences(content, declaration) !== 1) {
-          return `expected one ${declaration.replace(name, "")}${name} declaration`;
+        if (countOccurrences(content, `function ${name}`) !== blockCount) {
+          return `expected ${blockCount} ${name} declarations, one per consuming chunk`;
         }
         const alternateBinding = new RegExp(
           `(?:var|let|const)\\s+${name}\\b|(?:^|[;,])${name}=`,
@@ -200,10 +302,18 @@ const CHECKS: Check[] = [
         `async function (${identifier})\\((${identifier}),(${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return __calicoGatewayFastInteractive\\(\\2,\\4\\);if\\(!(${identifier})\\(\\)\\)return \\2\\((${identifier})\\(\\)\\?\\?"Fast mode is not available"\\),null;`,
         "g"
       );
+      // Each consumer must be immediately preceded by its own helper block, so
+      // a copy that drifted away from the code that needs it fails here.
+      const precededByHelperBlock = (index: number): boolean =>
+        content
+          .slice(0, index)
+          .replace(/\n$/, "")
+          .endsWith(helperBlock);
+
       const interactiveMatches = [...content.matchAll(interactivePattern)];
       if (
         interactiveMatches.length !== 1 ||
-        interactiveMatches[0].index !== interactiveStartMarker + 1
+        !precededByHelperBlock(interactiveMatches[0].index ?? -1)
       ) {
         return "interactive remora branch is missing, duplicated, or not before the native gate";
       }
@@ -234,11 +344,11 @@ const CHECKS: Check[] = [
       }
 
       const thinPattern = new RegExp(
-        `async function (${identifier})\\((${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return globalThis\\.__calicoGatewayFastThin\\(\\2\\);if\\(!(${identifier})\\(\\)\\)return\\{type:"text",value:(${identifier})\\(\\)\\?\\?"Fast mode is not available"\\};`,
+        `async function (${identifier})\\((${identifier}),(${identifier})\\)\\{if\\(process\\.env\\.REMORA_ACTIVE==="1"\\)return __calicoGatewayFastThin\\(\\2\\);if\\(!(${identifier})\\(\\)\\)return\\{type:"text",value:(${identifier})\\(\\)\\?\\?"Fast mode is not available"\\};`,
         "g"
       );
       const thinMatches = [...content.matchAll(thinPattern)];
-      if (thinMatches.length !== 1) {
+      if (thinMatches.length !== 1 || !precededByHelperBlock(thinMatches[0].index ?? -1)) {
         return "thin-client remora branch is missing, duplicated, or not before the native gate";
       }
       const thin = thinMatches[0];
@@ -304,10 +414,13 @@ const CHECKS: Check[] = [
       }
       const builder = builderMatches[0];
       const builderStart = builder.index ?? -1;
+      if (!precededByHelperBlock(builderStart)) {
+        return "request extra-body builder is not preceded by its gateway helper block";
+      }
       const builderEndCandidate = content.indexOf("function ", builderStart + builder[0].length);
       const builderEnd = builderEndCandidate === -1 ? content.length : builderEndCandidate;
       const builderSegment = content.slice(builderStart, builderEnd);
-      const applyNeedle = `${builder[4]}=globalThis.__calicoGatewayFastApply(${builder[4]});`;
+      const applyNeedle = `${builder[4]}=__calicoGatewayFastApply(${builder[4]});`;
       const betaNeedle = `if(${builder[2]}&&${builder[2]}.length>0){`;
       const parseErrorIndex = builderSegment.indexOf(
         "Error parsing CLAUDE_CODE_EXTRA_BODY:"
@@ -750,20 +863,22 @@ const CHECKS: Check[] = [
     run: (content: string): string | null => {
       const identifier = "[A-Za-z_$][\\w$]*";
       const accountingSignalHelper =
-        'globalThis.__calicoUsageHasAccountingSignal=function(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)};';
+        'function __calicoUsageHasAccountingSignal(e){if(!e||typeof e!=="object")return!1;return["input_tokens","output_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((t)=>typeof e[t]==="number"&&e[t]!==0)}';
       const exactZeroHelper =
-        'globalThis.__calicoUsageIsExactAllZero=function(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)};';
+        'function __calicoUsageIsExactAllZero(e){if(!e||typeof e!=="object")return!1;return e.input_tokens===0&&e.output_tokens===0&&(e.cache_creation_input_tokens===void 0||e.cache_creation_input_tokens===0)&&(e.cache_read_input_tokens===void 0||e.cache_read_input_tokens===0)&&(e.cache_creation?.ephemeral_1h_input_tokens===void 0||e.cache_creation?.ephemeral_1h_input_tokens===0)&&(e.cache_creation?.ephemeral_5m_input_tokens===void 0||e.cache_creation?.ephemeral_5m_input_tokens===0)}';
       const statuslineHelper =
-        'globalThis.__calicoStatuslineMessages=function(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&globalThis.__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})};';
+        'function __calicoStatuslineMessages(e){if(!Array.isArray(e))return e;return e.flatMap((t)=>{if(t?.type!=="assistant")return[t];let r=t.__calicoUsageState;if(r?.committed===!0&&r.usage)return[{...t,message:{...t.message,usage:r.usage}}];if(r===void 0&&t.message?.stop_reason!=null&&__calicoUsageHasAccountingSignal(t.message?.usage))return[t];return[]})}';
       const stateCell = "__calicoUsageState:{committed:!1,usage:null}";
       const helperMarkers: Array<[string, number]> = [
         [stateCell, 1],
-        [accountingSignalHelper, 1],
-        [exactZeroHelper, 1],
+        // One copy per consuming chunk; see the patcher for why a single
+        // shared definition is not reliably evaluated first.
+        [accountingSignalHelper, 2],
+        [exactZeroHelper, 2],
         [statuslineHelper, 1],
-        ["globalThis.__calicoUsageHasAccountingSignal=", 1],
-        ["globalThis.__calicoUsageIsExactAllZero=", 1],
-        ["globalThis.__calicoStatuslineMessages=", 1],
+        ["function __calicoUsageHasAccountingSignal", 2],
+        ["function __calicoUsageIsExactAllZero", 2],
+        ["function __calicoStatuslineMessages", 1],
       ];
       for (const [marker, expected] of helperMarkers) {
         const actual = countOccurrences(content, marker);
@@ -793,8 +908,11 @@ const CHECKS: Check[] = [
         return "statusline helper block is not executable code adjacent to its payload function";
       }
       for (const [name, expected] of [
-        ["__calicoUsageHasAccountingSignal", 3],
-        ["__calicoUsageIsExactAllZero", 2],
+        // 2 declarations + 1 use inside __calicoStatuslineMessages + 1 at the
+        // terminal commit; 2 declarations + 1 at the terminal commit; and
+        // 1 declaration + 1 at the selector.
+        ["__calicoUsageHasAccountingSignal", 4],
+        ["__calicoUsageIsExactAllZero", 3],
         ["__calicoStatuslineMessages", 2],
       ] as const) {
         const actual = countOccurrences(content, name);
@@ -876,7 +994,7 @@ const CHECKS: Check[] = [
       const wrapperFunctionStart = content.lastIndexOf("function ", wrapperIndex);
 
       const terminalPattern = new RegExp(
-        `for\\(let (${identifier}) of (${identifier})\\)\\1\\.message\\.usage=(${identifier}),\\1\\.message\\.stop_reason=(${identifier}),\\1\\.message\\.stop_details=(${identifier})\\.delta\\.stop_details\\?\\?null,\\4!=null&&!globalThis\\.__calicoUsageIsExactAllZero\\(\\5\\.usage\\)&&globalThis\\.__calicoUsageHasAccountingSignal\\(\\3\\)&&\\(\\1\\.__calicoUsageState\\.committed=!0,\\1\\.__calicoUsageState\\.usage=\\3\\);`,
+        `for\\(let (${identifier}) of (${identifier})\\)\\1\\.message\\.usage=(${identifier}),\\1\\.message\\.stop_reason=(${identifier}),\\1\\.message\\.stop_details=(${identifier})\\.delta\\.stop_details\\?\\?null,\\4!=null&&!__calicoUsageIsExactAllZero\\(\\5\\.usage\\)&&__calicoUsageHasAccountingSignal\\(\\3\\)&&\\(\\1\\.__calicoUsageState\\.committed=!0,\\1\\.__calicoUsageState\\.usage=\\3\\);`,
         "g"
       );
       const terminalMatches = [...content.matchAll(terminalPattern)];
@@ -992,7 +1110,7 @@ const CHECKS: Check[] = [
       // patcher: anchor on the `?.outputStyle||` assignment that precedes the
       // selector, inside the function that emits `context_window:`.
       const selectorPattern = new RegExp(
-        `${identifier}=${identifier}\\?\\.outputStyle\\|\\|[^,]{1,40},(${identifier})=${identifier}\\(globalThis\\.__calicoStatuslineMessages\\((${identifier})\\)\\),(${identifier})=(${identifier})\\((${identifier}),(${identifier})\\(\\)\\)`,
+        `${identifier}=${identifier}\\?\\.outputStyle\\|\\|[^,]{1,40},(${identifier})=${identifier}\\(__calicoStatuslineMessages\\((${identifier})\\)\\),(${identifier})=(${identifier})\\((${identifier}),(${identifier})\\(\\)\\)`,
         "g"
       );
       const selectorCandidates = [...content.matchAll(selectorPattern)];
@@ -1508,6 +1626,29 @@ async function main(): Promise<void> {
   const disableSet = new Set(opts.disable);
 
   const failures: { id: string; detail: string }[] = [];
+
+  // Evaluation-order check for every globalThis handoff the patcher installed.
+  // Runs once over the whole bundle rather than per module, because a helper
+  // published by one module and read by another is not any single module's
+  // property.
+  let moduleNames: string[] = [];
+  try {
+    moduleNames = (
+      require("./native-bun.ts") as { readClaudeJsModuleNames(path: string): string[] }
+    ).readClaudeJsModuleNames(inputPath);
+  } catch {
+    // Older container formats have no module table; the check is a no-op there.
+  }
+  const unreachable = unreachableGlobalPublications(content, moduleNames);
+  if (unreachable.length > 0) {
+    for (const problem of unreachable) {
+      console.log(`  FAIL cross-module-globals: ${problem}`);
+    }
+    failures.push({
+      id: "cross-module-globals",
+      detail: unreachable.join("; "),
+    });
+  }
   let verifiedCount = 0;
   let skippedCount = 0;
   for (const check of CHECKS) {

--- a/tests/bun-module-boundaries.test.js
+++ b/tests/bun-module-boundaries.test.js
@@ -71,36 +71,62 @@ test("refuses source that already contains the boundary marker", () => {
 
 // Bun chunks are separate ES module scopes. A helper declared in one chunk and
 // called from another passes every text-level check and is undefined at
-// runtime, which is how custom-context-window broke on upstream 2.1.242.
-test("rejects an injected helper used outside the chunk that declares it", () => {
-  const modules = jsModules("let a=__calico_display_window(1)", "function __calico_display_window(e){return e}");
-  const joined = nativeBun.joinClaudeJsModules(modules);
+// runtime, which is how custom-context-window broke on upstream 2.1.242 and how
+// thinking-streaming shipped a binary that died at startup with
+// "__cc_streamingThinkingSelector is not defined".
+//
+// The scope check compares the patched text against the module's unpatched
+// text, so these tests pass the clean modules as the originals and a separately
+// built patched string, the way splitClaudeJsModules is actually called.
+function splitPatched(originalContents, patchedContents) {
+  const modules = jsModules(...originalContents);
+  const patched = patchedContents.join("\n/*@@calico-bun-module-boundary@@*/\n");
+  return () => nativeBun.splitClaudeJsModules(patched, modules);
+}
 
+test("rejects an injected helper used outside the chunk that declares it", () => {
   assert.throws(
-    () => nativeBun.splitClaudeJsModules(joined, modules),
+    splitPatched(
+      ["let a=1", "let b=2"],
+      ["let a=__calico_display_window(1)", "function __calico_display_window(e){return e}let b=2"]
+    ),
     /chunk-0\.js references injected identifier\(s\) it does not declare: __calico_display_window/
   );
 });
 
-test("accepts an injected helper declared in the chunk that uses it", () => {
-  const modules = jsModules(
-    "function __calicoLocal(e){return e}let a=__calicoLocal(1)",
-    "let b=2"
+test("rejects an injected helper passed as a value across chunks", () => {
+  // The thinking-streaming failure: the selector is never called at the use
+  // site, only handed to a hook, so a call-position-only check would miss it.
+  assert.throws(
+    splitPatched(
+      ["let a=1", "let b=2"],
+      [
+        "let a=hook(store,__cc_streamingThinkingSelector)",
+        "function __cc_streamingThinkingSelector(e){return e.streamingThinking}let b=2",
+      ]
+    ),
+    /chunk-0\.js references injected identifier\(s\) it does not declare: __cc_streamingThinkingSelector/
   );
+});
 
-  assert.doesNotThrow(() =>
-    nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules)
+test("accepts an injected helper declared in the chunk that uses it", () => {
+  assert.doesNotThrow(
+    splitPatched(
+      ["let a=1", "let b=2"],
+      ["function __calicoLocal(e){return e}let a=__calicoLocal(1)", "let b=2"]
+    )
   );
 });
 
 test("accepts a cross-chunk helper reached through globalThis", () => {
-  const modules = jsModules(
-    "let a=globalThis.__calico_display_window(1)",
-    "globalThis.__calico_display_window=function(e){return e};"
-  );
-
-  assert.doesNotThrow(() =>
-    nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules)
+  assert.doesNotThrow(
+    splitPatched(
+      ["let a=1", "let b=2"],
+      [
+        "let a=globalThis.__calico_display_window(1)",
+        "globalThis.__calico_display_window=function(e){return e};let b=2",
+      ]
+    )
   );
 });
 
@@ -111,10 +137,26 @@ test("accepts var, let, const and class declarations of injected helpers", () =>
     "const __calicoX=1;let a=__calicoX",
     "class __calicoX{};let a=new __calicoX",
   ]) {
-    const modules = jsModules(declaration, "let b=2");
-    assert.doesNotThrow(
-      () => nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules),
-      declaration
-    );
+    assert.doesNotThrow(splitPatched(["let a=1", "let b=2"], [declaration, "let b=2"]), declaration);
   }
+});
+
+test("accepts arrow parameters and destructuring targets as bindings", () => {
+  assert.doesNotThrow(
+    splitPatched(
+      ["let a=1", "let b=2"],
+      [
+        'let a=r.split("\n").map((__cc_line)=>"+"+__cc_line)',
+        "let{streamingToolUses:x,streamingThinking:__cc_state}=hook(s);let b=__cc_state",
+      ]
+    )
+  );
+});
+
+test("does not flag an upstream identifier that shares an injected prefix", () => {
+  // Upstream generates a shell snippet using `$__cc_name`, `__cc_set` and
+  // `read -r __cc_line`. Those are not bindings in the surrounding JavaScript
+  // and are not ours, so a prefix-only check reports them forever.
+  const upstream = 'let s=\'\\builtin eval "__cc_set=\\${$__cc_name+x}"; read -r __cc_line\';';
+  assert.doesNotThrow(splitPatched([upstream, "let b=2"], [upstream, "let b=2"]));
 });

--- a/tests/bun-module-boundaries.test.js
+++ b/tests/bun-module-boundaries.test.js
@@ -1,0 +1,120 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const nativeBun = require(path.join(__dirname, "..", "scripts", "native-bun.ts"));
+
+function jsModules(...contents) {
+  return contents.map((content, index) => ({
+    index: index * 2 + 1,
+    name: `/$bunfs/root/chunk-${index}.js`,
+    content,
+  }));
+}
+
+test("round-trips module contents through join and split", () => {
+  const modules = jsModules("let a=1", "let b=2", "let c=3");
+  const replacements = nativeBun.splitClaudeJsModules(
+    nativeBun.joinClaudeJsModules(modules),
+    modules
+  );
+
+  assert.deepEqual([...replacements.keys()], [1, 3, 5]);
+  for (const module of modules) {
+    assert.equal(replacements.get(module.index).toString("utf8"), module.content);
+  }
+});
+
+test("keys replacements by container module index, not by position", () => {
+  const modules = jsModules("let a=1", "let b=2");
+  const replacements = nativeBun.splitClaudeJsModules(
+    nativeBun.joinClaudeJsModules(modules),
+    modules
+  );
+
+  assert.equal(replacements.get(3).toString("utf8"), "let b=2");
+  assert.equal(replacements.get(0), undefined);
+});
+
+test("carries patched content back to the right module", () => {
+  const modules = jsModules("let a=1", "let b=2");
+  const patched = nativeBun.joinClaudeJsModules(modules).replace("let b=2", "let b=99");
+  const replacements = nativeBun.splitClaudeJsModules(patched, modules);
+
+  assert.equal(replacements.get(1).toString("utf8"), "let a=1");
+  assert.equal(replacements.get(3).toString("utf8"), "let b=99");
+});
+
+test("rejects a patch that consumed a module boundary", () => {
+  const modules = jsModules("let a=1", "let b=2", "let c=3");
+  const joined = nativeBun.joinClaudeJsModules(modules);
+  const collapsed = joined.replace("\n/*@@calico-bun-module-boundary@@*/\n", "");
+
+  assert.throws(
+    () => nativeBun.splitClaudeJsModules(collapsed, modules),
+    /2 module section\(s\) but the binary has 3/
+  );
+});
+
+test("rejects a patch that introduced an extra module boundary", () => {
+  const modules = jsModules("let a=1", "let b=2");
+  const joined = `${nativeBun.joinClaudeJsModules(modules)}\n/*@@calico-bun-module-boundary@@*/\nlet d=4`;
+
+  assert.throws(() => nativeBun.splitClaudeJsModules(joined, modules), /3 module section\(s\)/);
+});
+
+test("refuses source that already contains the boundary marker", () => {
+  const modules = jsModules("let a=1", "let b=2\n/*@@calico-bun-module-boundary@@*/\nlet c=3");
+
+  assert.throws(() => nativeBun.joinClaudeJsModules(modules), /already present/);
+});
+
+// Bun chunks are separate ES module scopes. A helper declared in one chunk and
+// called from another passes every text-level check and is undefined at
+// runtime, which is how custom-context-window broke on upstream 2.1.242.
+test("rejects an injected helper used outside the chunk that declares it", () => {
+  const modules = jsModules("let a=__calico_display_window(1)", "function __calico_display_window(e){return e}");
+  const joined = nativeBun.joinClaudeJsModules(modules);
+
+  assert.throws(
+    () => nativeBun.splitClaudeJsModules(joined, modules),
+    /chunk-0\.js references injected identifier\(s\) it does not declare: __calico_display_window/
+  );
+});
+
+test("accepts an injected helper declared in the chunk that uses it", () => {
+  const modules = jsModules(
+    "function __calicoLocal(e){return e}let a=__calicoLocal(1)",
+    "let b=2"
+  );
+
+  assert.doesNotThrow(() =>
+    nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules)
+  );
+});
+
+test("accepts a cross-chunk helper reached through globalThis", () => {
+  const modules = jsModules(
+    "let a=globalThis.__calico_display_window(1)",
+    "globalThis.__calico_display_window=function(e){return e};"
+  );
+
+  assert.doesNotThrow(() =>
+    nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules)
+  );
+});
+
+test("accepts var, let, const and class declarations of injected helpers", () => {
+  for (const declaration of [
+    "var __calicoX=1;let a=__calicoX",
+    "let __calicoX=1;let a=__calicoX",
+    "const __calicoX=1;let a=__calicoX",
+    "class __calicoX{};let a=new __calicoX",
+  ]) {
+    const modules = jsModules(declaration, "let b=2");
+    assert.doesNotThrow(
+      () => nativeBun.splitClaudeJsModules(nativeBun.joinClaudeJsModules(modules), modules),
+      declaration
+    );
+  }
+});

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -470,8 +470,8 @@ test("binary verifier accepts the complete gateway fast-mode structure", () => {
   assert.equal(evaluatePatchModule("gateway-fast-mode", patched), null);
 
   const withNativeMetadataNormalization = patched.replace(
-    "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
-    'let n=r.metadata;if(n&&typeof n.user_id==="string")r.metadata={...n,user_id:n.user_id};r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){'
+    "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
+    'let n=r.metadata;if(n&&typeof n.user_id==="string")r.metadata={...n,user_id:n.user_id};r=__calicoGatewayFastApply(r);if(e&&e.length>0){'
   );
   assert.notEqual(withNativeMetadataNormalization, patched);
   assert.equal(
@@ -486,7 +486,7 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
   const interactiveStart = patched.indexOf("async function Wj_", helperStart);
   const helperBlock = patched.slice(helperStart, interactiveStart);
   const applyHelper = helperBlock.match(
-    /globalThis\.__calicoGatewayFastApply=function[\s\S]*$/
+    /function __calicoGatewayFastApply[\s\S]*$/
   )?.[0];
   const builderStart = patched.indexOf("function tHt(");
   const builderEnd = patched.indexOf("async function uea", builderStart);
@@ -501,31 +501,31 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     patched.slice(interactiveStart);
   const alternateApply = patched.replace(
     applyHelper,
-    `globalThis.__calicoGatewayFastApply=()=>{};/*${applyHelper}*/`
+    `__calicoGatewayFastApply=()=>{};/*${applyHelper}*/`
   );
   const withoutThinBranch = patched.replace(
-    'if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin(e);',
+    'if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(e);',
     ""
   );
   const withoutNativeAction = patched.replace('"shortcut"', '"shortcut-broken"');
   const applyAfterBetaMerge = patched.replace(
     builderBlock,
     builderBlock
-      .replace("r=globalThis.__calicoGatewayFastApply(r);", "")
-      .replace("return r}", "r=globalThis.__calicoGatewayFastApply(r);return r}")
+      .replace("r=__calicoGatewayFastApply(r);", "")
+      .replace("return r}", "r=__calicoGatewayFastApply(r);return r}")
   );
   const applyBeforeNativeParse = patched
     .replace(
-      "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
+      "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
       "if(e&&e.length>0){"
     )
     .replace(
       "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};",
-      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};r=globalThis.__calicoGatewayFastApply(r);"
+      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};r=__calicoGatewayFastApply(r);"
     );
   const applyInsideNativeCatch = patched.replace(
-    ',{level:"error"})}r=globalThis.__calicoGatewayFastApply(r);',
-    ',{level:"error"});r=globalThis.__calicoGatewayFastApply(r)}'
+    ',{level:"error"})}r=__calicoGatewayFastApply(r);',
+    ',{level:"error"});r=__calicoGatewayFastApply(r)}'
   );
   const withoutWorkerLocator = patched.replace(
     ",...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE}",
@@ -540,12 +540,12 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     'process.env.REMORA_ACTIVE==="1"?!1:!pn()'
   );
   const injectedAnthropicSpeed = patched.replace(
-    "globalThis.__calicoGatewayFastApply=function",
-    'var __calicoGatewayFastLeak={speed:"fast"};globalThis.__calicoGatewayFastApply=function'
+    "function __calicoGatewayFastApply",
+    'var __calicoGatewayFastLeak={speed:"fast"};function __calicoGatewayFastApply'
   );
   const injectedBuilderSpeed = patched.replace(
-    "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
-    'r=globalThis.__calicoGatewayFastApply(r);r.speed="fast";if(e&&e.length>0){'
+    "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
+    'r=__calicoGatewayFastApply(r);r.speed="fast";if(e&&e.length>0){'
   );
   const persistedExtraBody = patched.replace(
     "writeFileSync(l,e,{encoding:",

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -470,8 +470,8 @@ test("binary verifier accepts the complete gateway fast-mode structure", () => {
   assert.equal(evaluatePatchModule("gateway-fast-mode", patched), null);
 
   const withNativeMetadataNormalization = patched.replace(
-    "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
-    'let n=r.metadata;if(n&&typeof n.user_id==="string")r.metadata={...n,user_id:n.user_id};r=__calicoGatewayFastApply(r);if(e&&e.length>0){'
+    "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
+    'let n=r.metadata;if(n&&typeof n.user_id==="string")r.metadata={...n,user_id:n.user_id};r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){'
   );
   assert.notEqual(withNativeMetadataNormalization, patched);
   assert.equal(
@@ -486,7 +486,7 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
   const interactiveStart = patched.indexOf("async function Wj_", helperStart);
   const helperBlock = patched.slice(helperStart, interactiveStart);
   const applyHelper = helperBlock.match(
-    /function __calicoGatewayFastApply[\s\S]*$/
+    /globalThis\.__calicoGatewayFastApply=function[\s\S]*$/
   )?.[0];
   const builderStart = patched.indexOf("function tHt(");
   const builderEnd = patched.indexOf("async function uea", builderStart);
@@ -501,31 +501,31 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     patched.slice(interactiveStart);
   const alternateApply = patched.replace(
     applyHelper,
-    `var __calicoGatewayFastApply=()=>{};/*${applyHelper}*/`
+    `globalThis.__calicoGatewayFastApply=()=>{};/*${applyHelper}*/`
   );
   const withoutThinBranch = patched.replace(
-    'if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(e);',
+    'if(process.env.REMORA_ACTIVE==="1")return globalThis.__calicoGatewayFastThin(e);',
     ""
   );
   const withoutNativeAction = patched.replace('"shortcut"', '"shortcut-broken"');
   const applyAfterBetaMerge = patched.replace(
     builderBlock,
     builderBlock
-      .replace("r=__calicoGatewayFastApply(r);", "")
-      .replace("return r}", "r=__calicoGatewayFastApply(r);return r}")
+      .replace("r=globalThis.__calicoGatewayFastApply(r);", "")
+      .replace("return r}", "r=globalThis.__calicoGatewayFastApply(r);return r}")
   );
   const applyBeforeNativeParse = patched
     .replace(
-      "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
+      "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
       "if(e&&e.length>0){"
     )
     .replace(
       "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};",
-      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};r=__calicoGatewayFastApply(r);"
+      "function tHt(e){let t=process.env.CLAUDE_CODE_EXTRA_BODY,r={};r=globalThis.__calicoGatewayFastApply(r);"
     );
   const applyInsideNativeCatch = patched.replace(
-    ',{level:"error"})}r=__calicoGatewayFastApply(r);',
-    ',{level:"error"});r=__calicoGatewayFastApply(r)}'
+    ',{level:"error"})}r=globalThis.__calicoGatewayFastApply(r);',
+    ',{level:"error"});r=globalThis.__calicoGatewayFastApply(r)}'
   );
   const withoutWorkerLocator = patched.replace(
     ",...ye.CALICO_GATEWAY_FAST_STATE_FILE&&{CALICO_GATEWAY_FAST_STATE_FILE:ye.CALICO_GATEWAY_FAST_STATE_FILE}",
@@ -540,12 +540,12 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     'process.env.REMORA_ACTIVE==="1"?!1:!pn()'
   );
   const injectedAnthropicSpeed = patched.replace(
-    "function __calicoGatewayFastApply",
-    'var __calicoGatewayFastLeak={speed:"fast"};function __calicoGatewayFastApply'
+    "globalThis.__calicoGatewayFastApply=function",
+    'var __calicoGatewayFastLeak={speed:"fast"};globalThis.__calicoGatewayFastApply=function'
   );
   const injectedBuilderSpeed = patched.replace(
-    "r=__calicoGatewayFastApply(r);if(e&&e.length>0){",
-    'r=__calicoGatewayFastApply(r);r.speed="fast";if(e&&e.length>0){'
+    "r=globalThis.__calicoGatewayFastApply(r);if(e&&e.length>0){",
+    'r=globalThis.__calicoGatewayFastApply(r);r.speed="fast";if(e&&e.length>0){'
   );
   const persistedExtraBody = patched.replace(
     "writeFileSync(l,e,{encoding:",

--- a/tests/statusline-committed-usage.test.js
+++ b/tests/statusline-committed-usage.test.js
@@ -413,7 +413,7 @@ test("matches renamed wrapper, terminal, selector, and clone locals", () => {
   assert.match(result.content, /let assistantWrapper=\{message:\{\.\.\.baseMessage/);
   assert.match(result.content, /case"message_delta":\{aggregatedUsage=aggregateUsage\(aggregatedUsage,terminalEvent\.usage\);/);
   assert.match(result.content, /for\(let assistantEntry of assistantEntries\)assistantEntry\.message\.usage=aggregatedUsage/);
-  assert.match(result.content, /selectedUsage=usageReducer\(__calicoStatuslineMessages\(messageEntries\)\),windowSize=contextWindow\(modelContext,windowOptions\(\)\)/);
+  assert.match(result.content, /selectedUsage=usageReducer\(globalThis\.__calicoStatuslineMessages\(messageEntries\)\),windowSize=contextWindow\(modelContext,windowOptions\(\)\)/);
   assert.equal(completed[0].__calicoUsageState.committed, true);
   assert.deepEqual(readStatuslineUsage(context, completed), usage(333, 44));
 });
@@ -536,10 +536,22 @@ test("2.1.212 wrapper ownership rejects lost, mismatched, and duplicate effort v
   );
 });
 
-test("statusline selector is bound to the discovered usage reducer", () => {
-  const variant = committedUsageFixture
-    .replace("function fK_(", "function wrong(e){return null}function fK_(")
-    .replace("S=aJt(o),b=sw(y,UE())", "S=wrong(o),b=sw(y,UE())");
+// Until 2.1.242 the selector was pinned to the usage reducer by name, so a
+// selector calling anything else was rejected. Chunking removed that option:
+// the payload builder imports the reducer under a per-chunk alias, and minified
+// names are no longer unique across chunks (2.1.245 declares an unrelated
+// `function Bne(` while the statusline chunk imports the reducer *as* `Bne`),
+// so resolving the callee would need full cross-chunk alias resolution. The
+// enforceable tie is now positional plus consumption: the selector sits
+// immediately after the `?.outputStyle||` assignment, and its result and window
+// must be exactly the two arguments the payload's `context_window:` is built
+// from. These tests pin what that still rejects.
+test("statusline selector must feed its result into context_window", () => {
+  const variant = committedUsageFixture.replace(
+    "return{context_window:pK_(S,b)}",
+    "return{context_window:pK_(unrelatedUsage,b)}"
+  );
+  assert.notEqual(variant, committedUsageFixture);
   const result = patchStatuslineCommittedUsage(variant);
 
   assert.equal(result.patched, 0);
@@ -547,22 +559,46 @@ test("statusline selector is bound to the discovered usage reducer", () => {
   assert.equal(result.content.includes("__calicoUsageState"), false);
 });
 
+test("statusline selector must feed its window into context_window", () => {
+  const variant = committedUsageFixture.replace(
+    "return{context_window:pK_(S,b)}",
+    "return{context_window:pK_(S,unrelatedWindow)}"
+  );
+  assert.notEqual(variant, committedUsageFixture);
+  const result = patchStatuslineCommittedUsage(variant);
+
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, variant);
+});
+
+test("statusline selector must directly follow the outputStyle assignment", () => {
+  const variant = committedUsageFixture.replace(
+    '_=n?.outputStyle||"default",S=aJt(o)',
+    '_=n?.outputStyle||"default",spacer=0,S=aJt(o)'
+  );
+  assert.notEqual(variant, committedUsageFixture);
+  const result = patchStatuslineCommittedUsage(variant);
+
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, variant);
+});
+
 test("binary verifier rejects dead helpers and broken wrapper ownership", () => {
   const patched = patchStatuslineCommittedUsage(committedUsageFixture).content;
   assert.equal(evaluatePatchModule("statusline-committed-usage", patched), null);
 
   const statuslineHelper = patched.match(
-    /function __calicoStatuslineMessages[\s\S]*?(?=function fK_\()/
+    /globalThis\.__calicoStatuslineMessages=function[\s\S]*?(?=function fK_\()/
   )?.[0];
   const helperBlock = patched.match(
-    /function __calicoUsageHasAccountingSignal[\s\S]*?(?=function fK_\()/
+    /globalThis\.__calicoUsageHasAccountingSignal=function[\s\S]*?(?=function fK_\()/
   )?.[0];
   assert.ok(statuslineHelper);
   assert.ok(helperBlock);
 
   const emptyHelper = patched.replace(
     statuslineHelper,
-    `var __calicoStatuslineMessages=(e)=>e;/*${statuslineHelper}*/`
+    `globalThis.__calicoStatuslineMessages=(e)=>e;/*${statuslineHelper}*/`
   );
   const destructuredHelpers = patched.replace(
     helperBlock,

--- a/tests/statusline-committed-usage.test.js
+++ b/tests/statusline-committed-usage.test.js
@@ -413,7 +413,7 @@ test("matches renamed wrapper, terminal, selector, and clone locals", () => {
   assert.match(result.content, /let assistantWrapper=\{message:\{\.\.\.baseMessage/);
   assert.match(result.content, /case"message_delta":\{aggregatedUsage=aggregateUsage\(aggregatedUsage,terminalEvent\.usage\);/);
   assert.match(result.content, /for\(let assistantEntry of assistantEntries\)assistantEntry\.message\.usage=aggregatedUsage/);
-  assert.match(result.content, /selectedUsage=usageReducer\(globalThis\.__calicoStatuslineMessages\(messageEntries\)\),windowSize=contextWindow\(modelContext,windowOptions\(\)\)/);
+  assert.match(result.content, /selectedUsage=usageReducer\(__calicoStatuslineMessages\(messageEntries\)\),windowSize=contextWindow\(modelContext,windowOptions\(\)\)/);
   assert.equal(completed[0].__calicoUsageState.committed, true);
   assert.deepEqual(readStatuslineUsage(context, completed), usage(333, 44));
 });
@@ -588,17 +588,19 @@ test("binary verifier rejects dead helpers and broken wrapper ownership", () => 
   assert.equal(evaluatePatchModule("statusline-committed-usage", patched), null);
 
   const statuslineHelper = patched.match(
-    /globalThis\.__calicoStatuslineMessages=function[\s\S]*?(?=function fK_\()/
+    /function __calicoStatuslineMessages[\s\S]*?(?=function fK_\()/
   )?.[0];
+  // Two copies of the predicates exist (one per consuming site); this is the
+  // copy that precedes the status-line payload builder.
   const helperBlock = patched.match(
-    /globalThis\.__calicoUsageHasAccountingSignal=function[\s\S]*?(?=function fK_\()/
-  )?.[0];
+    /function __calicoUsageHasAccountingSignal(?:(?!function __calicoUsageHasAccountingSignal)[\s\S])*?(?=function fK_\()/g
+  )?.at(-1);
   assert.ok(statuslineHelper);
   assert.ok(helperBlock);
 
   const emptyHelper = patched.replace(
     statuslineHelper,
-    `globalThis.__calicoStatuslineMessages=(e)=>e;/*${statuslineHelper}*/`
+    `__calicoStatuslineMessages=(e)=>e;/*${statuslineHelper}*/`
   );
   const destructuredHelpers = patched.replace(
     helperBlock,

--- a/tools/local-verify/mockapi.js
+++ b/tools/local-verify/mockapi.js
@@ -1,0 +1,120 @@
+// Minimal Anthropic-compatible endpoint that returns a canned streaming
+// response, so the full client + render path can be exercised with no
+// credentials and no network.
+const http = require("node:http");
+
+const MODEL = "claude-sonnet-4-5-20250929";
+
+function sse(res, event, data) {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+const server = http.createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    const url = req.url.split("?")[0];
+    if (!url.endsWith("/v1/messages")) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ type: "error", error: { type: "not_found_error", message: url } }));
+      return;
+    }
+
+    let parsed = {};
+    try {
+      parsed = JSON.parse(body || "{}");
+    } catch {}
+    process.stderr.write(
+      `REQUEST thinking=${JSON.stringify(parsed.thinking)} stream=${parsed.stream}\n`
+    );
+
+    if (!parsed.stream) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: "msg_mock",
+          type: "message",
+          role: "assistant",
+          model: MODEL,
+          content: [{ type: "text", text: "pong" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 2 },
+        })
+      );
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+
+    const wantsThinking =
+      parsed.thinking && (parsed.thinking.type === "enabled" || parsed.thinking.type === "adaptive");
+    let index = 0;
+
+    sse(res, "message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_mock",
+        type: "message",
+        role: "assistant",
+        model: MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    });
+
+    if (wantsThinking) {
+      sse(res, "content_block_start", {
+        type: "content_block_start",
+        index,
+        content_block: { type: "thinking", thinking: "" },
+      });
+      for (const piece of ["Let me ", "think about ", "this carefully."]) {
+        sse(res, "content_block_delta", {
+          type: "content_block_delta",
+          index,
+          delta: { type: "thinking_delta", thinking: piece },
+        });
+      }
+      sse(res, "content_block_delta", {
+        type: "content_block_delta",
+        index,
+        delta: { type: "signature_delta", signature: "mock-signature" },
+      });
+      sse(res, "content_block_stop", { type: "content_block_stop", index });
+      index += 1;
+    }
+
+    sse(res, "content_block_start", {
+      type: "content_block_start",
+      index,
+      content_block: { type: "text", text: "" },
+    });
+    for (const piece of ["pong", " from ", "the mock"]) {
+      sse(res, "content_block_delta", {
+        type: "content_block_delta",
+        index,
+        delta: { type: "text_delta", text: piece },
+      });
+    }
+    sse(res, "content_block_stop", { type: "content_block_stop", index });
+
+    sse(res, "message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 12 },
+    });
+    sse(res, "message_stop", { type: "message_stop" });
+    res.end();
+  });
+});
+
+server.listen(Number(process.argv[2] || 8787), "127.0.0.1", () => {
+  process.stderr.write(`mock listening on ${server.address().port}\n`);
+});

--- a/tools/local-verify/run.sh
+++ b/tools/local-verify/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Run a patched (or unpatched) Claude binary against a canned streaming response
+# and report what the TUI actually rendered. Needs no credentials and no
+# network.
+#
+#   bash tools/local-verify/run.sh <claude-binary> [port]
+#
+# Three defects in the 2.1.242 chunk-split work produced bundles where every
+# text-level check passed and the feature was dead or the whole turn was empty.
+# Static checks cannot see a wrong-but-valid call; this can.
+set -uo pipefail
+
+BINARY="${1:-}"
+PORT="${2:-8787}"
+if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
+  echo "usage: bash tools/local-verify/run.sh <claude-binary> [port]" >&2
+  exit 2
+fi
+for cmd in node expect perl; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "missing required command: $cmd" >&2; exit 2; }
+done
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+CONFIG="$WORK/config"
+mkdir -p "$CONFIG"
+trap 'kill "${MOCK_PID:-}" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+# Seed onboarding, folder trust and API-key approval. Without all three the TUI
+# stops before the main renderer mounts and nothing downstream is exercised —
+# which is exactly why the CI PTY smoke test missed a startup crash.
+node -e '
+  const fs = require("node:fs");
+  fs.writeFileSync(process.argv[1], JSON.stringify({
+    hasCompletedOnboarding: true,
+    theme: "dark",
+    numStartups: 9,
+    installMethod: "native",
+    // Suppress the first-launch "What'"'"'s new" panel: it shifts the layout and
+    // races the input box into existence.
+    lastReleaseNotesSeen: "99.0.0",
+    customApiKeyResponses: { approved: ["sk-ant-mock"], rejected: [] },
+    primaryApiKey: "sk-ant-mock",
+    projects: {
+      [process.argv[2]]: {
+        hasTrustDialogAccepted: true,
+        hasCompletedProjectOnboarding: true,
+        allowedTools: [],
+        history: [],
+      },
+    },
+  }));
+' "$CONFIG/.claude.json" "$PWD"
+
+node "$HERE/mockapi.js" "$PORT" >/dev/null 2>"$WORK/mock.err" &
+MOCK_PID=$!
+for _ in $(seq 1 40); do
+  grep -q "mock listening" "$WORK/mock.err" 2>/dev/null && break
+  sleep 0.25
+done
+grep -q "mock listening" "$WORK/mock.err" 2>/dev/null || {
+  echo "mock API failed to start:" >&2; cat "$WORK/mock.err" >&2; exit 1; }
+
+expect "$HERE/tui.exp" "$BINARY" "$WORK/tui.raw" "$CONFIG" "http://127.0.0.1:$PORT" >/dev/null 2>&1
+STATUS=$?
+
+LC_ALL=C perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\e\][^\a]*(?:\a|\e\\)//g; s/\e[()][A-Za-z0-9]//g' \
+  "$WORK/tui.raw" 2>/dev/null | LC_ALL=C tr -cd '\11\12\15\40-\176' > "$WORK/tui.clean"
+
+echo "binary        : $BINARY"
+grep -q "REQUEST" "$WORK/mock.err" \
+  && echo "request       : SENT ($(grep -c REQUEST "$WORK/mock.err"))" \
+  || echo "request       : NEVER SENT  <-- the turn died before reaching the API"
+grep -aq "pongfromthemock" "$WORK/tui.clean" \
+  && echo "assistant text: RENDERED" \
+  || echo "assistant text: MISSING  <-- the stream arrived but nothing was rendered"
+ERR="$(LC_ALL=C grep -aoE "[A-Za-z_.$]*(is not defined|is not a function)" "$WORK/tui.clean" | head -2)"
+[ -n "$ERR" ] && echo "errors        : $ERR" || echo "errors        : none"
+[ "$STATUS" -ne 0 ] && echo "harness       : expect exited $STATUS (see above)"
+
+grep -aq "pongfromthemock" "$WORK/tui.clean"

--- a/tools/local-verify/tui.exp
+++ b/tools/local-verify/tui.exp
@@ -1,25 +1,47 @@
 #!/usr/bin/expect -f
-# Drive the interactive TUI against the local mock API and log everything the
-# terminal receives. usage: tui.exp <binary> <logfile>
+# Drive the interactive TUI against a local mock API and log everything the
+# terminal receives.
+#
+#   tui.exp <binary> <logfile> <config-dir> [base-url]
+#
+# The config directory must already be seeded so the launch reaches the main
+# renderer; run.sh does that. Without it the TUI stops at onboarding and the
+# wait below times out before anything is exercised.
+if {[llength $argv] < 3} {
+    puts "usage: tui.exp <binary> <logfile> <config-dir> \[base-url\]"
+    exit 2
+}
 set binary [lindex $argv 0]
 set logfile [lindex $argv 1]
+set configdir [lindex $argv 2]
+set baseurl [expr {[llength $argv] > 3 ? [lindex $argv 3] : "http://127.0.0.1:8787"}]
 
 set timeout 60
 log_file -noappend $logfile
-set env(ANTHROPIC_BASE_URL) "http://127.0.0.1:8787"
+set env(ANTHROPIC_BASE_URL) $baseurl
 set env(ANTHROPIC_API_KEY) "sk-ant-mock"
-set env(CLAUDE_CONFIG_DIR) "/private/tmp/claude-501/-Users-nanako-side-project-calico-claude/6862363f-a158-4cc4-9197-546228441a51/scratchpad/cfgmin"
+set env(CLAUDE_CONFIG_DIR) $configdir
 
 spawn -noecho $binary
-# Wait for the prompt box to appear rather than guessing a delay.
+# Wait for the status line the main renderer draws, then for the input
+# placeholder, so the prompt is not typed before the box exists.
 expect {
     -re {shortcuts} {}
-    timeout { puts "\nHARNESS: prompt never appeared"; exit 2 }
+    timeout { puts "\nHARNESS: main renderer never mounted"; exit 2 }
+}
+expect {
+    -re {Try "} {}
+    timeout {}
 }
 sleep 2
 send "say pong\r"
-# Give the stream time to arrive and render.
-sleep 16
+# Wait for the response itself rather than a fixed delay. "from" appears only in
+# the mock's reply, never in the echoed prompt, so this cannot match the input.
+expect {
+    -re {from} {}
+    timeout { puts "\nHARNESS: no response rendered before timeout" }
+}
+sleep 2
 send \003
 sleep 1
 send \003

--- a/tools/local-verify/tui.exp
+++ b/tools/local-verify/tui.exp
@@ -1,0 +1,26 @@
+#!/usr/bin/expect -f
+# Drive the interactive TUI against the local mock API and log everything the
+# terminal receives. usage: tui.exp <binary> <logfile>
+set binary [lindex $argv 0]
+set logfile [lindex $argv 1]
+
+set timeout 60
+log_file -noappend $logfile
+set env(ANTHROPIC_BASE_URL) "http://127.0.0.1:8787"
+set env(ANTHROPIC_API_KEY) "sk-ant-mock"
+set env(CLAUDE_CONFIG_DIR) "/private/tmp/claude-501/-Users-nanako-side-project-calico-claude/6862363f-a158-4cc4-9197-546228441a51/scratchpad/cfgmin"
+
+spawn -noecho $binary
+# Wait for the prompt box to appear rather than guessing a delay.
+expect {
+    -re {shortcuts} {}
+    timeout { puts "\nHARNESS: prompt never appeared"; exit 2 }
+}
+sleep 2
+send "say pong\r"
+# Give the stream time to arrive and render.
+sleep 16
+send \003
+sleep 1
+send \003
+expect eof


### PR DESCRIPTION
The hourly Patch Claude Native workflow has failed on all five platforms since
2.1.239 and the last release is 2.1.238. This restores every patch module
against 2.1.245.

## What broke

Upstream 2.1.242 split Claude Code from a single `/$bunfs/root/cli` bundle into
a 19,949-character dynamic-import loader plus ~1,377 `chunk-*.js` modules.
`/$bunfs/root/cli` is still present and still the container entry point, so the
extractor kept returning the right module — it just no longer held any of the
patchable source, and every matcher reported 0 candidates.

`scripts/native-bun.ts` now treats the payload as a set of modules: it collects
every module whose Bun loader tag is JS (selection by loader tag, not by name,
so nothing depends on upstream's chunk naming), joins them with a boundary
marker for the patcher, splits the result back, and writes each module's content
individually. `rebuildBunData` already recomputed every offset, so per-module
contents are free to change size. Because the patcher still consumes and returns
one text, the 19 patch modules, `--assert-all` and the verifier needed no
interface change, and candidate counts stay comparable across the
monolith/chunked boundary. Verified to produce byte-identical patch counts to
the previous single-module extraction on 2.1.239.

## The failure class this introduced

Chunks are separate ES module scopes that import each other under per-chunk
aliases, and minified names are neither unique nor portable across them. Four
defects of this shape reached a built binary during this work, each of which
passed the patch summary, `--assert-all` and every verifier marker check:

- a helper declared in one chunk and called from another (`custom-context-window`)
- a helper spliced in by first-occurrence text replace, landing in the wrong
  chunk because `function kC(` occurs four times (`thinking-streaming`; the
  binary died at startup)
- helpers shared through `globalThis` from a chunk the consumer does not
  statically import, so the publisher had not been evaluated (`gateway-fast-mode`;
  every request threw and produced no output). Only 8 of 1,384 modules are
  statically reachable from the cli entry — everything else arrives through
  dynamic import
- an *upstream* name captured at one site and emitted at another, where the same
  alias means a different function (`thinking-streaming`'s stream reducer; every
  turn with a thinking block rendered nothing at all)

Each is now structurally prevented rather than patched around: self-contained
copies per consuming chunk where the helper can be copied, offset-anchored
splicing, and same-module resolution for captured names.

## Guards added

- `native-bun.ts` refuses the write when a module references an injected
  `__calico*`/`__cc_*` identifier it does not declare, comparing against that
  module's unpatched text so upstream names sharing the prefix are not flagged
- `verify-patched-binary.ts` gains `cross-module-globals`, which builds the
  static import graph and fails when a `globalThis` consumer cannot reach its
  publisher; `inSameModule`, which keeps cross-site name equalities enforced
  wherever they remain meaningful; assertions on the React-compiler memo cache
  slot that `thinking-streaming` claims; and a check that the stream reducer's
  message helper is declared in its own module
- the CI PTY smoke test now seeds onboarding and folder-trust state so the launch
  reaches the main renderer, and asserts the status line. On a fresh config the
  TUI stops at the theme picker, which is why it passed on a binary that crashed
  as the fullscreen renderer mounted
- `tools/local-verify/` drives the real TUI against a canned streaming response
  with no credentials and no network. Three of the defects above were invisible
  to every static check and only this reproduced them

## Modules repaired

All nine matchers that broke on the chunk split — destructured JSX factories and
React hooks, lazy module accessors, `crypto.randomUUID` losing its receiver,
non-portable identifiers — plus `gateway-fast-mode`, which had been silently
applying 0 changes since 2.1.239 for an unrelated reason (upstream appended
arguments to the worker dispatch call).

`PATCHING_PLAYBOOK.md` records each rule against the module it broke.

## Verification

All five platforms: `--assert-all` passes with full candidate counts, the
module-scope and cross-module-globals guards pass, and
`verify-patched-binary.ts` reports 18 modules verified with 1 disabled. On
macos-arm64 the patched binary runs, reports `2.1.245 (Claude Code) / (patched)`,
mounts the full TUI, and renders a complete turn including thinking blocks
identically to the unpatched build. `npm test`: 142 passing.

Not yet run: `gh workflow run patch-claude.yml`. Note that a dispatch creates
five GitHub releases tagged at the dispatched commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e