### PR TITLE
fix(patch,verify): support Claude 2.1.251's statusline and fast-mode reshuffle

### DIFF
--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -585,6 +585,15 @@ function closingParenIndex(text, openIndex) {
   return -1;
 }
 
+// Truncate a segment at the first Bun module boundary it contains. Segments cut
+// with `indexOf("function ")` routinely run past the end of their chunk, so
+// evidence gathered from them can come from a module the matched code cannot
+// even see.
+function boundedToModule(segment) {
+  const boundary = segment.indexOf(BUN_MODULE_BOUNDARY);
+  return boundary === -1 ? segment : segment.slice(0, boundary);
+}
+
 // Index of the `}` that closes the `{` at openIndex, or -1.
 function closingBraceIndex(text, openIndex) {
   let depth = 0;
@@ -2663,8 +2672,13 @@ function patchStatuslineCommittedUsage(content) {
   // 2.1.246 appends `,...{}` after the effort spread. Match any trailing spread
   // entries so the wrapper still matches; the replacement is derived from the
   // matched text, so whatever upstream appended is carried across unchanged.
+  // 2.1.251 appends a third argument to the batch content builder itself — a
+  // callback, `j2t(Uq([…],o,d.agentId,{…},d.storageV5),o,(a,b)=>p0(a,b,…))` —
+  // so the call no longer closes right after the second argument. Accept a
+  // trailing argument list, one level of call nesting deep so the callback body
+  // does not terminate it early.
   const batchWrapperPattern = new RegExp(
-    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
+    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
     "g"
   );
   const terminalPattern = new RegExp(
@@ -2992,16 +3006,45 @@ function patchStatuslineRateLimitWindows(content) {
   const window = (local, key) =>
     `...${local}.${key}&&{${key}:{used_percentage:${local}.${key}.utilization*100,resets_at:${local}.${key}.resets_at}}`;
 
-  const projectionPattern = new RegExp(
-    `\\{\\.\\.\\.(${identifier})\\.five_hour&&\\{five_hour:\\{used_percentage:\\1\\.five_hour\\.utilization\\*100,resets_at:\\1\\.five_hour\\.resets_at\\}\\},\\.\\.\\.\\1\\.seven_day&&\\{seven_day:\\{used_percentage:\\1\\.seven_day\\.utilization\\*100,resets_at:\\1\\.seven_day\\.resets_at\\}\\}\\}`,
+  // Match the projection object by its opening entries only, and find its end
+  // by brace matching. 2.1.251 appended a third entry —
+  // `...X()==="gateway"&&L.overage&&{spend_limit:{…}}` — so a pattern that
+  // required `}` right after seven_day stopped matching and the module went to
+  // zero candidates. Enumerating the new entry would only invite the next one,
+  // and rewriting the object without it would silently drop an upstream field:
+  // capture whatever follows seven_day and re-emit it verbatim.
+  const projectionPrefixPattern = new RegExp(
+    `\\{\\.\\.\\.(${identifier})\\.five_hour&&\\{five_hour:\\{used_percentage:\\1\\.five_hour\\.utilization\\*100,resets_at:\\1\\.five_hour\\.resets_at\\}\\},\\.\\.\\.\\1\\.seven_day&&\\{seven_day:\\{used_percentage:\\1\\.seven_day\\.utilization\\*100,resets_at:\\1\\.seven_day\\.resets_at\\}\\}`,
     "g"
   );
+  // The guard was `(L.five_hour||L.seven_day)` and is `(L.five_hour||
+  // L.seven_day||L.spend_limit)` on 2.1.251. The replacement below tests
+  // `Object.keys(L).length>0`, which subsumes any number of alternatives, so
+  // accept an open-ended chain rather than the exact pair.
   const guardPattern = new RegExp(
-    `\\.\\.\\.\\((${identifier})\\.five_hour\\|\\|\\1\\.seven_day\\)&&\\{rate_limits:\\1\\}`,
+    `\\.\\.\\.\\((${identifier})\\.five_hour(?:\\|\\|\\1\\.[\\w$]+)+\\)&&\\{rate_limits:\\1\\}`,
     "g"
   );
 
-  const projectionMatches = [...content.matchAll(projectionPattern)];
+  // Expand each prefix match to the full object literal it opens, so the rest
+  // of this function can go on treating a projection match as {text, index,
+  // local} and additionally knows what trailing entries to carry across.
+  const projectionMatches = [...content.matchAll(projectionPrefixPattern)].flatMap((match) => {
+    const start = match.index ?? -1;
+    const end = start === -1 ? -1 : closingBraceIndex(content, start);
+    if (start === -1 || end === -1) {
+      return [];
+    }
+    return [
+      {
+        text: content.slice(start, end + 1),
+        index: start,
+        local: match[1],
+        // Everything upstream appended after seven_day, closing `}` excluded.
+        tail: content.slice(start + match[0].length, end),
+      },
+    ];
+  });
   const guardMatches = [...content.matchAll(guardPattern)];
   const candidates = projectionMatches.length + guardMatches.length;
 
@@ -3009,7 +3052,7 @@ function patchStatuslineRateLimitWindows(content) {
     return { content: original, candidates, patched: 0 };
   }
 
-  const projectionLocal = projectionMatches[0][1];
+  const projectionLocal = projectionMatches[0].local;
   const guardLocal = guardMatches[0][1];
 
   // Global counts alone do not prove the two anchors belong to each other: an
@@ -3019,7 +3062,7 @@ function patchStatuslineRateLimitWindows(content) {
   // recurs across functions:
   //   1. both anchors sit inside the same function
   //   2. the projection literal is the initializer of the very local the guard reads
-  const projectionIndex = projectionMatches[0].index ?? -1;
+  const projectionIndex = projectionMatches[0].index;
   const guardIndex = guardMatches[0].index ?? -1;
   const projectionFunctionStart =
     projectionIndex === -1 ? -1 : content.lastIndexOf("function ", projectionIndex);
@@ -3047,7 +3090,7 @@ function patchStatuslineRateLimitWindows(content) {
   // closes a bracket it did not open — that is, the guard is reached without
   // leaving the block the projection lives in.
   const projectionEnd =
-    projectionIndex === -1 ? -1 : projectionIndex + projectionMatches[0][0].length;
+    projectionIndex === -1 ? -1 : projectionIndex + projectionMatches[0].text.length;
   let leftProjectionScope = projectionEnd === -1 || guardIndex < projectionEnd;
   if (!leftProjectionScope) {
     let depth = 0;
@@ -3088,6 +3131,10 @@ function patchStatuslineRateLimitWindows(content) {
   ) {
     return { content: original, candidates, patched: 0 };
   }
+  // Carry upstream's trailing entries across verbatim. Rewriting the object
+  // without them would silently drop a field the statusline payload is supposed
+  // to carry — 2.1.251's `spend_limit` being the first one.
+  const projectionTail = projectionMatches[0].tail;
   const projectionReplacement = `{${[
     "five_hour",
     "seven_day",
@@ -3095,13 +3142,20 @@ function patchStatuslineRateLimitWindows(content) {
     "overage",
   ]
     .map((key) => window(projectionLocal, key))
-    .join(",")}}`;
+    .join(",")}${projectionTail}}`;
   const guardReplacement = `...Object.keys(${guardLocal}).length>0&&{rate_limits:${guardLocal}}`;
 
   // projectionReplacement/guardReplacement interpolate the captured
   // projectionLocal/guardLocal names; use callbacks so a captured `$1`-style
   // name cannot be read back as a backreference against these regexes.
-  let output = original.replace(projectionPattern, () => projectionReplacement);
+  // Splice by offset rather than String.replace: the matched text is the whole
+  // object literal, located by brace matching, and re-searching for it would
+  // rewrite the first textual occurrence anywhere in the joined bundle.
+  const projectionText = projectionMatches[0].text;
+  let output =
+    original.slice(0, projectionIndex) +
+    projectionReplacement +
+    original.slice(projectionIndex + projectionText.length);
   output = output.replace(guardPattern, () => guardReplacement);
 
   if (
@@ -3222,16 +3276,26 @@ function patchGatewayFastMode(content) {
     interactiveStart + interactive[0].length
   );
   const interactiveEnd = interactiveEndCandidate === -1 ? content.length : interactiveEndCandidate;
-  const interactiveSegment = content.slice(interactiveStart, interactiveEnd);
-  const interactiveAction = interactiveSegment.match(
-    /await ([A-Za-z_$][\w$]*)\([^;]*?"shortcut"/
-  )?.[1];
+  // Stop at the chunk the handler lives in. `indexOf("async function ")` walks
+  // past the module boundary — on 2.1.250 this segment ran 49KB while the
+  // handler was 434 bytes — so every marker below could have been satisfied by
+  // an unrelated chunk. It happened to be honest there, which is precisely the
+  // kind of luck that stops holding without warning.
+  const interactiveSegment = boundedToModule(
+    content.slice(interactiveStart, interactiveEnd)
+  );
   if (
     interactiveStart === -1 ||
-    !interactiveAction ||
+    // What the injection needs is this handler, not the way it used to be
+    // recognised. 2.1.251 restructured the body: the `"shortcut"` apply call is
+    // gone, on/off now renders a component directly, and `.getAppState` /
+    // `.setAppState` moved out entirely — three markers vanished at once and
+    // the module went to 0 patched while still finding all 6 candidates. The
+    // signature already pins this function hard (three parameters, the
+    // availability guard, and the "Fast mode is not available" literal); the
+    // picker telemetry event and a component render are what remain
+    // characteristic of the interactive path.
     !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
-    !interactiveSegment.includes(".getAppState") ||
-    !interactiveSegment.includes(".setAppState") ||
     // Confirms the interactive handler renders a component. On 2.1.242+ the JSX
     // factory is a destructured local, so match the call-with-props shape
     // instead of a `.jsx(` literal.
@@ -3243,21 +3307,15 @@ function patchGatewayFastMode(content) {
   const thinStart = thin.index ?? -1;
   const thinEndCandidate = content.indexOf("async function ", thinStart + thin[0].length);
   const thinEnd = thinEndCandidate === -1 ? content.length : thinEndCandidate;
-  const thinSegment = content.slice(thinStart, thinEnd);
-  const thinAction = thinSegment.match(/await ([A-Za-z_$][\w$]*)\([^;]*?"bridge"/)?.[1];
+  const thinSegment = boundedToModule(content.slice(thinStart, thinEnd));
   if (
     thinStart === -1 ||
-    !thinAction ||
-    // Both handlers must reach the same apply-fast-mode action, but on 2.1.242+
-    // they are in different chunks and call it through different import
-    // aliases (2.1.245: `go` interactive, `i` thin), so the names cannot be
-    // compared. Each handler is still pinned by its own `"shortcut"` /
-    // `"bridge"` call shape plus the app-state and argument markers below, and
-    // neither capture is used outside the check itself.
+    // The thin handler kept its argument parsing across 2.1.251, so its own
+    // markers still hold. Both handlers reach the same apply-fast-mode action,
+    // but on 2.1.242+ they sit in different chunks and call it through
+    // different import aliases, so the names were never comparable anyway.
     !thinSegment.includes(".options.fastMode") ||
-    !thinSegment.includes("Unknown argument") ||
-    !thinSegment.includes(".getAppState") ||
-    !thinSegment.includes(".setAppState")
+    !thinSegment.includes("Unknown argument")
   ) {
     return { content: original, candidates, patched: 0 };
   }

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -46,6 +46,17 @@ type Check = {
 // module, so every equality below applies exactly as it did before.
 const { BUN_MODULE_BOUNDARY } = require("./native-bun.ts") as { BUN_MODULE_BOUNDARY: string };
 
+// Truncate a segment at the first Bun module boundary it contains. Segments cut
+// with `indexOf("async function ")` routinely run past the end of their chunk,
+// so a marker required of one handler can be satisfied by an entirely different
+// module. Mirrors boundedToModule in patch-claude-display.ts — the patcher
+// bounding its segments while the verifier did not is how a handler missing a
+// required invariant could still verify clean.
+function boundedToModule(segment: string): string {
+  const boundary = segment.indexOf(BUN_MODULE_BOUNDARY);
+  return boundary === -1 ? segment : segment.slice(0, boundary);
+}
+
 function inSameModule(content: string, first: number, second: number): boolean {
   if (first < 0 || second < 0) {
     return false;
@@ -387,9 +398,11 @@ const CHECKS: Check[] = [
         "async function ",
         (interactive.index ?? -1) + interactive[0].length
       );
-      const interactiveSegment = content.slice(
-        interactive.index ?? -1,
-        interactiveEnd === -1 ? content.length : interactiveEnd
+      const interactiveSegment = boundedToModule(
+        content.slice(
+          interactive.index ?? -1,
+          interactiveEnd === -1 ? content.length : interactiveEnd
+        )
       );
       // 2.1.251 restructured this handler: the `"shortcut"` apply call is gone,
       // on/off renders a component directly, and `.getAppState`/`.setAppState`
@@ -429,9 +442,8 @@ const CHECKS: Check[] = [
         "async function ",
         (thin.index ?? -1) + thin[0].length
       );
-      const thinSegment = content.slice(
-        thin.index ?? -1,
-        thinEnd === -1 ? content.length : thinEnd
+      const thinSegment = boundedToModule(
+        content.slice(thin.index ?? -1, thinEnd === -1 ? content.length : thinEnd)
       );
       const thinAction = thinSegment.match(
         /await ([A-Za-z_$][\w$]*)\([^;]*?"bridge"/
@@ -1902,7 +1914,7 @@ function evaluateDisabledPatchModule(id: string, content: string): string | null
     : null;
 }
 
-module.exports = { evaluateDisabledPatchModule, evaluatePatchModule };
+module.exports = { boundedToModule, evaluateDisabledPatchModule, evaluatePatchModule };
 
 if (require.main === module) {
   void main();

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -391,21 +391,29 @@ const CHECKS: Check[] = [
         interactive.index ?? -1,
         interactiveEnd === -1 ? content.length : interactiveEnd
       );
+      // 2.1.251 restructured this handler: the `"shortcut"` apply call is gone,
+      // on/off renders a component directly, and `.getAppState`/`.setAppState`
+      // moved out. Those were evidence that the segment is the fast-mode
+      // interactive handler, not properties of the injection — and the
+      // signature matched above already pins the function far harder. Kept in
+      // lockstep with the gate in patch-claude-display.ts.
+      //
+      // Still captured, because when both handlers live in one module and both
+      // still call an apply action, requiring them to call the SAME one is a
+      // real ownership proof. It is now conditional on both being present
+      // rather than required.
       const interactiveAction = interactiveSegment.match(
         /await ([A-Za-z_$][\w$]*)\([^;]*?"shortcut"/
       )?.[1];
       if (
-        !interactiveAction ||
         !interactiveSegment.includes("tengu_fast_mode_picker_shown") ||
-        !interactiveSegment.includes(".getAppState") ||
-        !interactiveSegment.includes(".setAppState") ||
         // 2.1.242+ destructures the JSX factory, so match a component call
         // shape rather than a `.jsx(` literal.
         !/[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\([A-Za-z_$][\w$]*,\{[^}]*\}\)/.test(
           interactiveSegment
         )
       ) {
-        return "interactive native Fast action, picker, or app-state fallback is missing";
+        return "interactive native Fast picker or component render is missing";
       }
 
       const thinPattern = new RegExp(
@@ -438,7 +446,7 @@ const CHECKS: Check[] = [
         (handlersShareModule &&
           (interactive[5] !== thin[4] ||
             interactive[6] !== thin[5] ||
-            thinAction !== interactiveAction)) ||
+            (interactiveAction !== undefined && thinAction !== interactiveAction))) ||
         !/\.options\.fastMode(?![A-Za-z0-9_$])/.test(thinSegment) ||
         !thinSegment.includes("Unknown argument") ||
         !thinSegment.includes(".getAppState") ||
@@ -1002,7 +1010,7 @@ const CHECKS: Check[] = [
       // (`…messageId:Gr.id},i.storageV5)`), matched optionally so the patched
       // 2.1.237 and 2.1.238 binaries both verify.
       const batchWrapperPattern = new RegExp(
-        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
+        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
         "g"
       );
       const wrapperMatches = [

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -605,3 +605,40 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     assert.notEqual(evaluatePatchModule("gateway-fast-mode", broken), null, name);
   }
 });
+
+// Segments cut with indexOf("async function ") run past the end of their Bun
+// chunk. Bounding them in the patcher while leaving the verifier unbounded is
+// how a handler that fails a required invariant can still verify clean: move
+// the picker event out of the handler and into the next module, and the
+// verifier finds it there.
+
+// Segments cut with indexOf("async function ") run past the end of their Bun
+// chunk, so a marker required of one handler can be satisfied by an entirely
+// different module. The patcher bounds its segments; the verifier did not,
+// which meant a handler failing a required invariant could still verify clean.
+//
+// This pins the truncation helper both verifier and patcher rely on. It does
+// not drive a whole bundle through evaluatePatchModule: every text insertion
+// that lands inside the unbounded slice also disturbs an invariant checked
+// earlier — helper-block adjacency, or the requirement that the helper copies
+// be byte-identical — so the verdict turns on that instead of on the boundary,
+// and the case proves nothing about bounding either way.
+test("module truncation stops at the first Bun module boundary", () => {
+  const { BUN_MODULE_BOUNDARY } = require("../scripts/native-bun.ts");
+  const { boundedToModule } = require("../scripts/verify-patched-binary.ts");
+
+  const handler = 'async function a(){return "tengu_fast_mode_picker_shown"}';
+  const neighbour = 'var b="tengu_fast_mode_picker_shown";';
+
+  assert.equal(boundedToModule(handler), handler, "a segment with no boundary is unchanged");
+  assert.equal(
+    boundedToModule(`${handler}${BUN_MODULE_BOUNDARY}${neighbour}`),
+    handler,
+    "everything from the boundary onward is dropped"
+  );
+  // The point of the truncation: the marker survives in the bundle but stops
+  // counting as evidence about the handler.
+  const spilled = `async function a(){return 1}${BUN_MODULE_BOUNDARY}${neighbour}`;
+  assert.ok(spilled.includes("tengu_fast_mode_picker_shown"));
+  assert.ok(!boundedToModule(spilled).includes("tengu_fast_mode_picker_shown"));
+});

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -507,7 +507,18 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     'if(process.env.REMORA_ACTIVE==="1")return __calicoGatewayFastThin(e);',
     ""
   );
-  const withoutNativeAction = patched.replace('"shortcut"', '"shortcut-broken"');
+  // Was `patched.replace('"shortcut"', '"shortcut-broken"')`. 2.1.251 removed the
+  // "shortcut" apply call from the interactive handler entirely — on/off now
+  // renders a component — so the verifier can no longer treat its absence as a
+  // defect without rejecting legitimate builds. The picker telemetry event is
+  // the invariant that survived the restructure and is what the verifier
+  // requires instead, so break that.
+  // Renaming to a superstring would not work: the verifier tests `includes`, so
+  // "..._shown_broken" still satisfies it.
+  const withoutPickerEvent = patched.replace(
+    '"tengu_fast_mode_picker_shown"',
+    '"tengu_fast_mode_picker_hidden"'
+  );
   const applyAfterBetaMerge = patched.replace(
     builderBlock,
     builderBlock
@@ -573,7 +584,7 @@ test("binary verifier rejects detached helpers and broken gateway ownership", ()
     ["comment-only helpers", commentOnlyHelpers],
     ["alternate apply binding", alternateApply],
     ["missing thin branch", withoutThinBranch],
-    ["missing native action", withoutNativeAction],
+    ["missing picker event", withoutPickerEvent],
     ["apply after beta merge", applyAfterBetaMerge],
     ["apply before native parse", applyBeforeNativeParse],
     ["apply inside native catch", applyInsideNativeCatch],


### PR DESCRIPTION
Upstream 2.1.251 moved three things at once. **The preflight gate caught it before any release went out** — and the run was dispatched by the launchd watcher, not by GitHub's scheduler, so this is drift repair rather than incident recovery.

```
18:27:24Z  launchd agent: upstream 2.1.251 has no releases -> dispatch
           preflight: download, patch, verify linux-x64
           --assert-all FAILED on three modules
           Report drift and stop -> nothing released
```

## What moved

| module | before | after | cause |
| --- | --- | --- | --- |
| `statusline-rate-limit-windows` | 2/2 | **0/0** | projection gained a `spend_limit` entry; guard went three-way |
| `gateway-fast-mode` | 6/6 | **6/0** | interactive handler restructured; three gate markers vanished |
| `statusline-committed-usage` | 6/6 | **5/0** | batch content builder gained a callback argument |

### statusline-rate-limit-windows

The projection object gained `...X()==="gateway"&&L.overage&&{spend_limit:{…}}`, so a matcher requiring `}` right after `seven_day` stopped matching. Enumerating the new entry would only invite the next one, and rewriting the object without it would **silently drop an upstream field**. The prefix matches as before and the object's end is now found by brace matching, so anything upstream appends is captured and re-emitted verbatim — verified that `spend_limit` survives alongside all four injected windows. The guard's replacement already tests `Object.keys(L).length>0`, so it just needed to accept an open-ended `||` chain.

### gateway-fast-mode

All six candidates were still found and every one rejected. The handler lost its `"shortcut"` apply call (on/off now renders a component) and `.getAppState`/`.setAppState` moved out — three markers gone in one release. Those were *evidence that the segment is the fast-mode handler*, not properties of the injection, and the signature already pins it far harder (three parameters, availability guard, `"Fast mode is not available"`). The gate now asks for what survives and what the injection needs: the picker telemetry event and a component render.

**Both handler segments are now bounded to their own Bun module.** `indexOf("async function ")` walks past the chunk boundary — on 2.1.250 the interactive segment ran 49KB while the handler was 434 bytes, so every marker *could* have been satisfied by an unrelated chunk. It happened to be honest there, which is exactly the kind of luck that stops holding without warning.

### statusline-committed-usage

```js
2.1.250  Mre(V1([Cr],o,p.agentId,{…},p.storageV5),o)
2.1.251  j2t(Uq([Mr],o,d.agentId,{…},d.storageV5),o,(a,b)=>p0(a,b,d.agentId,d.storageV5))
```

The wrapper required the call to close right after the second argument. It now accepts a trailing argument list one level of call nesting deep, so the callback body does not terminate the match early.

Instrumenting each module's early returns to find *which* gate fired, rather than reading matchers and guessing, is what made this quick: two of the three were single conditions inside composite gates of 5 and 13 terms.

## Test change worth flagging

`tests/gateway-fast-mode.test.js`'s "missing native action" case mutated `"shortcut"` — a property upstream no longer guarantees — so it could no longer tell a broken build from a legitimate 2.1.251 one. Replaced with a case that breaks the picker telemetry event, which the verifier now requires and which had no negative coverage.

The first attempt renamed it to `"…_shown_broken"` and **passed vacuously**: the verifier tests `includes`, so a superstring still satisfies it. Renamed to `"…_picker_hidden"` and confirmed failing before the fix, passing after.

## Verification

```
2.1.251 macos-arm64   patch 19/19 (all three restored), verify clean,
                      (patched) marker, live-thinking PASS
regression 246/247/248 x linux-x64 + macos-arm64    18/18 PASS
live thinking  246 / 247 / 248 / 250 / 251          all PASS
node suite                                          153 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e