### PR TITLE
fix(patch): support Claude 2.1.248's hoisted session-id header constant

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -143,6 +143,12 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   killed an injection anchored on that suffix. The stable thing is the parameter you are inserting
   next to; use a negative lookahead for your own inserted name to stay idempotent instead of pinning
   a neighbour.
+- **An object key can stop being a literal.** 2.1.248 hoisted the session-id header name into a
+  module-level constant, so `{"X-Claude-Code-Session-Id":qe(),…}` became `{[DDe]:q(),…}`. Three
+  modules used that literal as their "this is the Anthropic client factory" discriminator and all
+  went to zero candidates in the same build. Do not pin the new constant either — `DDe` names
+  `4*ODe` and `$d[9]` in other chunks of the same bundle. Match the key's *shape*
+  (`(?:"Literal"|\[<id>\])`) and keep the entry's position in the object as the real anchor.
 - **Gate an injection on what it needs, not on how it used to be discovered.** The renderer-signature
   injection was gated on the old store-snapshot discovery having succeeded. 2.1.247 removed that
   destructuring entirely — the store is now read per field through selector calls — so the gate went

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -3287,6 +3287,25 @@ function __calicoGatewayFastApply(e){if(process.env.REMORA_ACTIVE!=="1")return e
 
   return { content: output, candidates, patched: 6 };
 }
