### PR TITLE
fix(patch): support Claude 2.1.247, and gate releases on a preflight verify

### DIFF
--- a/.github/workflows/watch-claude-release.yml
+++ b/.github/workflows/watch-claude-release.yml
@@ -83,8 +83,63 @@ jobs:
 
           echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch patch workflow
+      # Gate the release on a cheap patch+verify of one platform first. Without
+      # it, upstream drift is only discovered when the release run fails on all
+      # five platforms, after the tags have already been attempted. One platform
+      # is not proof for the others — minified locals differ per build, and the
+      # release run still verifies each — but every drift seen so far has shown
+      # up identically everywhere, so this catches it a full release earlier and
+      # names the module.
+      - name: Check out the patcher
         if: steps.active.outputs.skip != 'true' && steps.releases.outputs.missing == '1'
+        uses: actions/checkout@v5
+
+      - name: Install dependencies
+        if: steps.active.outputs.skip != 'true' && steps.releases.outputs.missing == '1'
+        run: npm ci
+
+      - name: Verify the patcher against the new version
+        id: preflight
+        if: steps.active.outputs.skip != 'true' && steps.releases.outputs.missing == '1'
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+          DISABLED_MODULES: tool-call-verbose
+        run: |
+          set -euo pipefail
+
+          bash scripts/download-native-from-installer.sh \
+            --platform linux-x64 \
+            --version "$VERSION" \
+            --output work/preflight.original \
+            --manifest-out work/preflight-manifest.json
+
+          cp work/preflight.original work/preflight.patched
+          chmod +x work/preflight.patched
+
+          node scripts/patch-native.ts \
+            --input work/preflight.patched \
+            --disable "$DISABLED_MODULES" \
+            --assert-all
+
+          node scripts/verify-patched-binary.ts \
+            --input work/preflight.patched \
+            --disable "$DISABLED_MODULES"
+
+          work/preflight.patched --version | tee work/preflight-version.txt
+          grep -F "(patched)" work/preflight-version.txt
+
+      - name: Report drift and stop
+        if: steps.preflight.outcome == 'failure'
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          echo "The patcher does not cleanly handle Claude $VERSION yet, so no release was dispatched." >&2
+          echo "See the preflight step above for the module that drifted." >&2
+          exit 1
+
+      - name: Dispatch patch workflow
+        if: steps.active.outputs.skip != 'true' && steps.releases.outputs.missing == '1' && steps.preflight.outcome == 'success'
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}

--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -138,6 +138,16 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   injected value that occupies no slot leaves the renderer showing a stale element forever while the
   patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
   slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **Anchor on the parameter, not on what follows it.** 2.1.247 dropped `showAllInTranscript` from
+  the renderer's destructured params and moved `isLoading` up behind `streamingToolUses`, which
+  killed an injection anchored on that suffix. The stable thing is the parameter you are inserting
+  next to; use a negative lookahead for your own inserted name to stay idempotent instead of pinning
+  a neighbour.
+- **Gate an injection on what it needs, not on how it used to be discovered.** The renderer-signature
+  injection was gated on the old store-snapshot discovery having succeeded. 2.1.247 removed that
+  destructuring entirely — the store is now read per field through selector calls — so the gate went
+  false while the call site above was still supplying the prop, and the renderer received a value it
+  never destructured. Ask "is anything going to pass this", not "did the previous mechanism match".
 - **Write back only the modules you changed.** Bun keeps bytecode in a
   position-sensitive pool, so rewriting every module — even with identical bytes — forces a full
   re-layout of the container. 2.1.245 tolerated that; 2.1.246 killed the process at exec with no

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -739,127 +739,132 @@ function patchThinkingStreaming(content) {
     );
     output = output.replace(jsxTranscriptRendererPropsPattern, injectStreamingThinking);
 
