### PR TITLE
ci(watch): trigger releases on merge, and stop trusting the hourly cron

### DIFF
--- a/.github/workflows/watch-claude-release.yml
+++ b/.github/workflows/watch-claude-release.yml
@@ -1,8 +1,23 @@
 name: Watch Claude Code Releases
 
 on:
+  # GitHub does not honour this cadence; it is an upper bound on how often the
+  # schedule is *considered*. Observed firing on this repo: roughly hourly but
+  # always 30-50 minutes late, then degrading to 2.3h, 4.3h, 10.3h and 10.7h
+  # gaps over 2026-08-26/27, which left a merged 2.1.247 compat fix unreleased
+  # for hours. Asking every 15 minutes does not make GitHub punctual, it just
+  # gives four chances per hour instead of one. Every run past the first is a
+  # ~15s no-op: the release-existence check short-circuits before checkout.
   schedule:
-    - cron: "17 * * * *"
+    - cron: "*/15 * * * *"
+  # The schedule is a backstop, not the primary trigger. A compat fix landing on
+  # main is the event that should release, and it is observable immediately, so
+  # do not wait for a cron that may skip ten hours. Safe to fire on every push:
+  # the job no-ops when the releases already exist, when a patch run is already
+  # active, and never dispatches unless the preflight patch+verify passes.
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The release pipeline stalled twice in two days with a verified compat fix already
sitting on main. Both times the patcher was correct and the only missing step was
a run of `watch-claude-release.yml`.

## The cron is not misconfigured

GitHub is progressively deprioritising this repo's schedule. Firing history for
`cron: "17 * * * *"`:

| window | behaviour |
| --- | --- |
| 2026-08-25 | fires roughly hourly, but **never at :17** — consistently 30–50 min late |
| 2026-08-26 16:59 → 19:18 | 2.3h gap |
| 2026-08-26 19:18 → 23:33 | 4.3h gap |
| 2026-08-26 23:33 → 08-27 09:49 | **10.3h gap** |
| 2026-08-27 09:49 → 20:30 | **10.7h gap** |

The schedule was never punctual and degraded into ten-hour skips. 2.1.247's fix
merged at 13:17Z and was still unreleased at 20:30Z, when the workflow was
dispatched by hand. 2.1.248's fix has been merged and unreleased since.

Downstream this matters more than it looks: `calico-claude` self-updates from
these releases, so a stalled release pipeline is what a user experiences as
"it never updated".

## Changes

**`push` on `main` becomes the primary trigger.** A compat fix landing on main is
the event that should produce a release, and unlike a cron slot it is observable
the moment it happens. The job was already written to be safe under repeated
firing — it no-ops when every platform release for the latest version exists,
no-ops while a patch run is active, and dispatches only when the preflight
patch + verify + run of linux-x64 passes — so a push with nothing releasable costs
one short run. `patch-claude.yml` only creates releases and never pushes to main,
so this cannot re-trigger itself.

**The schedule tightens to `*/15` as a backstop.** This does not make GitHub
punctual; it gives four chances an hour instead of one, so a deprioritisation
window has to be four times longer before it hides a new upstream version. Runs
past the first are ~15s no-ops — the release-existence check short-circuits ahead
of `checkout` and `npm ci`.

Both cadence decisions are recorded as comments at the trigger, with the observed
gaps, so the next person does not re-derive them from run history.

## What merging this does

Merging is a push to `main`, so it fires the new trigger immediately: preflight
against the current upstream release (**2.1.250**), then a five-platform release
if preflight passes. Locally, 2.1.250 patches 19/19 with counts identical to
2.1.246/247/248 and verifies clean on both linux-x64 and macos-arm64, so preflight
is expected to pass and 2.1.250 to ship.

Note that this releases 2.1.250 with the inline-thinking rendering defect that is
still open — thinking collapses to `Thought for 1s` instead of rendering inline.
That defect is present in 2.1.246, 2.1.247 and 2.1.250 alike, and in unpatched
upstream builds under the same harness, so shipping 2.1.250 does not make it
worse; it is tracked separately and is not what this PR addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e