+// The Anthropic client factory is the shared anchor for active-turn identity,
+// compact-request-source and compact-body-policy. All three recognise it by the
+// session-id entry in the header object it builds.
+//
+// 2.1.248 hoisted that header's name into a module-level constant, so the key
+// went from the literal `"X-Claude-Code-Session-Id":` to a computed `[DDe]:`.
+// The constant is a per-chunk minified name and is not unique across chunks —
+// in 2.1.248 the same `DDe` also names `4*ODe` and `$d[9]` elsewhere — so match
+// the key's shape rather than its name, and keep accepting the literal so older
+// bundles still patch.
+const SESSION_ID_HEADER_KEY =
+  '(?:"X-Claude-Code-Session-Id"|\\[[A-Za-z_$][\\w$]*\\])';
+
+// `<session-id key>:<fn>(),...<custom headers>,` — the entry every one of the
+// three modules keys off, and the position each of them injects after.
+const SESSION_ID_HEADER_ENTRY = new RegExp(
+  `${SESSION_ID_HEADER_KEY}:[A-Za-z_$][\\w$]*\\(\\),\\.\\.\\.[A-Za-z_$][\\w$]*,`
+);
+
 function patchActiveTurnPromptIdentity(content) {
   const original = content;
   let agentCandidates = 0;
@@ -3392,7 +3411,7 @@ function patchActiveTurnPromptIdentity(content) {
     const end = nextAsyncFunction === -1 ? output.length : nextAsyncFunction;
     const segment = output.slice(start, end);
     if (
-      !segment.includes('"X-Claude-Code-Session-Id"') ||
+      !SESSION_ID_HEADER_ENTRY.test(segment) ||
       !segment.includes('"x-claude-code-agent-id"') ||
       segment.includes('"x-calico-active-turn-version"')
     ) {
@@ -3435,7 +3454,7 @@ function patchActiveTurnPromptIdentity(content) {
     );
     nextSegment = nextSegment.replace(
       new RegExp(
-        `("X-Claude-Code-Session-Id":[A-Za-z_$][\\w$]*\\(\\),)(\\.\\.\\.${escapeRegExp(extraHeadersLocal)},)`
+        `(${SESSION_ID_HEADER_KEY}:[A-Za-z_$][\\w$]*\\(\\),)(\\.\\.\\.${escapeRegExp(extraHeadersLocal)},)`
       ),
       '$1$2...__calicoPromptId&&{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"},'
     );
@@ -3494,7 +3513,7 @@ function patchCompactRequestSource(content) {
     const end = nextAsyncFunction === -1 ? output.length : nextAsyncFunction;
     const segment = output.slice(start, end);
     if (
-      !segment.includes('"X-Claude-Code-Session-Id"') ||
+      !SESSION_ID_HEADER_ENTRY.test(segment) ||
       segment.includes('"x-calico-request-source"')
     ) {
       continue;
@@ -3524,7 +3543,7 @@ function patchCompactRequestSource(content) {
     // the source param — go through a callback so the capture is threaded
     // explicitly and sourceParam is emitted verbatim.
     nextSegment = nextSegment.replace(
-      /("X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,)/,
+      new RegExp(`(${SESSION_ID_HEADER_ENTRY.source})`),
       (_full, headerPrefix) =>
         `${headerPrefix}...process.env.REMORA_ACTIVE==="1"&&${sourceParam}==="compact"&&{"x-calico-request-source":"compact"},`
     );
@@ -3599,7 +3618,7 @@ function __calicoCompactStripContentLength(e){if(e==null)return e;if(typeof Head
     const end = nextAsyncFunction === -1 ? output.length : nextAsyncFunction;
     const segment = output.slice(start, end);
     if (
-      !segment.includes('"X-Claude-Code-Session-Id"') ||
+      !SESSION_ID_HEADER_ENTRY.test(segment) ||
       segment.includes("__calicoCompactWrapFetch(")
     ) {
       continue;

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -54,6 +54,16 @@ function inSameModule(content: string, first: number, second: number): boolean {
   return !content.slice(low, high).includes(BUN_MODULE_BOUNDARY);
 }
 
+// The session-id entry in the Anthropic client's header object is the anchor
+// the active-turn and compact-request-source injections sit behind. 2.1.248
+// hoisted the header's name into a module-level constant, turning the literal
+// key `"X-Claude-Code-Session-Id":` into a computed `[DDe]:`; that constant is
+// a per-chunk minified name that means something else in other chunks, so match
+// the key's shape, not its name. Kept in lockstep with SESSION_ID_HEADER_KEY in
+// patch-claude-display.ts.
+const SESSION_ID_HEADER_KEY =
+  '(?:"X-Claude-Code-Session-Id"|\\[[A-Za-z_$][\\w$]*\\])';
+
 // Cross-chunk references through globalThis are only safe when the chunk doing
 // the reading statically imports (transitively) the chunk doing the writing:
 // only then is the publisher guaranteed to have been evaluated first. Of 1,384
@@ -573,8 +583,9 @@ const CHECKS: Check[] = [
       }
       // Compact request-source may inject between custom headers and active-turn
       // Calico-owned headers when both modules apply (default module order).
-      const protectedHeaderOrder =
-        /"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,(?:\.\.\.process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*==="compact"&&\{"x-calico-request-source":"compact"\},)?\.\.\.__calicoPromptId&&\{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"\}/;
+      const protectedHeaderOrder = new RegExp(
+        `${SESSION_ID_HEADER_KEY}:[A-Za-z_$][\\w$]*\\(\\),\\.\\.\\.[A-Za-z_$][\\w$]*,(?:\\.\\.\\.process\\.env\\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\\w$]*==="compact"&&\\{"x-calico-request-source":"compact"\\},)?\\.\\.\\.__calicoPromptId&&\\{"x-calico-prompt-id":__calicoPromptId,"x-calico-active-turn-version":"1"\\}`
+      );
       return protectedHeaderOrder.test(content)
         ? null
         : "Calico-owned headers are missing or can be overridden by custom headers";
@@ -616,8 +627,9 @@ const CHECKS: Check[] = [
       // shifts the extra-header local and header-object local by one letter
       // (`u=…(),p={` → `d=…(),f={`); the signature tail and both locals are
       // matched generically. The IIFE parameter stays the literal `u`.
-      const ownedFactory =
-        /async function [A-Za-z_$][\w$]*\(\{apiKey:[A-Za-z_$][\w$]*,maxRetries:[A-Za-z_$][\w$]*,model:[A-Za-z_$][\w$]*,fetchOverride:([A-Za-z_$][\w$]*),source:([A-Za-z_$][\w$]*),agentContext:[A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*)*\}\)\{(?:if\(process\.env\.REMORA_ACTIVE==="1"&&\2==="compact"\)\{\1=__calicoCompactWrapFetch\(\1\)\})?let [\s\S]*?[A-Za-z_$][\w$]*=\(\(u\)=>process\.env\.REMORA_ACTIVE==="1"\?__calicoOmitHeader\(u,"x-calico-request-source"\):u\)\([A-Za-z_$][\w$]*\(\)\),[A-Za-z_$][\w$]*=\{[\s\S]*?"X-Claude-Code-Session-Id":[A-Za-z_$][\w$]*\(\),\.\.\.[A-Za-z_$][\w$]*,\.\.\.process\.env\.REMORA_ACTIVE==="1"&&\2==="compact"&&\{"x-calico-request-source":"compact"\}/;
+      const ownedFactory = new RegExp(
+        `async function [A-Za-z_$][\\w$]*\\(\\{apiKey:[A-Za-z_$][\\w$]*,maxRetries:[A-Za-z_$][\\w$]*,model:[A-Za-z_$][\\w$]*,fetchOverride:([A-Za-z_$][\\w$]*),source:([A-Za-z_$][\\w$]*),agentContext:[A-Za-z_$][\\w$]*(?:,[A-Za-z_$][\\w$]*:[A-Za-z_$][\\w$]*)*\\}\\)\\{(?:if\\(process\\.env\\.REMORA_ACTIVE==="1"&&\\2==="compact"\\)\\{\\1=__calicoCompactWrapFetch\\(\\1\\)\\})?let [\\s\\S]*?[A-Za-z_$][\\w$]*=\\(\\(u\\)=>process\\.env\\.REMORA_ACTIVE==="1"\\?__calicoOmitHeader\\(u,"x-calico-request-source"\\):u\\)\\([A-Za-z_$][\\w$]*\\(\\)\\),[A-Za-z_$][\\w$]*=\\{[\\s\\S]*?${SESSION_ID_HEADER_KEY}:[A-Za-z_$][\\w$]*\\(\\),\\.\\.\\.[A-Za-z_$][\\w$]*,\\.\\.\\.process\\.env\\.REMORA_ACTIVE==="1"&&\\2==="compact"&&\\{"x-calico-request-source":"compact"\\}`
+      );
       if (!ownedFactory.test(content)) {
         return "compact request-source sanitize/header inject is not owned by Zie factory";
       }

--- a/tests/session-id-header-constant.test.js
+++ b/tests/session-id-header-constant.test.js
@@ -1,0 +1,121 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  patchActiveTurnPromptIdentity,
+  patchCompactRequestSource,
+  patchCompactBodyPolicy,
+} = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
+
+// active-turn-prompt-id, compact-request-source and compact-body-policy all
+// recognise the Anthropic client factory by the session-id entry in the header
+// object it builds, and the first two inject immediately after it.
+//
+// 2.1.248 hoisted that header's name into a module-level constant, so the key
+// went from the literal `"X-Claude-Code-Session-Id":` to a computed `[DDe]:`,
+// and all three modules dropped to zero candidates at once. The constant's name
+// is per-chunk minified and not unique across chunks, so the patcher matches the
+// key's shape rather than the name; these fixtures pin both forms.
+const literalFixture = `
+var Pt={promptId:"turn-a"};
+var currentContext;
+var Pkr={getStore:()=>currentContext,run:(context,callback)=>{let previous=currentContext;currentContext=context;try{return callback()}finally{currentContext=previous}}};
+function xht(){return Pt.promptId}function $$t(e){Pt.promptId=e}
+function TN(e){if(e===void 0)return;if(e.startsWith("repl_main_thread")||e==="sdk")return"main";if(e.startsWith("agent:")||e==="hook_agent")return"subagent";return"auxiliary"}
+function iK(e,t){return Pkr.run(e,t)}function c_(){return{agentType:"main",agentId:xt()}}
+function $pe(e){return e.agentType==="main"}
+function kAi(){return customHeaders}
+var customHeaders={};
+function bs(){return false}
+function dfe(){return"fixture"}
+function xt(){return"session-a"}
+function bhi(e){return e}
+async function Zie({apiKey:e,maxRetries:t,model:r,fetchOverride:n,source:o,agentContext:i}){let s=process.env.CLAUDE_CODE_CONTAINER_ID,a=process.env.CLAUDE_CODE_REMOTE_SESSION_ID,l=process.env.CLAUDE_AGENT_SDK_CLIENT_APP,c=$pe(i)?void 0:i,u=kAi(),p={"x-app":bs()?"cli-bg":"cli","User-Agent":dfe(),"X-Claude-Code-Session-Id":xt(),...u,...s&&{"x-claude-remote-container-id":s},...a&&{"x-claude-remote-session-id":a},...l&&{"x-client-app":l},...c?.agentId&&{"x-claude-code-agent-id":bhi(c.agentId)},...c?.parentAgentId&&{"x-claude-code-parent-agent-id":bhi(c.parentAgentId)}};return p}
+async function Next(){}
+`;
+
+// The 2.1.248 shape. `DDe` deliberately reuses a name that means something else
+// elsewhere in the bundle, matching upstream, where the same minified name binds
+// `4*ODe` and `$d[9]` in other chunks.
+const constantFixture = literalFixture
+  .replace(
+    'function bhi(e){return e}',
+    'function bhi(e){return e}\nvar DDe="X-Claude-Code-Session-Id";\nvar unrelated={DDe:4};'
+  )
+  .replace('"X-Claude-Code-Session-Id":xt(),', "[DDe]:xt(),");
+
+function runPatched(content, env = { REMORA_ACTIVE: "1" }) {
+  const context = { process: { env: { ...env } } };
+  vm.createContext(context);
+  vm.runInContext(content, context);
+  return context;
+}
+
+for (const [shape, fixture] of [
+  ["literal key", literalFixture],
+  ["hoisted constant key", constantFixture],
+]) {
+  test(`active-turn-prompt-id patches a header object with a ${shape}`, async () => {
+    const result = patchActiveTurnPromptIdentity(fixture);
+    assert.equal(result.candidates, 2);
+    assert.equal(result.patched, 2);
+    assert.equal(evaluatePatchModule("active-turn-prompt-id", result.content), null);
+
+    const context = runPatched(result.content);
+    const headers = await context.Zie({
+      source: "repl_main_thread",
+      agentContext: { agentType: "main" },
+    });
+    // The session id still reaches the wire under its real name, and the Calico
+    // headers sit after the custom-header spread so they cannot be overridden.
+    assert.equal(headers["X-Claude-Code-Session-Id"], "session-a");
+    assert.equal(headers["x-calico-prompt-id"], "turn-a");
+    assert.equal(headers["x-calico-active-turn-version"], "1");
+  });
+
+  test(`compact-request-source patches a header object with a ${shape}`, async () => {
+    const result = patchCompactRequestSource(fixture);
+    assert.equal(result.candidates, 1);
+    assert.equal(result.patched, 1);
+    assert.equal(evaluatePatchModule("compact-request-source", result.content), null);
+
+    const context = runPatched(result.content);
+    const compact = await context.Zie({
+      source: "compact",
+      agentContext: { agentType: "main" },
+    });
+    assert.equal(compact["X-Claude-Code-Session-Id"], "session-a");
+    assert.equal(compact["x-calico-request-source"], "compact");
+
+    const other = await context.Zie({
+      source: "repl_main_thread",
+      agentContext: { agentType: "main" },
+    });
+    assert.equal(other["x-calico-request-source"], undefined);
+  });
+
+  test(`compact-body-policy patches a client factory with a ${shape}`, () => {
+    const result = patchCompactBodyPolicy(fixture);
+    assert.equal(result.candidates, 1);
+    assert.equal(result.patched, 1);
+    assert.equal(evaluatePatchModule("compact-body-policy", result.content), null);
+  });
+}
+
+test("a header object with no session-id entry is not treated as the client factory", () => {
+  // Guarding on the key's shape alone would accept any computed key; the entry
+  // has to keep its `<key>:<fn>(),...<custom headers>,` position in the object.
+  const withoutSessionId = literalFixture.replace('"X-Claude-Code-Session-Id":xt(),', "");
+  for (const patch of [
+    patchActiveTurnPromptIdentity,
+    patchCompactRequestSource,
+    patchCompactBodyPolicy,
+  ]) {
+    const result = patch(withoutSessionId);
+    assert.equal(result.candidates, patch === patchActiveTurnPromptIdentity ? 1 : 0);
+    assert.equal(result.patched, 0);
+    assert.equal(result.content, withoutSessionId);
+  }
+});


### PR DESCRIPTION
Upstream 2.1.248 moved the session-id request header's name out of the Anthropic
client factory into a module-level constant, turning the header object key from a
string literal into a computed member:

```
2.1.247   p={"x-app":…,"User-Agent":dfe(),"X-Claude-Code-Session-Id":qe(),...u,…}
2.1.248   k={"x-app":…,"User-Agent":O1(),[DDe]:q(),...P,…}
          var DDe="X-Claude-Code-Session-Id"
```

That entry is the shared anchor for three patch modules. Each of them walks every
`async function …({apiKey,maxRetries,model,fetchOverride,source,agentContext,…})`,
slices to the next `async function `, and confirms the segment is the real client
factory by finding the session-id header in it; two of them also splice their own
headers in immediately after it. With the literal gone the confirmation failed,
every candidate segment was skipped, and all three dropped in the same build:

| module | 2.1.247 | 2.1.248 |
| --- | --- | --- |
| `active-turn-prompt-id` | 2 / 2 | 1 / **0** |
| `compact-request-source` | 1 / 1 | **0** / 0 |
| `compact-body-policy` | 1 / 1 | **0** / 0 |

The other sixteen modules matched 2.1.248 at exactly their 2.1.247 counts, so this
is one upstream change rather than broad drift.

## Fix

Match the key's shape instead of its text. `SESSION_ID_HEADER_KEY` accepts either
form — `(?:"X-Claude-Code-Session-Id"|\[<minified id>\])` — and
`SESSION_ID_HEADER_ENTRY` pins the entry's position in the header object as
`<key>:<fn>(),...<custom headers>,`. The three `segment.includes(…)` guards become
tests of that entry and both injection anchors are rebuilt from the same source,
so the headers keep landing after the custom-header spread, which is what stops
`ANTHROPIC_CUSTOM_HEADERS` from overriding the Calico-owned ones.

`scripts/verify-patched-binary.ts` pinned the same literal in its active-turn
header-order check and its compact-request-source owned-factory check, and would
otherwise have rejected a correctly patched 2.1.248 binary; both are updated in
lockstep.

The new constant's name is deliberately **not** pinned. `DDe` is a per-chunk
minified name — in the same bundle it also binds `4*ODe` and `$d[9]` in other
chunks — so keying on it would be keying on a collision.

## Verification

`tests/session-id-header-constant.test.js` runs all three modules over one fixture
in both key shapes, asserting candidate/patched counts, the verifier's verdict via
`evaluatePatchModule`, and — by evaluating the patched factory in a `vm` — that the
session id still ships under its real name while the Calico headers appear only
under `REMORA_ACTIVE=1` and the right source. The constant-key fixture reproduces
upstream's name collision. A negative case strips the session-id entry entirely and
asserts all three modules decline the segment, so the widened key cannot match an
arbitrary computed key in some unrelated object. Suite: 144 → **151** passing.

Three-version regression over 2.1.246 / 2.1.247 / 2.1.248:

```
PASS patch/verify   2.1.246  linux-x64 + macos-arm64
PASS version+harness 2.1.246 macos-arm64   request SENT (2), assistant text RENDERED
PASS patch/verify   2.1.247  linux-x64 + macos-arm64
PASS version+harness 2.1.247 macos-arm64   request SENT (2), assistant text RENDERED
PASS patch/verify   2.1.248  linux-x64 + macos-arm64
PASS version+harness 2.1.248 macos-arm64   request SENT (2), assistant text RENDERED
```

Each harness run is `tools/local-verify/run.sh` driving the real patched
macos-arm64 binary through a PTY against the mock streaming endpoint, so the
turn is observed rendering rather than inferred from the bundle text.

`PATCHING_PLAYBOOK.md` records the rule: an object key can stop being a literal,
and the constant that replaces it is not a safe anchor either.

## Known gap, unchanged by this PR

`--assert-all` still only fails a module at `patched == 0`, so a falling but
non-zero candidate count ships silently. It did not bite here — the counts fell to
zero and to a value the module's own `!== 1` check rejected — but the class of
failure remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e
