### PR TITLE
fix(ci): pin a bun version that exists, and poke the watcher from launchd

### DIFF
--- a/.github/workflows/patch-claude.yml
+++ b/.github/workflows/patch-claude.yml
@@ -87,7 +87,14 @@ jobs:
         if: matrix.platform_label == 'macos-arm64'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.1"
+          # 1.4.1 does not exist. setup-bun builds the asset URL from the pin
+          # without checking the tag, so it 404s on the download and fails the
+          # whole macos-arm64 job at step 4 — before any patching runs, which
+          # makes it read like a patcher failure rather than a bad pin. 1.4.0 is
+          # the newest published release. The live-thinking test uses only
+          # Bun.serve, Bun.spawn and Bun.sleep, all long stable; it was
+          # developed and calibrated against 1.3.13 locally.
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         id: dependencies

--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -43,10 +43,19 @@ log() {
   printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_FILE"
 }
 
+# `&`, `<` and `>` are all legal in a macOS path and all special in XML, so a
+# checkout under e.g. ~/src/claude&co would emit a malformed plist. launchctl
+# then refuses to bootstrap it and the watcher is silently never installed.
+xml_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
 install_agent() {
-  local script_path plist_path
+  local script_path plist_path script_xml log_xml
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   plist_path="$HOME/Library/LaunchAgents/$LABEL.plist"
+  script_xml="$(xml_escape "$script_path")"
+  log_xml="$(xml_escape "$LOG_FILE")"
   mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
 
   cat > "$plist_path" <<PLIST
@@ -58,12 +67,12 @@ install_agent() {
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>$script_path</string>
+    <string>$script_xml</string>
   </array>
   <key>StartInterval</key><integer>3600</integer>
   <key>RunAtLoad</key><true/>
-  <key>StandardOutPath</key><string>$LOG_FILE</string>
-  <key>StandardErrorPath</key><string>$LOG_FILE</string>
+  <key>StandardOutPath</key><string>$log_xml</string>
+  <key>StandardErrorPath</key><string>$log_xml</string>
 </dict>
 </plist>
 PLIST

--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Dispatch watch-claude-release.yml when upstream has a version we have not
+# released yet.
+#
+# Why this exists: GitHub's scheduler is the only in-GitHub trigger for "upstream
+# published a new version and nothing happened in this repo", and it does not
+# honour the cron on this repository. Measured over 2026-08-26/27 the hourly
+# schedule drifted 30-50 minutes late, then skipped 2.3h, 4.3h, 10.3h and 10.7h;
+# tightening it to */15 produced zero scheduled runs in the 80 minutes after it
+# went live. Merges to main are covered by the workflow's `push` trigger, and
+# `liskin/gh-workflow-keepalive` covers schedules GitHub disables for
+# inactivity, but neither covers upstream drift. This does.
+#
+# It is deliberately not an unconditional poke: it resolves the current upstream
+# version and dispatches only when a platform release for it is missing, so a
+# machine that is awake all day produces no runs until there is actual work.
+#
+# Install as a LaunchAgent (hourly, plus once at load):
+#
+#   bash tools/watch-poke.sh --install
+#   launchctl list | grep calico-watch-poke
+#
+# Remove:
+#
+#   launchctl bootout gui/$(id -u)/com.calico.watch-poke
+#   rm ~/Library/LaunchAgents/com.calico.watch-poke.plist
+#
+# Logs to ~/Library/Logs/calico-watch-poke.log.
+
+set -uo pipefail
+
+REPO="${CALICO_WATCH_REPO:-Nanako0129/calico-claude}"
+WORKFLOW="watch-claude-release.yml"
+LABEL="com.calico.watch-poke"
+PLATFORMS=(linux-x64 linux-arm64 macos-arm64 win32-x64 win32-arm64)
+LOG_FILE="$HOME/Library/Logs/calico-watch-poke.log"
+
+# launchd hands a process a near-empty PATH, so Homebrew's gh and node are not
+# on it. Everything below runs through this PATH explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+log() {
+  printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_FILE"
+}
+
+install_agent() {
+  local script_path plist_path
+  script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  plist_path="$HOME/Library/LaunchAgents/$LABEL.plist"
+  mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
+
+  cat > "$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$script_path</string>
+  </array>
+  <key>StartInterval</key><integer>3600</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>$LOG_FILE</string>
+  <key>StandardErrorPath</key><string>$LOG_FILE</string>
+</dict>
+</plist>
+PLIST
+
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null
+  launchctl bootstrap "gui/$(id -u)" "$plist_path" || {
+    echo "failed to bootstrap $LABEL" >&2
+    return 1
+  }
+  echo "installed $plist_path (hourly, runs once now)"
+  echo "log: $LOG_FILE"
+}
+
+if [ "${1:-}" = "--install" ]; then
+  install_agent
+  exit $?
+fi
+
+for tool in gh npm; do
+  command -v "$tool" >/dev/null 2>&1 || { log "missing $tool on PATH"; exit 1; }
+done
+
+VERSION="$(npm view @anthropic-ai/claude-code version 2>/dev/null)"
+if [ -z "$VERSION" ]; then
+  log "npm did not return an upstream version; skipping"
+  exit 0
+fi
+
+MISSING=0
+for suffix in "${PLATFORMS[@]}"; do
+  if ! gh release view "v${VERSION}-${suffix}" --repo "$REPO" >/dev/null 2>&1; then
+    MISSING=1
+    break
+  fi
+done
+
+if [ "$MISSING" -eq 0 ]; then
+  log "upstream $VERSION already released on all platforms; no dispatch"
+  exit 0
+fi
+
+# Do not pile dispatches on top of a run that is already working. The workflow
+# guards this too, but a queued no-op still costs a run and clutters the list.
+ACTIVE="$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 10 \
+  --json status --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null)"
+if [ -n "$ACTIVE" ] && [ "$ACTIVE" -gt 0 ]; then
+  log "upstream $VERSION missing releases, but $WORKFLOW already has $ACTIVE active run(s); skipping"
+  exit 0
+fi
+
+if gh workflow run "$WORKFLOW" --repo "$REPO" >/dev/null 2>&1; then
+  log "dispatched $WORKFLOW for upstream $VERSION"
+else
+  log "failed to dispatch $WORKFLOW for upstream $VERSION"
+  exit 1
+fi

--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -51,11 +51,17 @@ xml_escape() {
 }
 
 install_agent() {
-  local script_path plist_path script_xml log_xml
+  local script_path plist_path script_xml log_xml repo_xml
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   plist_path="$HOME/Library/LaunchAgents/$LABEL.plist"
   script_xml="$(xml_escape "$script_path")"
   log_xml="$(xml_escape "$LOG_FILE")"
+  # CALICO_WATCH_REPO is read at run time, and launchd starts the agent with a
+  # clean environment, so a fork owner installing with
+  # `CALICO_WATCH_REPO=owner/fork ... --install` would get an agent that quietly
+  # checks and dispatches against the default repo instead. Bake the resolved
+  # value into the plist so the installed agent targets what was configured.
+  repo_xml="$(xml_escape "$REPO")"
   mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
 
   cat > "$plist_path" <<PLIST
@@ -69,6 +75,10 @@ install_agent() {
     <string>/bin/bash</string>
     <string>$script_xml</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CALICO_WATCH_REPO</key><string>$repo_xml</string>
+  </dict>
   <key>StartInterval</key><integer>3600</integer>
   <key>RunAtLoad</key><true/>
   <key>StandardOutPath</key><string>$log_xml</string>


### PR DESCRIPTION
Two independent fixes to the release path, both surfaced by watching a real release fail.

## CI: `bun-version: "1.4.1"` does not exist

The live-thinking test step arrived from upstream pinned to a version oven-sh/bun never published. `setup-bun` builds the asset URL straight from the pin without checking the tag:

```
Downloading a new version of Bun: .../bun-v1.4.1/bun-darwin-aarch64.zip
##[error]Error: Unexpected HTTP response: 404
```

It fails at **step 4** of the macos-arm64 job — before dependencies install, before any patching — so every later step is skipped and the job reads as a patcher failure rather than a bad pin.

It took down the macOS half of the 2.1.250 re-release carrying the live-thinking fix:

| platform | tag |
| --- | --- |
| linux-x64 / linux-arm64 / win32-x64 / win32-arm64 | `v2.1.250-*-2` ✅ |
| macos-arm64 | `v2.1.250-macos-arm64` (stale, pre-fix) ❌ |

Pinned to **1.4.0**, the newest published tag. The test uses only `Bun.serve`, `Bun.spawn` and `Bun.sleep`; it was calibrated locally against 1.3.13, so the minor is not load-bearing.

## `tools/watch-poke.sh`: dispatch the watcher from launchd

GitHub's scheduler is the only in-GitHub trigger for *upstream published a version and nothing happened in this repo*, and it does not honour this repo's cron:

| window | behaviour |
| --- | --- |
| 2026-08-25 | fires roughly hourly, always 30–50 min late |
| 08-26 → 08-27 | skips of 2.3h, 4.3h, **10.3h**, **10.7h** |
| after `*/15` went live | **zero** scheduled runs in 80 minutes |

So GitHub is *dropping* the schedule, not sampling it — raising the frequency cannot help. The other triggers cover different cases: `push` on main releases a fix the moment it merges (verified, 42s), and `gh-workflow-keepalive` re-enables schedules disabled for repo inactivity, which was never the failure. Upstream drift had no reliable trigger; that is what stranded 2.1.248 and 2.1.250.

The script runs as a user LaunchAgent, hourly plus once at load. Not an unconditional poke: it resolves the upstream version from npm and dispatches **only when a platform release is missing**, and skips while a run is already active, so an all-day machine produces no runs until there is real work. Explicit `PATH` because launchd hands a near-empty one; every decision is logged so a silent no-op is distinguishable from a silent failure.

### Known limitation, stated because it just bit

The missing-release check asks whether a *version* was released, not which *commit* it was released from. A release built before a fix landed still counts as present — which is exactly why merging the live-thinking fix produced `No action needed` and needed a `force=true` dispatch. That case belongs to the `push` trigger or a forced dispatch, whose `-2` suffix tag `install-patched-claude.sh` already prefers over the base tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e