### PR TITLE
feat(patch): restore the fullscreen sticky prompt header, and fix the harness proxy bug

### DIFF
--- a/PATCHING_PLAYBOOK.md
+++ b/PATCHING_PLAYBOOK.md
@@ -139,6 +139,20 @@ These rules are not style preferences. They are what keeps the patcher alive acr
   injected value that occupies no slot leaves the renderer showing a stale element forever while the
   patch summary, `--assert-all` and the verifier all report success. Grow the allocation and claim a
   slot in both the guard and the write-back, and assert that wiring in the verifier.
+- **A memo key that never changes freezes a live read.** The same compiler pass also memoizes plain
+  reads, and when it keys them on an object whose identity is stable for the component's lifetime the
+  value is captured once at mount and reused forever. 2.1.247 did this to the sticky prompt header
+  (`if(Eo[2]!==ot.handle)iS=ot.handle?.isSticky()??!0,…;else iS=Eo[3]`): `ot.handle` never changes, so
+  `isSticky()` stayed at its mount-time `true`, the scan gated on `!isSticky` never ran, and the
+  header rendered blank from 2.1.247 through 2.1.251 — upstream
+  [#90299](https://github.com/anthropics/claude-code/issues/90299). Sibling reads through the same
+  handle froze with it, and the one read that bypassed the memo (a callback calling
+  `handle.isSticky()` directly) kept working, which is why scroll state looked correctly detected
+  while the feature was dead. Forcing the guard (`if(!0||…)`) restores per-render evaluation and
+  leaves the cache writes well-formed; downstream memos keyed on the values these derive then
+  invalidate on their own. When a bundle predates the memo the module must report skipped, and the
+  verifier must version-gate the waiver rather than accept absence, or a drifted shape passes as
+  "not applicable".
 - **Anchor on the parameter, not on what follows it.** 2.1.247 dropped `showAllInTranscript` from
   the renderer's destructured params and moved `isLoading` up behind `streamingToolUses`, which
   killed an injection anchored on that suffix. The stable thing is the parameter you are inserting

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -3000,6 +3000,102 @@ function patchStatuslineCommittedUsage(content) {
 // seven_day_overage_included "Fable 5 limit"; overage is the usage-credit window.
 // Both keep their upstream key names so a future upstream projection is a
 // drop-in replacement for this patch.
+// Restore the fullscreen sticky prompt header, which stopped rendering in
+// 2.1.247 and is still broken in 2.1.251 (anthropics/claude-code#90299).
+//
+// Through 2.1.246 the sticky-prompt component read the viewport on every
+// render. 2.1.247 rewrote the same reads under compiler-style memoization keyed
+// on the viewport HANDLE:
+//
+//   if(Eo[2]!==ot.handle)iS=ot.handle?.isSticky()??!0,Eo[2]=ot.handle,Eo[3]=iS;else iS=Eo[3];
+//
+// `ot.handle` keeps the same object identity for the lifetime of the list, so
+// each read is evaluated once at mount — while the view is still pinned to the
+// bottom, so isSticky() returns true — and that value is reused forever. The
+// prompt-scan that fills the header is gated on `!isSticky`, so it never runs.
+// getScrollTop and getPendingDelta are frozen on the same key, which also
+// freezes the derived offset the scan compares against.
+//
+// The scroll subscription still triggers re-renders; they just reuse the stale
+// cache. The "Jump to bottom" pill is unaffected because it calls
+// handle.isSticky() directly inside a callback rather than through the memo,
+// which is why scroll state looks correctly detected while the header is blank.
+//
+// Force the three guards instead of removing the memo: the cache writes stay
+// well-formed, the downstream scan memo keyed on the derived offset invalidates
+// on its own once these recompute, and the edit is one insertion per site.
+// Bundles that never memoized these reads report skipped rather than failing
+// --assert-all, since the feature works there without help.
+function patchStickyPromptHeader(content) {
+  const original = content;
+  const identifier = "[A-Za-z_$][\\w$]*";
+  const memoizedViewportRead = new RegExp(
+    `if\\((${identifier})\\[(\\d+)\\]!==(${identifier})\\.handle\\)(${identifier})=\\3\\.handle\\?\\.(isSticky|getScrollTop|getPendingDelta)\\(\\)\\?\\?(?:!0|0),\\1\\[\\2\\]=\\3\\.handle,\\1\\[(\\d+)\\]=\\4;else \\4=\\1\\[\\6\\];`,
+    "g"
+  );
+  const matches = [...content.matchAll(memoizedViewportRead)];
+  const candidates = matches.length;
+
+  if (candidates === 0) {
+    return {
+      content: original,
+      candidates: 0,
+      patched: 0,
+      skipped: true,
+      reason: "viewport reads are not memoized on the handle in this bundle",
+    };
+  }
+
+  // All three reads belong to one component. Requiring them to share the cache
+  // local, the viewport local and the enclosing function is what stops this
+  // from forcing a guard in some other memoized component that happens to read
+  // a `.handle`.
+  const [first] = matches;
+  const cacheLocal = first[1];
+  const viewportLocal = first[3];
+  const kinds = new Set(matches.map((match) => match[5]));
+  const functionStarts = new Set(
+    matches.map((match) => content.lastIndexOf("function ", match.index ?? -1))
+  );
+  const owningFunctionStart = functionStarts.values().next().value;
+  const owningFunction =
+    owningFunctionStart === undefined || owningFunctionStart === -1
+      ? ""
+      : boundedToModule(content.slice(owningFunctionStart, (first.index ?? 0) + 4000));
+
+  if (
+    candidates !== 3 ||
+    kinds.size !== 3 ||
+    !matches.every((match) => match[1] === cacheLocal && match[3] === viewportLocal) ||
+    functionStarts.size !== 1 ||
+    owningFunctionStart === -1 ||
+    // The component that owns the header publishes it through this setter, and
+    // the literal occurs twice in the whole bundle. Nothing weaker identifies
+    // the sticky-prompt component; the memo shape alone is a compiler idiom.
+    !owningFunction.includes("setStickyPrompt")
+  ) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  let output = content;
+  let patched = 0;
+  // Splice from the last match backwards so earlier offsets stay valid.
+  for (const match of [...matches].sort((a, b) => (b.index ?? 0) - (a.index ?? 0))) {
+    const start = match.index ?? -1;
+    if (start === -1 || !output.startsWith("if(", start)) {
+      return { content: original, candidates, patched: 0 };
+    }
+    output = `${output.slice(0, start + 3)}!0||${output.slice(start + 3)}`;
+    patched += 1;
+  }
+
+  if (output.split("!0||").length - 1 - (content.split("!0||").length - 1) !== 3) {
+    return { content: original, candidates, patched: 0 };
+  }
+
+  return { content: output, candidates, patched };
+}
+
 function patchStatuslineRateLimitWindows(content) {
   const original = content;
   const identifier = "[A-Za-z_$][\\w$]*";
@@ -3971,6 +4067,11 @@ const PATCH_MODULES = [
     apply: patchStatuslineRateLimitWindows,
   },
   {
+    id: "sticky-prompt-header",
+    description: "Restore the fullscreen sticky prompt header frozen by handle-keyed memoization",
+    apply: patchStickyPromptHeader,
+  },
+  {
     id: "custom-context-window",
     description: "Allow exact opt-in custom model context windows",
     apply: patchCustomContextWindows,
@@ -4248,6 +4349,7 @@ function main() {
 
 module.exports = {
   patchDisableUsageWrapUpHints,
+  patchStickyPromptHeader,
   patchGatewayFastMode,
   patchActiveTurnPromptIdentity,
   patchCompactRequestSource,

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1286,6 +1286,77 @@ const CHECKS: Check[] = [
     },
   },
   {
+    id: "sticky-prompt-header",
+    kind: "custom",
+    describe: "fullscreen sticky prompt header re-reads the viewport on every render",
+    disabledMarker: /if\(!0\|\|[A-Za-z_$][\w$]*\[\d+\]!==[A-Za-z_$][\w$]*\.handle\)/,
+    run: (content: string): string | null => {
+      const identifier = "[A-Za-z_$][\\w$]*";
+      const forced = new RegExp(
+        `if\\(!0\\|\\|(${identifier})\\[(\\d+)\\]!==(${identifier})\\.handle\\)(${identifier})=\\3\\.handle\\?\\.(isSticky|getScrollTop|getPendingDelta)\\(\\)`,
+        "g"
+      );
+      const stale = new RegExp(
+        `if\\((${identifier})\\[(\\d+)\\]!==(${identifier})\\.handle\\)(${identifier})=\\3\\.handle\\?\\.(isSticky|getScrollTop|getPendingDelta)\\(\\)`,
+        "g"
+      );
+      const forcedMatches = [...content.matchAll(forced)];
+      const staleMatches = [...content.matchAll(stale)];
+
+      // 2.1.247 introduced the handle-keyed memo; before it the reads were
+      // straight-line and the header worked unaided, so absence there is
+      // correct rather than a missing patch. Version-gate the waiver instead of
+      // waiving on absence alone: on 2.1.247+ a read still keyed on the handle
+      // is the defect this module exists to remove.
+      const versionMatch = content.match(
+        /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
+      );
+      const version = versionMatch?.slice(1).map(Number);
+      if (version === undefined) {
+        return "expected parseable Claude Code VERSION metadata";
+      }
+      const memoizedHere =
+        version[0] > 2 ||
+        (version[0] === 2 &&
+          (version[1] > 1 || (version[1] === 1 && version[2] >= 247)));
+
+      if (!memoizedHere) {
+        return forcedMatches.length === 0 && staleMatches.length === 0
+          ? null
+          : "unexpected handle-keyed viewport memo on a bundle that predates it";
+      }
+
+      if (staleMatches.length > 0) {
+        return `found ${staleMatches.length} viewport read(s) still frozen on the handle identity`;
+      }
+      if (forcedMatches.length !== 3) {
+        return `expected 3 forced viewport reads, found ${forcedMatches.length}`;
+      }
+      const kinds = new Set(forcedMatches.map((match) => match[5]));
+      if (kinds.size !== 3) {
+        return `expected isSticky, getScrollTop and getPendingDelta, found ${[...kinds].join(", ")}`;
+      }
+      const cacheLocals = new Set(forcedMatches.map((match) => match[1]));
+      const viewportLocals = new Set(forcedMatches.map((match) => match[3]));
+      if (cacheLocals.size !== 1 || viewportLocals.size !== 1) {
+        return "forced viewport reads do not share one memo cache and viewport";
+      }
+      // The header is published through this setter, and the literal occurs
+      // twice in the whole bundle. Without it the memo shape alone would accept
+      // a forced guard in any other compiled component reading a `.handle`.
+      const owner = content.lastIndexOf("function ", forcedMatches[0].index ?? -1);
+      if (
+        owner === -1 ||
+        !boundedToModule(content.slice(owner, (forcedMatches[0].index ?? 0) + 4000)).includes(
+          "setStickyPrompt"
+        )
+      ) {
+        return "forced viewport reads are not inside the sticky-prompt component";
+      }
+      return null;
+    },
+  },
+  {
     id: "statusline-rate-limit-windows",
     kind: "custom",
     describe:

--- a/tests/sticky-prompt-header.test.js
+++ b/tests/sticky-prompt-header.test.js
@@ -1,0 +1,112 @@
+// The fullscreen sticky prompt header stopped rendering in 2.1.247
+// (anthropics/claude-code#90299). Through 2.1.246 the component read the
+// viewport on every render; 2.1.247 put the same reads behind compiler-style
+// memoization keyed on the viewport handle, whose object identity never changes
+// for the lifetime of the list. Every read is therefore frozen at its
+// mount-time value — isSticky() true, because the view starts pinned to the
+// bottom — and the prompt scan gated on `!isSticky` never runs again.
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const { patchStickyPromptHeader } = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
+
+const VERSION_METADATA = 'var meta={PACKAGE_URL:"@anthropic-ai/claude-code",VERSION:"2.1.251"};';
+
+// The 2.1.247+ shape: one component, one memo cache, three handle-keyed reads,
+// then a scan memoized on the offset they derive.
+const memoizedFixture = `${VERSION_METADATA}
+function km(XE){let Eo=_(36),{messages:Fa,start:wn,end:cr,getItemTop:ur,scrollViewport:ot}=XE,{setStickyPrompt:dr}=Or(),rS;if(Eo[0]!==ot.handle)rS=()=>ot.handle,Eo[0]=ot.handle,Eo[1]=rS;else rS=Eo[1];Lt(ot.subscribe,rS);let iS;if(Eo[2]!==ot.handle)iS=ot.handle?.isSticky()??!0,Eo[2]=ot.handle,Eo[3]=iS;else iS=Eo[3];let Rm=iS,aS;if(Eo[4]!==ot.handle)aS=ot.handle?.getScrollTop()??0,Eo[4]=ot.handle,Eo[5]=aS;else aS=Eo[5];let lS;if(Eo[6]!==ot.handle)lS=ot.handle?.getPendingDelta()??0,Eo[6]=ot.handle,Eo[7]=lS;else lS=Eo[7];let pr=Math.max(0,aS+lS);dr(Rm?null:pr);return Rm}
+`;
+
+// Pre-2.1.247: same reads, no memo. The module must decline, not fail.
+const plainFixture = `${VERSION_METADATA.replace("2.1.251", "2.1.246")}
+function km(XE){let{scrollViewport:ot}=XE,{setStickyPrompt:dr}=Or();let Rm=ot.handle?.isSticky()??!0,pr=(ot.handle?.getScrollTop()??0)+(ot.handle?.getPendingDelta()??0);dr(Rm?null:pr);return Rm}
+`;
+
+// Drive the component the way the TUI does: mount while pinned to the bottom,
+// then scroll. A frozen read keeps reporting the mount-time value.
+function runComponent(source) {
+  const context = {
+    sticky: true,
+    scrollTop: 0,
+    published: [],
+    handle: null,
+  };
+  vm.createContext(context);
+  vm.runInContext(
+    `var handle={isSticky:()=>sticky,getScrollTop:()=>scrollTop,getPendingDelta:()=>0};` +
+      `var _=(n)=>new Array(n);var Lt=()=>{};` +
+      `var Or=()=>({setStickyPrompt:(v)=>{published.push(v)}});` +
+      source +
+      `;var __cache=_(36);` +
+      // One component instance, re-rendered: the memo cache persists across
+      // renders exactly as the compiler's does.
+      `function render(){let saved=_;_=()=>__cache;try{return km({scrollViewport:{handle,subscribe:()=>{}}})}finally{_=saved}}`,
+    context
+  );
+  vm.runInContext("render()", context);
+  context.sticky = false;
+  context.scrollTop = 120;
+  vm.runInContext("render()", context);
+  return context.published;
+}
+
+test("frozen fixture reproduces the defect before patching", () => {
+  const published = runComponent(memoizedFixture);
+  // Second render happens after scrolling away, so the header should have been
+  // published with an offset. The stale cache keeps reporting sticky.
+  assert.deepEqual(published, [null, null], "unpatched memo should stay stuck on sticky");
+});
+
+test("forces every handle-keyed viewport read to re-evaluate", () => {
+  const result = patchStickyPromptHeader(memoizedFixture);
+  assert.equal(result.candidates, 3);
+  assert.equal(result.patched, 3);
+  assert.equal(evaluatePatchModule("sticky-prompt-header", result.content), null);
+
+  const published = runComponent(result.content);
+  assert.equal(published[0], null, "still sticky at mount");
+  assert.equal(published[1], 120, "after scrolling, the header publishes the offset");
+});
+
+test("declines bundles whose viewport reads were never memoized", () => {
+  const result = patchStickyPromptHeader(plainFixture);
+  assert.equal(result.candidates, 0);
+  assert.equal(result.patched, 0);
+  assert.equal(result.skipped, true);
+  assert.equal(result.content, plainFixture);
+  // The verifier must treat that as correct rather than as a missing patch.
+  assert.equal(evaluatePatchModule("sticky-prompt-header", plainFixture), null);
+});
+
+test("re-running the patch does not force a guard twice", () => {
+  const once = patchStickyPromptHeader(memoizedFixture).content;
+  const twice = patchStickyPromptHeader(once);
+  assert.equal(twice.candidates, 0);
+  assert.equal(twice.patched, 0);
+  assert.equal(twice.content, once);
+});
+
+test("refuses reads that do not belong to one sticky-prompt component", () => {
+  // Same memo shape, but the owning function does not publish a sticky prompt.
+  const notSticky = memoizedFixture.replace("{setStickyPrompt:dr}=Or()", "{setSomethingElse:dr}=Or()");
+  assert.notEqual(notSticky, memoizedFixture);
+  const result = patchStickyPromptHeader(notSticky);
+  assert.equal(result.candidates, 3);
+  assert.equal(result.patched, 0, "three reads alone are a compiler idiom, not this component");
+
+  // And a bundle where the three reads are split across two caches.
+  const splitCache = memoizedFixture.replace("Eo[6]!==ot.handle", "Fo[6]!==ot.handle");
+  assert.notEqual(splitCache, memoizedFixture);
+  assert.equal(patchStickyPromptHeader(splitCache).patched, 0);
+});
+
+test("verifier rejects a bundle whose reads are still frozen", () => {
+  assert.notEqual(
+    evaluatePatchModule("sticky-prompt-header", memoizedFixture),
+    null,
+    "an unpatched 2.1.247+ bundle must not verify clean"
+  );
+});

--- a/tools/local-verify/run.sh
+++ b/tools/local-verify/run.sh
@@ -11,7 +11,11 @@
 set -uo pipefail
 
 BINARY="${1:-}"
-PORT="${2:-8787}"
+# Default to 0 so the OS picks a free port. A fixed port made back-to-back runs
+# fail with EADDRINUSE when the previous mock had not released the socket yet,
+# and the summary reports that as a harness failure indistinguishable at a
+# glance from a broken binary.
+PORT="${2:-0}"
 if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
   echo "usage: bash tools/local-verify/run.sh <claude-binary> [port]" >&2
   exit 2
@@ -59,7 +63,11 @@ for _ in $(seq 1 40); do
   sleep 0.25
 done
 grep -q "mock listening" "$WORK/mock.err" 2>/dev/null || {
-  echo "mock API failed to start:" >&2; cat "$WORK/mock.err" >&2; exit 1; }
+  echo "HARNESS PROBLEM (not the binary): mock API failed to start" >&2
+  cat "$WORK/mock.err" >&2; exit 1; }
+# With PORT=0 the chosen port is only known once the mock is listening.
+PORT="$(sed -n 's/.*mock listening on \([0-9][0-9]*\).*/\1/p' "$WORK/mock.err" | head -1)"
+[ -n "$PORT" ] || { echo "HARNESS PROBLEM (not the binary): could not read the mock port" >&2; exit 1; }
 
 expect "$HERE/tui.exp" "$BINARY" "$WORK/tui.raw" "$CONFIG" "http://127.0.0.1:$PORT" >/dev/null 2>&1
 STATUS=$?

--- a/tools/local-verify/tui.exp
+++ b/tools/local-verify/tui.exp
@@ -21,6 +21,13 @@ log_file -noappend $logfile
 set env(ANTHROPIC_BASE_URL) $baseurl
 set env(ANTHROPIC_API_KEY) "sk-ant-mock"
 set env(CLAUDE_CONFIG_DIR) $configdir
+# Without this the binary routes 127.0.0.1 through a proxy and the request never
+# reaches the mock: "request NEVER SENT", which reads as a dead binary rather
+# than an unreachable endpoint. Port 8787 happened to work and every other port
+# did not, so the harness looked port-sensitive for days when it was proxy
+# configuration all along.
+set env(NO_PROXY) "127.0.0.1,localhost"
+set env(no_proxy) "127.0.0.1,localhost"
 
 spawn -noecho $binary
 # Wait for the status line the main renderer draws, then for the input


### PR DESCRIPTION
Two independent things, the second found while regressing the first.

## sticky-prompt-header

The scroll-aware sticky prompt header — the dimmed line pinned at row 1 showing the prompt that owns the visible output, clickable to jump back — worked through 2.1.246 and has rendered blank since 2.1.247. Reported upstream as [anthropics/claude-code#90299](https://github.com/anthropics/claude-code/issues/90299), still broken in 2.1.251.

```js
if(Eo[2]!==ot.handle)iS=ot.handle?.isSticky()??!0,Eo[2]=ot.handle,Eo[3]=iS;else iS=Eo[3];
```

`ot.handle` keeps one object identity for the lifetime of the list, so the read is evaluated once **at mount** — while the view is still pinned to the bottom, so `isSticky()` returns true — and reused forever. The prompt scan that fills the header is gated on `!isSticky`, so it never runs again. `getScrollTop` and `getPendingDelta` froze on the same key, freezing the offset the scan compares against.

The scroll subscription still re-rendered; every re-render reused the stale cache. The "Jump to bottom" pill was unaffected because it calls `handle.isSticky()` directly inside a callback — which is why scroll state looked correctly detected while the header was missing.

The bisect is confirmed independently against the bundles:

| version | handle-keyed viewport reads |
| --- | --- |
| 2.1.239 / 2.1.245 / 2.1.246 | 0 — feature works unaided |
| 2.1.247 / 2.1.248 / 2.1.250 / 2.1.251 | **3** — isSticky, getScrollTop, getPendingDelta |

**Fix.** Force the three guards (`if(!0||…)`) rather than removing the memo: cache writes stay well-formed, the downstream scan memo keyed on the derived offset invalidates on its own once these recompute, and the edit is one insertion per site.

Three reads sharing a memo cache is a compiler idiom, not an identity, so the module also requires all three to share one cache local, one viewport local and one enclosing function — and that function to contain `setStickyPrompt`, a literal occurring twice in the whole bundle. Bundles predating the memo report **skipped** rather than failing `--assert-all`, and the verifier version-gates that waiver so a merely drifted shape cannot pass as "not applicable".

**Confirmed by the user** against a patched 2.1.251: scrolling up shows the dimmed prompt, and clicking it jumps back.

## tools/local-verify proxy bug

Regressing the above kept failing with `request NEVER SENT`, which reads as a dead binary. It was neither the binary nor — as I first assumed — harness flakiness: `tui.exp` never set `NO_PROXY`, so the spawned binary routed `127.0.0.1` through a proxy and never reached the mock.

Port 8787 happened to work and every other port did not, so the harness looked *port-sensitive* across two separate investigations. Upstream's own integration test sets `NO_PROXY`; the connection was there to make and I did not make it.

With that fixed the fixed port could go too — it defaults to `0` and the chosen port is read back from the mock, because back-to-back runs failed with `EADDRINUSE` when the previous mock had not released the socket, reported in a shape also indistinguishable at a glance from a broken binary. Three consecutive runs now pass, where the second used to fail. Harness-level failures say `HARNESS PROBLEM (not the binary)` explicitly.

## Verification

```
node suite                     154 -> 160 passing
  · reproduces the frozen behaviour BEFORE patching
  · drives the patched component through a scroll, asserts the offset publishes
  · confirmed failing when the !0|| insertion is reverted

verifier calibration
  unpatched 2.1.251  rejected: "3 viewport read(s) still frozen on the handle identity"
  2.1.246            verifies clean (correctly not applicable)

2.1.251 macos-arm64            patch 19/19, verify 19 modules, live-thinking PASS
regression 246/247/248         linux-x64 + macos-arm64   18/18
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e