### PR TITLE
fix(patch): support Claude 2.1.246, and stop rewriting untouched Bun modules

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -144,6 +144,15 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   drives the real TUI against a canned streaming response, in a throwaway seeded config, with no
   credentials and no network. It reproduces this entire class locally and exits non-zero when the
   turn renders nothing — run it before claiming a rendering or request-path module works.
+- **If a replacement rewrites an object, carry its members across.** Several matchers rewrite an
+  initialiser or a destructuring wholesale and hardcode the member list, so a field upstream adds is
+  silently dropped rather than failing loudly. 2.1.246 appended `seenToolUseIds:new Set` to the
+  background-agent tracker and `toolProgress:<local>` to the streaming store destructuring; both are
+  now captured and re-emitted. Prefer capturing the tail over widening the anchor and discarding it.
+- **Widening an anchor can make two branches overlap.** A patch with several known upstream shapes
+  relies on exactly one matching. Allowing a trailing `,...{}` on the wrapper patterns let the
+  legacy branch also match the effort shape, taking the candidate count from 6 to 7 and failing the
+  module. Widen to what upstream actually emits, and check the other branches still exclude it.
 - **A replacement must be anchored to the site you located, not to its text.** `output.replace(
   "function kC(", …)` rewrites the *first* match in the whole joined bundle, and minified names are
   not unique across chunks — `function kC(` occurs four times in 2.1.245. A `thinking-streaming`

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -138,6 +138,20 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   injected value that occupies no slot leaves the renderer showing a stale element forever while the
   patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
   slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **Write back only the modules you changed.** Bun keeps bytecode in a