-    // 2.1.245 rewrote the main renderer call site: instead of an explicit prop
-    // list it spreads a rest object and reads the streaming state through store
-    // selectors, inside a React-compiler memo cache:
-    //
-    //   function kC(lh){let ju=v(19);…
-    //     let mh=Do(Wu,NC)??!1,ph=Do(Wu?.stream,EC)??_i,…
-    //     let qu;if(ju[10]!==Vu||…||ju[14]!==fh)
-    //       qu=o(Rh,{...nn,messages:Vu,isLoading:mh,streamingToolUses:ph,
-    //               onRateLimitAutoQueueContinue:fh}),
-    //       ju[10]=Vu,…,ju[14]=fh,ju[15]=qu;else qu=ju[15];
-    //
-    // Adding the prop alone is not enough: the cached element is only rebuilt
-    // when one of the compared slots changes, so a streamingThinking value that
-    // updates on its own would never reach the renderer. The injection
-    // therefore also claims one new cache slot — growing the allocation the way
-    // the compiler itself would — and adds it to both the guard and the
-    // write-back. `streamingThinking` is read through its own module-scoped
-    // selector declared beside the component, so the selector identity is
-    // stable across renders and nothing crosses a chunk scope.
-    // Not gated on the earlier prop patterns having failed: the spread call
-    // site is a distinct shape that simply does not exist on pre-2.1.245
-    // bundles, so it self-selects and pre-2.1.245 builds keep their counts.
-    {
-      const storeSelectorPattern = new RegExp(
-        `(${identifierPattern})=(${identifierPattern})\\((${identifierPattern})\\?\\.stream,${identifierPattern}\\)\\?\\?${identifierPattern},`,
-        "g"
+  }
+
+  // 2.1.245 rewrote the main renderer call site: instead of an explicit prop
+  // list it spreads a rest object and reads the streaming state through store
+  // selectors, inside a React-compiler memo cache:
+  //
+  //   function kC(lh){let ju=v(19);…
+  //     let mh=Do(Wu,NC)??!1,ph=Do(Wu?.stream,EC)??_i,…
+  //     let qu;if(ju[10]!==Vu||…||ju[14]!==fh)
+  //       qu=o(Rh,{...nn,messages:Vu,isLoading:mh,streamingToolUses:ph,
+  //               onRateLimitAutoQueueContinue:fh}),
+  //       ju[10]=Vu,…,ju[14]=fh,ju[15]=qu;else qu=ju[15];
+  //
+  // Adding the prop alone is not enough: the cached element is only rebuilt
+  // when one of the compared slots changes, so a streamingThinking value that
+  // updates on its own would never reach the renderer. The injection
+  // therefore also claims one new cache slot — growing the allocation the way
+  // the compiler itself would — and adds it to both the guard and the
+  // write-back. `streamingThinking` is read through its own module-scoped
+  // selector declared beside the component, so the selector identity is
+  // stable across renders and nothing crosses a chunk scope.
+  // Not gated on the earlier prop patterns having failed: the spread call
+  // site is a distinct shape that simply does not exist on pre-2.1.245
+  // bundles, so it self-selects and pre-2.1.245 builds keep their counts.
+  {
+    // 2.1.247 keeps this idiom but passes the store through a parenthesised
+    // expression rather than a plain local (`et((FM?Xr:null)?.stream,wv)??li`),
+    // and the `??default` tail is not always present. Capture the whole
+    // receiver so the injected read uses the same store the renderer does.
+    const storeSelectorPattern = new RegExp(
+      `(${identifierPattern})=(${identifierPattern})\\((${identifierPattern}|\\([^()]*\\))\\?\\.stream,${identifierPattern}\\)(?:\\?\\?${identifierPattern})?,`,
+      "g"
+    );
+
+    for (const selectorRead of [...output.matchAll(storeSelectorPattern)]) {
+      const toolUsesLocal = selectorRead[1];
+      const storeHook = selectorRead[2];
+      const storeReceiver = selectorRead[3];
+      const escapedToolUses = escapeRegExp(toolUsesLocal);
+      const memoCallPattern = new RegExp(
+        `let (${identifierPattern});if\\((${identifierPattern})\\[\\d+\\]!==[^)]*?\\)\\1=${identifierPattern}\\(${identifierPattern},\\{\\.\\.\\.${identifierPattern},[^{}]*streamingToolUses:${escapedToolUses}[^{}]*\\}\\),[^;]*?,\\2\\[(\\d+)\\]=\\1;`
       );
-
-      for (const selectorRead of [...output.matchAll(storeSelectorPattern)]) {
-        const toolUsesLocal = selectorRead[1];
-        const storeHook = selectorRead[2];
-        const turnLocal = selectorRead[3];
-        const escapedToolUses = escapeRegExp(toolUsesLocal);
-        const memoCallPattern = new RegExp(
-          `let (${identifierPattern});if\\((${identifierPattern})\\[\\d+\\]!==[^)]*?\\)\\1=${identifierPattern}\\(${identifierPattern},\\{\\.\\.\\.${identifierPattern},[^{}]*streamingToolUses:${escapedToolUses}[^{}]*\\}\\),[^;]*?,\\2\\[(\\d+)\\]=\\1;`
-        );
-        const memoCall = output.slice(selectorRead.index).match(memoCallPattern);
-        if (!memoCall || memoCall[0].includes("streamingThinking:")) {
-          continue;
-        }
-
-        const cacheLocal = memoCall[2];
-        const cacheAllocPattern = new RegExp(
-          `let ${escapeRegExp(cacheLocal)}=(${identifierPattern})\\((\\d+)\\)([,;])`
-        );
-        const functionStart = output.lastIndexOf("function ", selectorRead.index);
-        const cacheAlloc =
-          functionStart === -1
-            ? null
-            : output.slice(functionStart, selectorRead.index).match(cacheAllocPattern);
-        if (!cacheAlloc) {
-          continue;
-        }
-
-        const cacheSize = Number(cacheAlloc[2]);
-        const resultSlot = Number(memoCall[3]);
-        if (!Number.isInteger(cacheSize) || resultSlot >= cacheSize) {
-          continue;
-        }
-
-        propCandidates += 1;
-
-        const thinkingLocal = "__cc_streamingThinking";
-        const selectorName = "__cc_streamingThinkingSelector";
-        const grownCall = memoCall[0]
-          .replace(
-            new RegExp(`\\)${escapeRegExp(memoCall[1])}=`),
-            () => `||${cacheLocal}[${cacheSize}]!==${thinkingLocal})${memoCall[1]}=`
-          )
-          .replace(
-            new RegExp(`streamingToolUses:${escapedToolUses}`),
-            () => `streamingToolUses:${toolUsesLocal},streamingThinking:${thinkingLocal}`
-          )
-          .replace(
-            new RegExp(`,${escapeRegExp(cacheLocal)}\\[${resultSlot}\\]=${escapeRegExp(memoCall[1])};$`),
-            () => `,${cacheLocal}[${cacheSize}]=${thinkingLocal},${cacheLocal}[${resultSlot}]=${memoCall[1]};`
-          );
-
-        // Every edit here is applied to the one enclosing function, spliced
-        // back by offset. A plain `output.replace(text, …)` would rewrite the
-        // FIRST occurrence in the whole joined bundle, and minified names are
-        // not unique across chunks: `function kC(` occurs four times in
-        // 2.1.245, so the selector declaration landed in chunk 25 while its use
-        // stayed in chunk 117 and the binary died at startup with
-        // "__cc_streamingThinkingSelector is not defined". The uniqueness
-        // assertions below keep the in-region replaces honest.
-        const regionStart = functionStart;
-        const regionEnd = selectorRead.index + memoCall.index + memoCall[0].length;
-        const region = output.slice(regionStart, regionEnd);
-        if (
-          region.split(cacheAlloc[0]).length - 1 !== 1 ||
-          region.split(selectorRead[0]).length - 1 !== 1 ||
-          region.split(memoCall[0]).length - 1 !== 1
-        ) {
-          continue;
-        }
-
-        const patchedRegion = region
-          .replace(
-            cacheAlloc[0],
-            () => `let ${cacheLocal}=${cacheAlloc[1]}(${cacheSize + 1})${cacheAlloc[3]}`
-          )
-          .replace(
-            selectorRead[0],
-            () =>
-              `${selectorRead[0]}${thinkingLocal}=${storeHook}(${turnLocal}?.stream,${selectorName})??null,`
-          )
-          .replace(memoCall[0], () => grownCall);
-
-        const nextOutput =
-          output.slice(0, regionStart) +
-          `function ${selectorName}(e){return e.streamingThinking}` +
-          patchedRegion +
-          output.slice(regionEnd);
-
-        if (nextOutput !== output) {
-          output = nextOutput;
-          propPatched += 1;
-        }
-        break;
+      const memoCall = output.slice(selectorRead.index).match(memoCallPattern);
+      if (!memoCall || memoCall[0].includes("streamingThinking:")) {
+        continue;
       }
+
+      const cacheLocal = memoCall[2];
+      const cacheAllocPattern = new RegExp(
+        `let ${escapeRegExp(cacheLocal)}=(${identifierPattern})\\((\\d+)\\)([,;])`
+      );
+      const functionStart = output.lastIndexOf("function ", selectorRead.index);
+      const cacheAlloc =
+        functionStart === -1
+          ? null
+          : output.slice(functionStart, selectorRead.index).match(cacheAllocPattern);
+      if (!cacheAlloc) {
+        continue;
+      }
+
+      const cacheSize = Number(cacheAlloc[2]);
+      const resultSlot = Number(memoCall[3]);
+      if (!Number.isInteger(cacheSize) || resultSlot >= cacheSize) {
+        continue;
+      }
+
+      propCandidates += 1;
+
+      const thinkingLocal = "__cc_streamingThinking";
+      const selectorName = "__cc_streamingThinkingSelector";
+      const grownCall = memoCall[0]
+        .replace(
+          new RegExp(`\\)${escapeRegExp(memoCall[1])}=`),
+          () => `||${cacheLocal}[${cacheSize}]!==${thinkingLocal})${memoCall[1]}=`
+        )
+        .replace(
+          new RegExp(`streamingToolUses:${escapedToolUses}`),
+          () => `streamingToolUses:${toolUsesLocal},streamingThinking:${thinkingLocal}`
+        )
+        .replace(
+          new RegExp(`,${escapeRegExp(cacheLocal)}\\[${resultSlot}\\]=${escapeRegExp(memoCall[1])};$`),
+          () => `,${cacheLocal}[${cacheSize}]=${thinkingLocal},${cacheLocal}[${resultSlot}]=${memoCall[1]};`
+        );
+
+      // Every edit here is applied to the one enclosing function, spliced
+      // back by offset. A plain `output.replace(text, …)` would rewrite the
+      // FIRST occurrence in the whole joined bundle, and minified names are
+      // not unique across chunks: `function kC(` occurs four times in
+      // 2.1.245, so the selector declaration landed in chunk 25 while its use
+      // stayed in chunk 117 and the binary died at startup with
+      // "__cc_streamingThinkingSelector is not defined". The uniqueness
+      // assertions below keep the in-region replaces honest.
+      const regionStart = functionStart;
+      const regionEnd = selectorRead.index + memoCall.index + memoCall[0].length;
+      const region = output.slice(regionStart, regionEnd);
+      if (
+        region.split(cacheAlloc[0]).length - 1 !== 1 ||
+        region.split(selectorRead[0]).length - 1 !== 1 ||
+        region.split(memoCall[0]).length - 1 !== 1
+      ) {
+        continue;
+      }
+
+      const patchedRegion = region
+        .replace(
+          cacheAlloc[0],
+          () => `let ${cacheLocal}=${cacheAlloc[1]}(${cacheSize + 1})${cacheAlloc[3]}`
+        )
+        .replace(
+          selectorRead[0],
+          () =>
+            `${selectorRead[0]}${thinkingLocal}=${storeHook}(${storeReceiver}?.stream,${selectorName})??null,`
+        )
+        .replace(memoCall[0], () => grownCall);
+
+      const nextOutput =
+        output.slice(0, regionStart) +
+        `function ${selectorName}(e){return e.streamingThinking}` +
+        patchedRegion +
+        output.slice(regionEnd);
+
+      if (nextOutput !== output) {
+        output = nextOutput;
+        propPatched += 1;
+      }
+      break;
     }
   }
 
@@ -1076,13 +1081,21 @@ function patchThinkingStreaming(content) {
     transcriptToolUseHelpersMatch?.[1] ?? virtualMessageDeclarationMatch?.[1] ?? null;
   let transcriptStreamingThinkingVar = null;
   const rendererStreamingThinkingMatch = output.match(
-    /\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:([A-Za-z_$][\w$]*),showAllInTranscript:/
+    // 2.1.247 dropped showAllInTranscript from the renderer's destructured
+    // params and moved isLoading up behind streamingToolUses, so neither the
+    // detection nor the injection below can pin what follows the parameter.
+    /\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:([A-Za-z_$][\w$]*)[,}]/
   );
   if (rendererStreamingThinkingMatch) {
     transcriptStreamingThinkingVar = rendererStreamingThinkingMatch[1];
-  } else if (streamingVar !== null) {
+  } else if (streamingVar !== null || propPatched > 0) {
+    // The gate is "is anything going to pass this prop", not "did the old
+    // store-snapshot discovery succeed". 2.1.247 dropped that destructuring
+    // entirely, so streamingVar is null there while the compiler-cached call
+    // site above does supply the prop — without this the renderer would receive
+    // a value it never destructures.
     const rendererSignaturePattern =
-      /(\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,)(showAllInTranscript:)/;
+      /(\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,)(?!streamingThinking:)([A-Za-z_$][\w$]*:)/;
     output = output.replace(rendererSignaturePattern, (full, beforeStreamingThinking, afterStreamingThinking) => {
       if (full.includes("streamingThinking:")) {
         return full;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1376,8 +1376,10 @@ const CHECKS: Check[] = [
           ) {
             return "expected exactly one stable __cc_streamingThinkingSelector declaration";
           }
+          // The store receiver is a plain local on 2.1.245/246 and a
+          // parenthesised expression on 2.1.247.
           const storeReadPattern =
-            /__cc_streamingThinking=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\?\.stream,__cc_streamingThinkingSelector\)\?\?null,/g;
+            /__cc_streamingThinking=[A-Za-z_$][\w$]*\((?:[A-Za-z_$][\w$]*|\([^()]*\))\?\.stream,__cc_streamingThinkingSelector\)\?\?null,/g;
           if ([...content.matchAll(storeReadPattern)].length !== 1) {
             return "expected exactly one streamingThinking store read at the renderer call site";
           }


### PR DESCRIPTION
The hourly watch workflow dispatched a release for 2.1.247 and all five platforms failed. `--assert-all` passed; the failure was the verify step, and only `thinking-streaming`: it applied 10 of its 14 sites, which `--assert-all` waves through because `patched > 0`. That is the fourth consecutive release where this module's candidate count silently dropped — 14 → 13 → 10 — and the verifier was the only thing that caught it each time.

## Two anchors, both pinning a neighbour

The renderer signature no longer contains `showAllInTranscript`; 2.1.247 moved `isLoading` up directly behind `streamingToolUses`, so both the detection and the injection missed. They now anchor on the `streamingToolUses` parameter itself, with a negative lookahead on the injected name for idempotency instead of a pinned neighbour.

The store-snapshot destructuring is gone entirely — 2.1.247 reads each field through its own selector call. That is the same idiom the compiler-cached renderer branch already handles, except the store arrives as a parenthesised expression rather than a plain local (`et((FM?Xr:null)?.stream,wv)??li`) and the `??default` tail is optional. The pattern now captures the whole receiver and reuses it for the injected read; the verifier's copy is relaxed to match.

## Two gates that were wrong, not merely narrow

The compiler-cached branch sat inside `if (streamingVar !== null)` — a leftover from the destructuring era. The branch is self-contained and creates its own local, so it now runs regardless.

The renderer-signature injection was gated the same way, so on 2.1.247 the call site supplied the prop while the component never destructured it. It is now gated on whether anything is actually going to pass the prop, rather than on whether the previous discovery mechanism matched.

## Preflight gate

The watch workflow auto-dispatched a release the moment a version appeared with no releases, which is why this surfaced as five failed platform jobs after the tags had already been attempted. It now patches and verifies one platform first and only dispatches when that passes, failing with the drifted module named otherwise.

One platform is not proof for the others — minified locals differ per build, and the release run still verifies each. This only moves discovery a release earlier, and turns "five red jobs" into one message naming the module.

## Verification

Real macos-arm64 binaries for 2.1.245, 2.1.246 and 2.1.247: all three apply every module under `--assert-all`, verify 18 modules with 1 disabled, run reporting `(patched)`, and render a complete turn through `tools/local-verify` against the mock API. 2.1.239 is unchanged at 14/14. `npm test`: 144 passing.

## Still open

`--assert-all` only fails a module at `patched == 0`, so a falling candidate count still ships silently. It has hidden real breakage four times in this sequence and the verifier has caught it every time — but only because a verifier check happened to cover the missing site. That gap is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e