### PR TITLE
ci(watch): stop treating unrelated workflows as build inputs

### DIFF
--- a/.github/workflows/watch-claude-release.yml
+++ b/.github/workflows/watch-claude-release.yml
@@ -161,7 +161,15 @@ jobs:
           # reach the binary. Docs, tests, the harness, the verifier (which gates
           # releases but never edits the bundle), the installers, this workflow,
           # and the bun lockfile used only by the test runner.
-          NON_BUILD_PATHS='^(docs/|test/|tests/|tools/local-verify/|tools/watch-poke\.sh$|scripts/verify-patched-binary\.ts$|install-patched-claude\.|\.github/workflows/watch-claude-release\.yml$|bun\.lock$|\.gitignore$|.*\.md$)'
+          # .github/ is excluded wholesale and patch-claude.yml added back below.
+          # Naming only watch-claude-release.yml here meant every other workflow
+          # counted as a build input: adding discord-ci-notify.yml republished all
+          # five platforms as v2.1.251-*-3 for a notification workflow that cannot
+          # reach the binary. Of everything under .github/, only patch-claude.yml
+          # is part of the build definition — it runs the patcher and sets
+          # DISABLED_MODULES. The rest decide when to build, or do not build.
+          NON_BUILD_PATHS='^(docs/|test/|tests/|tools/local-verify/|tools/watch-poke\.sh$|scripts/verify-patched-binary\.ts$|install-patched-claude\.|\.github/|bun\.lock$|\.gitignore$|.*\.md$)'
+          BUILD_WORKFLOW='.github/workflows/patch-claude.yml'
           STALE=0
 
           for SUFFIX in linux-x64 linux-arm64 macos-arm64 win32-x64 win32-arm64; do
@@ -184,7 +192,12 @@ jobs:
               continue
             fi
 
-            CHANGED="$(git diff --name-only "$BUILT_FROM" HEAD | grep -Ev "$NON_BUILD_PATHS" || true)"
+            CHANGED="$(
+              {
+                git diff --name-only "$BUILT_FROM" HEAD | grep -Ev "$NON_BUILD_PATHS" || true
+                git diff --name-only "$BUILT_FROM" HEAD -- "$BUILD_WORKFLOW"
+              } | sort -u
+            )"
             if [ -n "$CHANGED" ]; then
               echo "$SUFFIX: $TAG built from ${BUILT_FROM:0:7}; build inputs changed since:"
               echo "$CHANGED" | sed 's/^/    /'


### PR DESCRIPTION
Adding `.github/workflows/discord-ci-notify.yml` in a317e2f republished all five platforms as `v2.1.251-*-3`. A notification workflow cannot reach the patched binary — the rebuild was pure waste, and it would recur on every CI-adjacent change.

## Why it fired

The deny-list named `.github/workflows/watch-claude-release.yml` **specifically**, so every other workflow counted as a build input by default.

That default is right for the repository at large: a missed rebuild silently ships stale artifacts, which is worse than a redundant one. It is wrong for `.github/`, where exactly one file participates in the build — `patch-claude.yml` runs the patcher and sets `DISABLED_MODULES`. Everything else there decides *when* to build, or does not build at all.

`.github/` is now excluded wholesale with `patch-claude.yml` added back explicitly, which also survives a workflow being renamed or split without silently widening the set.

## Exercised against the real history

Including the commit that caused the false positive:

```
110a6d6 -> a317e2f  (adds discord-ci-notify.yml)   current   <- was stale
5554fb9 -> 6b45afe  (sticky module)                stale
                        .github/workflows/patch-claude.yml
                        patch-claude-display.ts
patch-claude.yml's own last change                 stale
a317e2f -> HEAD     (this fix only)                current
```

The last case matters most: judging the freshly published `-3` releases stale would be a republish loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e