+  position-sensitive pool, so rewriting every module — even with identical bytes — forces a full
+  re-layout of the container. 2.1.245 tolerated that; 2.1.246 killed the process at exec with no
+  output, and once the bytecode was cleared it segfaulted instead. Restricting the write-back to
+  real edits leaves the other ~1,400 modules and their bytecode untouched, and is what lets the
+  offset-preserving rebuild path apply. A replaced module's own bytecode is always dropped: it was
+  compiled from the unpatched source, so keeping it means the runtime can execute the old code and
+  the patch silently does nothing.
+- **Check `upstream/main` before reverse-engineering a new upstream shape.** This repo tracks
+  `a-connoisseur/patch-claude-code` and shares the extraction layer and the thinking patches with
+  it. The position-sensitive bytecode pool, the declaration-based fallback for the virtual-message
+  helper, and the 2.1.246 hoisted display guard were all already solved there. `git fetch upstream`
+  and read `git log upstream/main` first — porting a fix with attribution costs an hour less than
+  deriving it, and their release tags say which versions are known good.
 - **Static checks cannot see a wrong-but-valid call.** Three of the defects in this episode
   produced a bundle where every text-level assertion passed and the feature was dead or the whole
   turn was empty. The only thing that caught them was running the binary. `bash tools/local-verify/run.sh <binary>`

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -222,8 +222,12 @@ function patchWriteCreateDiffColors(content) {
     // and anchor on the distinctive `{filePath,content,verbose}` prop triple —
     // the factory's local name is exactly the kind of minified binding that
     // differs per platform build and must never be pinned.
+    // 2.1.246 appends `replacedUndiffedContent:<local>` to the create renderer's
+    // props. The trailing props are matched but not forwarded: the replacement
+    // renders through the *diff* component, which has its own prop contract —
+    // the same reason `content` is dropped in favour of `structuredPatch`.
     const createReturnMatch = createSegment.match(
-      /return ([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{filePath:([A-Za-z_$][\w$]*),content:([A-Za-z_$][\w$]*),verbose:([A-Za-z_$][\w$]*)\}\)/
+      /return ([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\(([A-Za-z_$][\w$]*),\{filePath:([A-Za-z_$][\w$]*),content:([A-Za-z_$][\w$]*),verbose:([A-Za-z_$][\w$]*)(?:,[A-Za-z_$][\w$]*:[^,{}]+)*\}\)/
     );
     if (!createReturnMatch) {
       index = updateStart + updateNeedle.length;
@@ -634,20 +638,22 @@ function patchThinkingStreaming(content) {
   if (streamingVar === null) {
     let storeCandidates = 0;
     let storePatched = 0;
+    // This destructuring is rewritten, so fields upstream adds have to be
+    // carried across rather than dropped: 2.1.246 appended `toolProgress:<local>`.
     const storeSnapshotPattern = new RegExp(
-      `\\{streamingToolUses:(${identifierPattern}),userInputOnProcessing:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\.stream\\)`,
+      `\\{streamingToolUses:(${identifierPattern}),userInputOnProcessing:(${identifierPattern})((?:,[^{}]*?)?)\\}=(${identifierPattern})\\((${identifierPattern})\\.stream\\)`,
       "g"
     );
     output = output.replace(
       storeSnapshotPattern,
-      (full, toolUsesVar, inputVar, hookFunction, contextVar) => {
+      (full, toolUsesVar, inputVar, extraSnapshotFields, hookFunction, contextVar) => {
         if (streamingVar !== null) {
           return full;
         }
         storeCandidates += 1;
         storePatched += 1;
         streamingVar = "__cc_streamingThinkingState";
-        return `{streamingToolUses:${toolUsesVar},streamingThinking:__cc_streamingThinkingState,userInputOnProcessing:${inputVar}}=${hookFunction}(${contextVar}.stream)`;
+        return `{streamingToolUses:${toolUsesVar},streamingThinking:__cc_streamingThinkingState,userInputOnProcessing:${inputVar}${extraSnapshotFields}}=${hookFunction}(${contextVar}.stream)`;
       }
     );
     candidates += storeCandidates;
@@ -2232,8 +2238,13 @@ function patchBackgroundAgentUsage(content) {
   const original = content;
   const identifierPattern = "[A-Za-z_$][\\w$]*";
   const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // The replacement rewrites this initialiser, so any field upstream adds has to
+  // be carried across rather than silently dropped: 2.1.246 appended
+  // `seenToolUseIds:new Set`. Capture the trailing fields verbatim. A future
+  // field whose value contains braces will fail to match, which reports zero
+  // candidates and fails --assert-all rather than quietly discarding state.
   const trackerPattern = new RegExp(
-    `function (${identifierPattern})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\]\\}\\}`,
+    `function (${identifierPattern})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\]((?:,[^{}]*)?)\\}\\}`,
     "g"
   );
   const totalPattern = new RegExp(
@@ -2248,6 +2259,7 @@ function patchBackgroundAgentUsage(content) {
   const totalMatches = [...content.matchAll(totalPattern)];
   const accountingMatches = [...content.matchAll(accountingPattern)];
   const trackerName = trackerMatches[0]?.[1];
+  const trackerUpstreamFields = trackerMatches[0]?.[2] ?? "";
   const totalName = totalMatches[0]?.[1];
   const accountingMatch = accountingMatches[0];
   const eventVar = accountingMatch?.[1];
@@ -2364,7 +2376,7 @@ function patchBackgroundAgentUsage(content) {
   const trackerReplacement =
     'function __calicoTrackAgentUsage(e,t,r,n){if(!t||typeof t!=="object")return;let o=["input_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((s)=>typeof t[s]==="number"),i=(t.input_tokens??0)+(t.cache_creation_input_tokens??0)+(t.cache_read_input_tokens??0);if(o&&(n||i>0))e.latestInputTokens=i;let s=typeof t.output_tokens==="number"&&Number.isFinite(t.output_tokens)?Math.max(0,t.output_tokens):0;if(r==null){if(s>0)e.cumulativeOutputTokens+=s;return}let a=e.responseOutputTokens.get(r)??0;if(s>a)e.cumulativeOutputTokens+=s-a;if(s>a||!e.responseOutputTokens.has(r))e.responseOutputTokens.set(r,Math.max(a,s))}' +
     'function __calicoRefreshAgentUsage(e,t){if(!Array.isArray(t))return;let r=!1;for(let n=t.length-1;n>=0;n--){let o=t[n];if(o?.type==="assistant")r=!0,__calicoTrackAgentUsage(e,o.message?.usage,o.message?.id,o.message?.stop_reason!=null);else if(o?.type==="user"&&r)break}}' +
-    `function ${trackerName}(){return{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:[],activeMessageId:null,responseOutputTokens:new Map}}`;
+    `function ${trackerName}(){return{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:[]${trackerUpstreamFields},activeMessageId:null,responseOutputTokens:new Map}}`;
   const eventReplacement =
     `if(${eventVar}.type==="stream_event"){if(${eventVar}.event.type==="message_start")${trackerVar}.activeMessageId=${eventVar}.event.message.id,__calicoTrackAgentUsage(${trackerVar},${eventVar}.event.message.usage,${trackerVar}.activeMessageId,!1);else if(${eventVar}.event.type==="message_delta")__calicoTrackAgentUsage(${trackerVar},${eventVar}.event.usage,${trackerVar}.activeMessageId,${eventVar}.event.delta.stop_reason!=null);else if(${eventVar}.event.type==="message_stop")${trackerVar}.activeMessageId=null;return}if(${eventVar}.type!=="assistant")return;let ${usageVar}=${eventVar}.message.usage;__calicoTrackAgentUsage(${trackerVar},${usageVar},${eventVar}.message.id,${eventVar}.message.stop_reason!=null);`;
   const progressReplacement = `${eventName}(${progressMatch[1]},${progressMatch[2]},${progressMatch[3]},${progressMatch[4]}.options.tools),__calicoRefreshAgentUsage(${progressMatch[1]},${completionTranscript}),${progressMatch[5]}(${progressOwner},${summaryName}(${progressMatch[1]}),${progressStatus});`;
@@ -2405,11 +2417,11 @@ function patchStatuslineCommittedUsage(content) {
     "g"
   );
   const legacyWrapperPattern = new RegExp(
-    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\}\\};`,
+    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
     "g"
   );
   const effortWrapperPattern = new RegExp(
-    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
+    `let (${identifierPattern})=\\{message:\\{\\.\\.\\.(${identifierPattern}),content:(${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
     "g"
   );
   // 2.1.236+: batch tool-use destructuring wraps the content builder. The
@@ -2423,8 +2435,11 @@ function patchStatuslineCommittedUsage(content) {
   // so the trailing `,<identifier-or-member>` is matched optionally to keep both
   // 2.1.237 (no fifth arg) and 2.1.238 (one appended arg) matching, and to
   // tolerate a further appended argument without another edit.
+  // 2.1.246 appends `,...{}` after the effort spread. Match any trailing spread
+  // entries so the wrapper still matches; the replacement is derived from the
+  // matched text, so whatever upstream appended is carried across unchanged.
   const batchWrapperPattern = new RegExp(
-    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}\\};`,
+    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
     "g"
   );
   const terminalPattern = new RegExp(

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1064,7 +1064,16 @@ function patchThinkingStreaming(content) {
   const transcriptToolUseHelpersMatch = output.match(
     /let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\(\{content:\[[A-Za-z_$][\w$]*\.contentBlock\]\}\);return [A-Za-z_$][\w$]*\.uuid=([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\.contentBlock\.id,0\),([A-Za-z_$][\w$]*)\(\[[A-Za-z_$][\w$]*\]\)/
   );
-  let createVirtualMessageHelper = transcriptToolUseHelpersMatch?.[1] ?? null;
+  // 2.1.246 restructured the transcript-extras memo, so its anchor no longer
+  // matches and the helper name cannot be captured there. The reducer sections
+  // below still need to know a helper exists; fall back to its own declaration.
+  // The name emitted at each injection site is resolved separately and per
+  // module by virtualMessageHelperAt — this value only gates the sections.
+  const virtualMessageDeclarationMatch = output.match(
+    new RegExp(VIRTUAL_MESSAGE_DECLARATION_PATTERN.source)
+  );
+  let createVirtualMessageHelper =
+    transcriptToolUseHelpersMatch?.[1] ?? virtualMessageDeclarationMatch?.[1] ?? null;
   let transcriptStreamingThinkingVar = null;
   const rendererStreamingThinkingMatch = output.match(
     /\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:([A-Za-z_$][\w$]*),showAllInTranscript:/
@@ -1579,14 +1588,11 @@ function patchThinkingStreaming(content) {
           const messageStopAfter = `if(${eventParam}.event.type==="message_stop"){${setStreamingThinkingParam}?.((__cc_prevStreamingThinking)=>__cc_prevStreamingThinking?{...__cc_prevStreamingThinking,isStreaming:!1,streamingEndedAt:Date.now(),currentIndex:null,currentMessage:null}:__cc_prevStreamingThinking),${setModeParam}("tool-use"),${setStreamingToolsParam}(()=>[]);return}`;
 
           const thinkingStartBefore = `case"thinking":case"redacted_thinking":${setModeParam}("thinking");return;`;
-          const thinkingStartAfter =
-            createVirtualMessageHelper === null
-              ? null
-              : `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
-                  eventParam,
-                  setStreamingThinkingParam,
-                  createVirtualMessageHelper
-                )},${setModeParam}("thinking");return;`;
+          const thinkingStartAfter = `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
+            eventParam,
+            setStreamingThinkingParam,
+            reducerMessageHelper
+          )},${setModeParam}("thinking");return;`;
 
           const textStartBefore = `case"text":${setModeParam}("responding");return;`;
           const textStartAfter = `case"text":${setStreamingThinkingParam}?.((__cc_prevStreamingThinking)=>__cc_prevStreamingThinking?{...__cc_prevStreamingThinking,isStreaming:!1,streamingEndedAt:void 0,currentIndex:null,currentMessage:null}:__cc_prevStreamingThinking),${setModeParam}("responding");return;`;
@@ -1598,14 +1604,11 @@ function patchThinkingStreaming(content) {
 
           const thinkingDeltaBefore = `case"thinking_delta":${appendOutputParam}(${eventParam}.event.delta.thinking);return;`;
           const thinkingDeltaBareBefore = `case"thinking_delta":return;`;
-          const thinkingDeltaBody =
-            createVirtualMessageHelper === null
-              ? null
-              : buildStreamingThinkingDeltaStatement(
-                  eventParam,
-                  setStreamingThinkingParam,
-                  createVirtualMessageHelper
-                );
+          const thinkingDeltaBody = buildStreamingThinkingDeltaStatement(
+            eventParam,
+            setStreamingThinkingParam,
+            reducerMessageHelper
+          );
           const thinkingDeltaAfter =
             thinkingDeltaBody === null
               ? null

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1574,7 +1574,13 @@ function patchThinkingStreaming(content) {
 
       if (signatureMatch) {
         const params = signatureMatch[1].split(",").map((param) => param.trim());
-        if (params.length >= 7) {
+        // This positional branch is its own scope: the helper the two
+        // destructured reducer loops resolve is not visible here, so referencing
+        // it would throw a ReferenceError and abort the whole patch run the
+        // first time an older bundle reached this shape. Resolve it for this
+        // reducer's own module, and skip the injection when it is unavailable.
+        const positionalMessageHelper = virtualMessageHelperAt(output, wg6Start);
+        if (params.length >= 7 && positionalMessageHelper !== null) {
           const eventParam = params[0];
           const appendOutputParam = params[2];
           const setModeParam = params[3];
@@ -1591,7 +1597,7 @@ function patchThinkingStreaming(content) {
           const thinkingStartAfter = `case"thinking":case"redacted_thinking":${buildStreamingThinkingStartExpression(
             eventParam,
             setStreamingThinkingParam,
-            reducerMessageHelper
+            positionalMessageHelper
           )},${setModeParam}("thinking");return;`;
 
           const textStartBefore = `case"text":${setModeParam}("responding");return;`;
@@ -1607,7 +1613,7 @@ function patchThinkingStreaming(content) {
           const thinkingDeltaBody = buildStreamingThinkingDeltaStatement(
             eventParam,
             setStreamingThinkingParam,
-            reducerMessageHelper
+            positionalMessageHelper
           );
           const thinkingDeltaAfter =
             thinkingDeltaBody === null
@@ -3902,6 +3908,9 @@ module.exports = {
   patchStatuslineCommittedUsage,
   patchStatuslineRateLimitWindows,
   patchCustomContextWindows,
+  // Exported for tests: the positional stream-reducer branch is only reachable
+  // on older bundle shapes, so nothing else exercises it.
+  patchThinkingStreaming,
 };
 
 if (require.main === module) {

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -489,7 +489,12 @@ function rebuildBunDataPreservingBytecodeOffsets(
       bunOffsets.modulesPtr.offset + replacement.index * moduleStructSize;
     rebuilt.writeUInt32LE(contentsOffset, moduleRecordOffset + 8);
     rebuilt.writeUInt32LE(replacement.contents.length, moduleRecordOffset + 12);
-    // Clear bytecode: it was compiled from the unpatched source.
+    // Clear the sourcemap and bytecode: both describe the unpatched source, so
+    // keeping them means stale mappings and stale code. The full-rebuild path
+    // below drops the same three ranges; this is the path every patch actually
+    // takes now that only real edits are written back.
+    rebuilt.writeUInt32LE(0, moduleRecordOffset + 16);
+    rebuilt.writeUInt32LE(0, moduleRecordOffset + 20);
     rebuilt.writeUInt32LE(0, moduleRecordOffset + 24);
     rebuilt.writeUInt32LE(0, moduleRecordOffset + 28);
     if (moduleStructSize === 52) {

--- a/scripts/native-bun.ts
+++ b/scripts/native-bun.ts
@@ -433,9 +433,82 @@ function splitClaudeJsModules(
 
   assertInjectionsAreModuleScoped(parts, jsModules);
 
-  return new Map(
-    jsModules.map((jsModule, index) => [jsModule.index, Buffer.from(parts[index], "utf8")])
-  );
+  // Only modules the patcher actually changed are written back. Bun keeps
+  // bytecode in a position-sensitive pool, so rewriting every module — even
+  // with identical bytes — forces a full re-layout that 2.1.246 rejects with a
+  // segfault. Restricting the map to real edits leaves the other ~1,400 modules
+  // and their bytecode untouched, and is what lets the offset-preserving
+  // rebuild path apply.
+  const replacements = new Map<number, Buffer>();
+  for (const [index, jsModule] of jsModules.entries()) {
+    if (parts[index] !== jsModule.content) {
+      replacements.set(jsModule.index, Buffer.from(parts[index], "utf8"));
+    }
+  }
+  return replacements;
+}
+
+// Bun's split bundles keep bytecode in a position-sensitive pool, so once any
+// module retains its bytecode the surrounding bytes cannot be re-laid-out. This
+// appends the replacement contents after the original data, repoints only the
+// affected module records, and clears their bytecode so the runtime falls back
+// to the patched source. Everything else stays byte-identical.
+//
+// Ported from upstream a-connoisseur/patch-claude-code (ec2c508, "fix: binary
+// shape"), keyed by container index rather than module name.
+function rebuildBunDataPreservingBytecodeOffsets(
+  bunData: Buffer,
+  bunOffsets: BunOffsets,
+  replacementContents: Map<number, Buffer>,
+  moduleStructSize: 36 | 52
+): Buffer {
+  const moduleTable = sliceRange(bunData, bunOffsets.modulesPtr);
+  const moduleCount = Math.floor(moduleTable.length / moduleStructSize);
+  const replacements: Array<{ index: number; contents: Buffer }> = [];
+  let replacementBytes = 0;
+
+  for (let index = 0; index < moduleCount; index += 1) {
+    const contents = replacementContents.get(index);
+    if (!contents) {
+      continue;
+    }
+    replacements.push({ index, contents });
+    replacementBytes += contents.length + 1;
+  }
+
+  const originalOffsetsOffset = bunData.length - BUN_TRAILER.length - 32;
+  const offsetsOffset = originalOffsetsOffset + replacementBytes;
+  const trailerOffset = offsetsOffset + 32;
+  const rebuilt = Buffer.alloc(trailerOffset + BUN_TRAILER.length);
+  bunData.copy(rebuilt, 0, 0, originalOffsetsOffset);
+
+  let contentsOffset = originalOffsetsOffset;
+  for (const replacement of replacements) {
+    replacement.contents.copy(rebuilt, contentsOffset);
+    const moduleRecordOffset =
+      bunOffsets.modulesPtr.offset + replacement.index * moduleStructSize;
+    rebuilt.writeUInt32LE(contentsOffset, moduleRecordOffset + 8);
+    rebuilt.writeUInt32LE(replacement.contents.length, moduleRecordOffset + 12);
+    // Clear bytecode: it was compiled from the unpatched source.
+    rebuilt.writeUInt32LE(0, moduleRecordOffset + 24);
+    rebuilt.writeUInt32LE(0, moduleRecordOffset + 28);
+    if (moduleStructSize === 52) {
+      rebuilt.writeUInt32LE(0, moduleRecordOffset + 40);
+      rebuilt.writeUInt32LE(0, moduleRecordOffset + 44);
+    }
+    contentsOffset += replacement.contents.length + 1;
+  }
+
+  rebuilt.writeBigUInt64LE(BigInt(offsetsOffset), offsetsOffset);
+  rebuilt.writeUInt32LE(bunOffsets.modulesPtr.offset, offsetsOffset + 8);
+  rebuilt.writeUInt32LE(bunOffsets.modulesPtr.length, offsetsOffset + 12);
+  rebuilt.writeUInt32LE(bunOffsets.entryPointId, offsetsOffset + 16);
+  rebuilt.writeUInt32LE(bunOffsets.compileExecArgvPtr.offset, offsetsOffset + 20);
+  rebuilt.writeUInt32LE(bunOffsets.compileExecArgvPtr.length, offsetsOffset + 24);
+  rebuilt.writeUInt32LE(bunOffsets.flags, offsetsOffset + 28);
+  BUN_TRAILER.copy(rebuilt, trailerOffset);
+
+  return rebuilt;
 }
 
 function rebuildBunData(
@@ -461,22 +534,46 @@ function rebuildBunData(
   const moduleTable = sliceRange(bunData, bunOffsets.modulesPtr);
   const moduleCount = Math.floor(moduleTable.length / moduleStructSize);
 
+  // Relaying out the whole blob moves bytecode that other records point at. If
+  // any module keeps its bytecode, take the offset-preserving path instead: on
+  // 2.1.246 a full rebuild produced a container the runtime kills at exec with
+  // no output at all, while --assert-all and every verifier check passed.
+  for (let index = 0; index < moduleCount; index += 1) {
+    const moduleRecord = readBunModule(moduleTable, index * moduleStructSize, moduleStructSize);
+    if (moduleRecord.bytecode.length > 0 && !replacementContents.has(index)) {
+      return rebuildBunDataPreservingBytecodeOffsets(
+        bunData,
+        bunOffsets,
+        replacementContents,
+        moduleStructSize
+      );
+    }
+  }
+
   for (let index = 0; index < moduleCount; index += 1) {
     const moduleOffset = index * moduleStructSize;
     const moduleRecord = readBunModule(moduleTable, moduleOffset, moduleStructSize);
 
     // Offsets and lengths for every module are recomputed below from the
     // rebuilt layout, so replacement contents are free to change size.
-    const nextContents =
-      replacementContents.get(index) ?? sliceRange(bunData, moduleRecord.contents);
+    const replacement = replacementContents.get(index);
+    const nextContents = replacement ?? sliceRange(bunData, moduleRecord.contents);
 
+    // A replaced module's bytecode was compiled from the unpatched source, so
+    // keeping it means the runtime can execute the old code and the patch does
+    // nothing — or, on 2.1.246, the container is rejected outright and the
+    // binary is killed at exec with no output. Drop it so the patched source is
+    // the only thing left to run.
+    const EMPTY = Buffer.alloc(0);
     const nextModule = {
       name: sliceRange(bunData, moduleRecord.name),
       contents: nextContents,
-      sourcemap: sliceRange(bunData, moduleRecord.sourcemap),
-      bytecode: sliceRange(bunData, moduleRecord.bytecode),
+      sourcemap: replacement ? EMPTY : sliceRange(bunData, moduleRecord.sourcemap),
+      bytecode: replacement ? EMPTY : sliceRange(bunData, moduleRecord.bytecode),
       moduleInfo: sliceRange(bunData, moduleRecord.moduleInfo),
-      bytecodeOriginPath: sliceRange(bunData, moduleRecord.bytecodeOriginPath),
+      bytecodeOriginPath: replacement
+        ? EMPTY
+        : sliceRange(bunData, moduleRecord.bytecodeOriginPath),
       encoding: moduleRecord.encoding,
       loader: moduleRecord.loader,
       moduleFormat: moduleRecord.moduleFormat,

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1404,8 +1404,20 @@ const CHECKS: Check[] = [
             return `expected the memo cache to be grown past slot ${slot} for __cc_streamingThinking`;
           }
         }
+        // The inline extras memo materialises streamed thinking into the
+        // transcript. 2.1.246 restructured that memo away entirely, so the site
+        // no longer exists to patch. Requiring the marker unconditionally would
+        // fail a correct build; accepting its absence unconditionally would
+        // re-open the hole this check was added for. Fail only when the
+        // unpatched shape is still present, i.e. a site we should have taken.
+        const unpatchedExtrasMemo =
+          /=[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\(\)=>[A-Za-z_$][\w$]*\.flatMap\(\([A-Za-z_$][\w$]*\)=>\{let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{content:\[[A-Za-z_$][\w$]*\.contentBlock\]\}\)/;
         if (!content.includes("__cc_streamingThinkingExtras")) {
-          return "expected inline streaming-thinking transcript extras";
+          if (unpatchedExtrasMemo.test(content)) {
+            return "inline streaming-thinking transcript extras site is present but was not patched";
+          }
+          // Absent site: streamed thinking still updates through the reducer
+          // plumbing asserted above, but is not materialised inline.
         }
         // The stream reducer builds virtual thinking messages through
         // upstream's create-message helper. That helper's name is a per-chunk

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1418,6 +1418,7 @@ const CHECKS: Check[] = [
             (version[1] > 1 || (version[1] === 1 && version[2] >= 246)));
         const unpatchedExtrasMemo =
           /=[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\(\)=>[A-Za-z_$][\w$]*\.flatMap\(\([A-Za-z_$][\w$]*\)=>\{let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{content:\[[A-Za-z_$][\w$]*\.contentBlock\]\}\)/;
+        let extrasWaived = false;
         if (!content.includes("__cc_streamingThinkingExtras")) {
           if (!allowsMissingExtras) {
             return "expected inline streaming-thinking transcript extras";
@@ -1425,9 +1426,11 @@ const CHECKS: Check[] = [
           if (unpatchedExtrasMemo.test(content)) {
             return "inline streaming-thinking transcript extras site is present but was not patched";
           }
-          // 2.1.246+ with the site genuinely gone: streamed thinking still
-          // updates through the reducer plumbing asserted above, but upstream no
-          // longer materialises it inline.
+          // 2.1.246+ with the site genuinely gone. Nothing above then requires
+          // any stream-reducer injection, so the reducer check below stops being
+          // optional: without it a renderer-only build passes while no stream
+          // event ever populates the state it reads.
+          extrasWaived = true;
         }
         // The stream reducer builds virtual thinking messages through
         // upstream's create-message helper. That helper's name is a per-chunk
@@ -1439,8 +1442,12 @@ const CHECKS: Check[] = [
         const reducerCalls = [
           ...content.matchAll(/__cc_streamingThinkingMessage=([A-Za-z_$][\w$]*)\(\{content:/g),
         ];
-        // Presence is already covered by the threading and extras checks above;
-        // what this adds is that whatever the reducer calls resolves here.
+        // When the extras marker was waived this is the only thing left that
+        // proves the reducer was patched at all, so presence becomes mandatory.
+        // Otherwise presence is covered above and this only checks resolution.
+        if (extrasWaived && reducerCalls.length === 0) {
+          return "expected the stream reducer to build virtual thinking messages when inline extras are absent";
+        }
         for (const call of reducerCalls) {
           const declaration = new RegExp(
             `function ${call[1]}\\(\\{content:[A-Za-z_$][\\w$]*,usage:`,

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -723,7 +723,7 @@ const CHECKS: Check[] = [
       }
       const identifier = "[A-Za-z_$][\\w$]*";
       const trackerPattern = new RegExp(
-        `function (${identifier})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\],activeMessageId:null,responseOutputTokens:new Map\\}\\}`,
+        `function (${identifier})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\](?:,[^{}]*?)?,activeMessageId:null,responseOutputTokens:new Map\\}\\}`,
         "g"
       );
       const trackerMatches = [...content.matchAll(trackerPattern)];
@@ -922,11 +922,11 @@ const CHECKS: Check[] = [
       }
 
       const legacyWrapperPattern = new RegExp(
-        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\}\\};`,
+        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
         "g"
       );
       const effortWrapperPattern = new RegExp(
-        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        `let (${identifier})=\\{message:\\{\\.\\.\\.(${identifier}),content:(${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:\\2\\.id\\}\\)\\},requestId:\\7\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\6\\.querySource,\\6\\.spawnedBySkill,\\6\\.activeSkill,\\6\\.activeMcpServer,\\6\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\10\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
         "g"
       );
       // 2.1.236+ batch tool-use destructured wrapper; see the matching
@@ -935,7 +935,7 @@ const CHECKS: Check[] = [
       // (`…messageId:Gr.id},i.storageV5)`), matched optionally so the patched
       // 2.1.237 and 2.1.238 binaries both verify.
       const batchWrapperPattern = new RegExp(
-        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}\\};`,
+        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
         "g"
       );
       const wrapperMatches = [

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1406,18 +1406,28 @@ const CHECKS: Check[] = [
         }
         // The inline extras memo materialises streamed thinking into the
         // transcript. 2.1.246 restructured that memo away entirely, so the site
-        // no longer exists to patch. Requiring the marker unconditionally would
-        // fail a correct build; accepting its absence unconditionally would
-        // re-open the hole this check was added for. Fail only when the
-        // unpatched shape is still present, i.e. a site we should have taken.
+        // no longer exists to patch there. Every version before it still has the
+        // site and still needs the marker: relaxing on the absence of an exact
+        // unpatched-shape regex would let a bundle whose shape merely drifted
+        // pass, approving a binary whose reducer updates state the UI never
+        // consumes. So the relaxation is version-gated, and even on 2.1.246+ a
+        // site that is still present un-patched is a failure.
+        const allowsMissingExtras =
+          version[0] > 2 ||
+          (version[0] === 2 &&
+            (version[1] > 1 || (version[1] === 1 && version[2] >= 246)));
         const unpatchedExtrasMemo =
           /=[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\(\)=>[A-Za-z_$][\w$]*\.flatMap\(\([A-Za-z_$][\w$]*\)=>\{let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{content:\[[A-Za-z_$][\w$]*\.contentBlock\]\}\)/;
         if (!content.includes("__cc_streamingThinkingExtras")) {
+          if (!allowsMissingExtras) {
+            return "expected inline streaming-thinking transcript extras";
+          }
           if (unpatchedExtrasMemo.test(content)) {
             return "inline streaming-thinking transcript extras site is present but was not patched";
           }
-          // Absent site: streamed thinking still updates through the reducer
-          // plumbing asserted above, but is not materialised inline.
+          // 2.1.246+ with the site genuinely gone: streamed thinking still
+          // updates through the reducer plumbing asserted above, but upstream no
+          // longer materialises it inline.
         }
         // The stream reducer builds virtual thinking messages through
         // upstream's create-message helper. That helper's name is a per-chunk

--- a/tests/bun-module-boundaries.test.js
+++ b/tests/bun-module-boundaries.test.js
@@ -12,27 +12,25 @@ function jsModules(...contents) {
   }));
 }
 
-test("round-trips module contents through join and split", () => {
+// Only real edits are written back: rewriting untouched modules forces Bun to
+// re-lay-out a bytecode pool it keeps position-sensitive, which 2.1.246 rejects.
+test("writes nothing back when the patcher changed nothing", () => {
   const modules = jsModules("let a=1", "let b=2", "let c=3");
   const replacements = nativeBun.splitClaudeJsModules(
     nativeBun.joinClaudeJsModules(modules),
     modules
   );
 
-  assert.deepEqual([...replacements.keys()], [1, 3, 5]);
-  for (const module of modules) {
-    assert.equal(replacements.get(module.index).toString("utf8"), module.content);
-  }
+  assert.equal(replacements.size, 0);
 });
 
 test("keys replacements by container module index, not by position", () => {
   const modules = jsModules("let a=1", "let b=2");
-  const replacements = nativeBun.splitClaudeJsModules(
-    nativeBun.joinClaudeJsModules(modules),
-    modules
-  );
+  const patched = nativeBun.joinClaudeJsModules(modules).replace("let b=2", "let b=99");
+  const replacements = nativeBun.splitClaudeJsModules(patched, modules);
 
-  assert.equal(replacements.get(3).toString("utf8"), "let b=2");
+  assert.deepEqual([...replacements.keys()], [3]);
+  assert.equal(replacements.get(3).toString("utf8"), "let b=99");
   assert.equal(replacements.get(0), undefined);
 });
 
@@ -41,7 +39,7 @@ test("carries patched content back to the right module", () => {
   const patched = nativeBun.joinClaudeJsModules(modules).replace("let b=2", "let b=99");
   const replacements = nativeBun.splitClaudeJsModules(patched, modules);
 
-  assert.equal(replacements.get(1).toString("utf8"), "let a=1");
+  assert.equal(replacements.get(1), undefined);
   assert.equal(replacements.get(3).toString("utf8"), "let b=99");
 });
 

--- a/tests/thinking-streaming-positional-reducer.test.js
+++ b/tests/thinking-streaming-positional-reducer.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const { patchThinkingStreaming } = require(
+  path.join(__dirname, "..", "patch-claude-display.ts")
+);
+
+// The positional stream-reducer branch is a separate scope from the two
+// destructured reducer loops. Referencing their helper there is not a syntax
+// error, so it only throws the first time a bundle actually reaches this shape —
+// and it aborts the entire patch run when it does. No fixture exercised this
+// branch, which is how a `reducerMessageHelper` reference survived here.
+function positionalReducerBundle() {
+  return [
+    'var VERSION="2.1.200";',
+    // upstream's create-virtual-message helper, matched by its option names
+    "function mkMessage({content:a,usage:b,isVirtual:c,now:d,uuid:e}){return inner({content:a,usage:b,isVirtual:c,now:d,uuid:e})}",
+    // a >=7 parameter positional reducer carrying all three anchors
+    "function reduce(evt,ctx,appendOutput,setMode,setStreamingTools,extra,setStreamingThinking){",
+    'if(evt.type!=="stream_event"&&evt.type==="stream_request_start"){setMode("requesting");return}',
+    'if(evt.type==="stream_request_start"){setMode("requesting");return}',
+    'switch(evt.event.type){case"thinking":case"redacted_thinking":setMode("thinking");return;',
+    'case"thinking_delta":return;}',
+    "}",
+    "function tail(){}",
+  ].join("");
+}
+
+test("positional stream reducer branch does not reference an out-of-scope helper", () => {
+  const source = positionalReducerBundle();
+
+  // The bug this pins is a ReferenceError thrown while building the
+  // replacement, which takes down the whole patch run rather than skipping one
+  // module. Any outcome other than throwing is acceptable here.
+  let result;
+  assert.doesNotThrow(() => {
+    result = patchThinkingStreaming(source);
+  });
+  assert.equal(typeof result.content, "string");
+  assert.equal(typeof result.candidates, "number");
+});
+
+test("positional stream reducer skips its injection when no helper is in its module", () => {
+  // Same bundle with the helper declaration removed: the branch must decline to
+  // inject rather than emit a name it could not resolve.
+  const source = positionalReducerBundle().replace(
+    /function mkMessage\([^)]*\)\{[^}]*\}/,
+    ""
+  );
+  const result = patchThinkingStreaming(source);
+
+  assert.equal(result.content.includes("__cc_streamingThinkingMessage"), false);
+});

--- a/tests/thinking-streaming-verifier.test.js
+++ b/tests/thinking-streaming-verifier.test.js
@@ -56,13 +56,21 @@ test("thinking verifier requires renderer threading and inline extras from Claud
     ),
     /expected 1 renderer call-site streamingThinking prop, found 0/
   );
-  // The inline-extras requirement is conditional: 2.1.246 restructured that memo
-  // away, so a bundle without the site is accepted, while a bundle that still
-  // carries the unpatched site must fail.
-  assert.equal(
+  // Before 2.1.246 the extras site exists, so its marker stays mandatory: a
+  // missing injection there means the reducer updates state the UI never reads.
+  assert.match(
     evaluatePatchModule(
       "thinking-streaming",
       bundle("2.1.234", `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker}`)
+    ),
+    /inline streaming-thinking transcript extras/
+  );
+  // 2.1.246 restructured that memo away, so its absence is accepted there —
+  // but only when the site is genuinely gone.
+  assert.equal(
+    evaluatePatchModule(
+      "thinking-streaming",
+      bundle("2.1.246", `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker}`)
     ),
     null
   );
@@ -70,7 +78,7 @@ test("thinking verifier requires renderer threading and inline extras from Claud
     evaluatePatchModule(
       "thinking-streaming",
       bundle(
-        "2.1.234",
+        "2.1.246",
         `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker} ${unpatchedExtrasMarker}`
       )
     ),

--- a/tests/thinking-streaming-verifier.test.js
+++ b/tests/thinking-streaming-verifier.test.js
@@ -15,6 +15,9 @@ const rendererCallSiteMarker = "screen:l,streamingToolUses:c,streamingThinking:d
 const storeCallSiteMarker =
   "screen:l,streamingToolUses:c,streamingThinking:__cc_streamingThinkingState,";
 const inlineExtrasMarker = "__cc_streamingThinkingExtras";
+// The un-rewritten memo the patch is supposed to take over.
+const unpatchedExtrasMarker =
+  'let extras=React.useMemo(()=>streamingToolUses.flatMap((entry)=>{let msg=createMessage({content:[entry.contentBlock]});return msg.uuid=mintUuid(entry.contentBlock.id,0),normalize([msg])}),[streamingToolUses])';
 
 function bundle(version, extra = "") {
   return `PACKAGE_URL:"@anthropic-ai/claude-code",VERSION:"${version}" ${plumbing} ${extra}`;
@@ -53,12 +56,25 @@ test("thinking verifier requires renderer threading and inline extras from Claud
     ),
     /expected 1 renderer call-site streamingThinking prop, found 0/
   );
-  assert.match(
+  // The inline-extras requirement is conditional: 2.1.246 restructured that memo
+  // away, so a bundle without the site is accepted, while a bundle that still
+  // carries the unpatched site must fail.
+  assert.equal(
     evaluatePatchModule(
       "thinking-streaming",
       bundle("2.1.234", `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker}`)
     ),
-    /inline streaming-thinking transcript extras/
+    null
+  );
+  assert.match(
+    evaluatePatchModule(
+      "thinking-streaming",
+      bundle(
+        "2.1.234",
+        `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker} ${unpatchedExtrasMarker}`
+      )
+    ),
+    /transcript extras site is present but was not patched/
   );
   assert.equal(
     evaluatePatchModule(

--- a/tests/thinking-streaming-verifier.test.js
+++ b/tests/thinking-streaming-verifier.test.js
@@ -15,6 +15,12 @@ const rendererCallSiteMarker = "screen:l,streamingToolUses:c,streamingThinking:d
 const storeCallSiteMarker =
   "screen:l,streamingToolUses:c,streamingThinking:__cc_streamingThinkingState,";
 const inlineExtrasMarker = "__cc_streamingThinkingExtras";
+// A stream-reducer injection plus the create-message helper it resolves to.
+// When the inline-extras marker is waived on 2.1.246+, this is the only
+// remaining proof that any stream event populates the state the renderer reads.
+const reducerProducerMarker =
+  "function mkMessage({content:a,usage:b,isVirtual:c,now:d,uuid:e}){return inner(a)}" +
+  "__cc_streamingThinkingMessage=mkMessage({content:[x]})";
 // The un-rewritten memo the patch is supposed to take over.
 const unpatchedExtrasMarker =
   'let extras=React.useMemo(()=>streamingToolUses.flatMap((entry)=>{let msg=createMessage({content:[entry.contentBlock]});return msg.uuid=mintUuid(entry.contentBlock.id,0),normalize([msg])}),[streamingToolUses])';
@@ -66,11 +72,22 @@ test("thinking verifier requires renderer threading and inline extras from Claud
     /inline streaming-thinking transcript extras/
   );
   // 2.1.246 restructured that memo away, so its absence is accepted there —
-  // but only when the site is genuinely gone.
-  assert.equal(
+  // but only when the site is genuinely gone AND the stream reducer was still
+  // patched. Renderer plumbing alone means nothing ever populates the state.
+  assert.match(
     evaluatePatchModule(
       "thinking-streaming",
       bundle("2.1.246", `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker}`)
+    ),
+    /stream reducer to build virtual thinking messages when inline extras are absent/
+  );
+  assert.equal(
+    evaluatePatchModule(
+      "thinking-streaming",
+      bundle(
+        "2.1.246",
+        `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker} ${reducerProducerMarker}`
+      )
     ),
     null
   );
@@ -79,7 +96,7 @@ test("thinking verifier requires renderer threading and inline extras from Claud
       "thinking-streaming",
       bundle(
         "2.1.246",
-        `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker} ${unpatchedExtrasMarker}`
+        `${briefMarker} ${rendererSignatureMarker} ${rendererCallSiteMarker} ${reducerProducerMarker} ${unpatchedExtrasMarker}`
       )
     ),
     /transcript extras site is present but was not patched/


### PR DESCRIPTION
The 2.1.245 release shipped from #13, but the workflow always takes the latest native version and upstream had moved to 2.1.246, where `--assert-all` failed on three modules. Fixing those exposed a container-format bug that had been latent since the chunked-bundle work.

Checking `upstream/main` (`a-connoisseur/patch-claude-code`, which this repo tracks and which had already shipped `v2.1.246-*` tags) named the cause in a comment: **Bun keeps bytecode in a position-sensitive pool.**

## Container format

The write-back replaced every JavaScript module — ~1,400 of them — even though the patcher changes a handful. Rewriting a module forces the container to be re-laid out, which moves bytecode other records point at. 2.1.245 tolerated that; 2.1.246 was killed at exec with no output at all, while `--assert-all` passed and `verify-patched-binary` reported 18 modules verified. `splitClaudeJsModules` now compares each split section against the module's unpatched text and returns only real edits.

Separately, a replaced module kept its own bytecode, sourcemap and bytecodeOriginPath, all of which describe the unpatched source. That is a silent-failure hazard on its own — the runtime can execute the old code while every text-level check passes — and on 2.1.246 it segfaulted. Replaced modules now drop all three, on both rebuild paths.

`rebuildBunData` gains upstream's offset-preserving path (ported from `ec2c508`, keyed by container index rather than module name): when any module keeps its bytecode, replacement contents are appended after the original data and only the affected records are repointed. With the write-back restricted to real edits, this is the path every patch now takes. Both binaries grow about 10MB, which is those appended contents.

## Matcher drift on 2.1.246

- `create-diff-colors`: the create renderer's props gained `replacedUndiffedContent`; trailing props are matched but not forwarded, since the replacement renders through the diff component.
- `background-agent-usage`: the tracker initialiser gained `seenToolUseIds:new Set`. Widening the anchor alone would have silently dropped it, because the replacement rewrites that initialiser and hardcodes its members — the trailing members are captured and re-emitted instead.
- `statusline-committed-usage`: the assistant wrapper gained a trailing `,...{}`. Allowing trailing spreads on all three wrapper patterns first made the legacy branch also match the effort shape, taking the candidate count 6 → 7 and failing the module closed; narrowed to the plain-object spread upstream emits.
- `thinking-streaming`: applied 3 of 14 sites while `--assert-all` passed — the silent candidate-downgrade blind spot, caught only by the verifier. The store destructuring gained `toolProgress`, and the virtual-message helper now falls back to its own declaration when the transcript-extras anchor is gone (also from upstream, `a75b89d`/`f861ec8`). 3 → 13 applied. The name emitted at each injection site is still resolved per module by `virtualMessageHelperAt`, which upstream's global fallback does not do and which caused the cross-chunk reducer defect in #13.

The positional stream-reducer branch — reachable only on older bundle shapes, so nothing exercised it — referenced a helper declared inside the destructured reducer loops and would have thrown a `ReferenceError` that aborted the whole patch run. It now resolves the helper for its own module and declines to inject when none is available.

## Verifier

The inline transcript-extras memo genuinely no longer exists on 2.1.246, so its marker is required only for versions before that, and even on 2.1.246+ a site that is still present un-patched is a failure. Because waiving that marker removes the only thing that covered reducer presence, at least one validated stream-reducer call becomes mandatory whenever it is waived — otherwise a bundle carrying renderer plumbing alone would verify clean with nothing populating the state the renderer reads.

## Verification

Real binaries, both versions, all five platforms: `--assert-all` passes with full candidate counts, `verify-patched-binary` reports 18 modules verified with 1 disabled. On macos-arm64 both run and report `(patched)` and render a complete turn through `tools/local-verify` against the mock API. `npm test`: 144 passing.

Known gap, matching upstream and present in a stock 2.1.246 binary too: streamed thinking is no longer materialised inline in the transcript, because the memo that did so was removed upstream. Driving the patched and unpatched 2.1.246 binaries through the harness with thinking deltas streamed 1.5s apart renders identically, so this is not a regression the patch introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e
