### PR TITLE
fix(patch,verify): support Claude 2.1.257, and stop pinning minified parameter names

### DIFF
--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1258,7 +1258,10 @@ function patchThinkingStreaming(content) {
     // 2.1.247 dropped showAllInTranscript from the renderer's destructured
     // params and moved isLoading up behind streamingToolUses, so neither the
     // detection nor the injection below can pin what follows the parameter.
-    /\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:([A-Za-z_$][\w$]*)[,}]/
+    // 2.1.257 stopped destructuring in the parameter list: the compiler now emits
+    // `function f(p){let c=_(203),{messages:…}=p`. Anchor on the destructuring
+    // itself, which is `({messages:` in one form and `,{messages:` in the other.
+    /[(,]\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:([A-Za-z_$][\w$]*)[,}]/
   );
   if (rendererStreamingThinkingMatch) {
     transcriptStreamingThinkingVar = rendererStreamingThinkingMatch[1];
@@ -1269,7 +1272,7 @@ function patchThinkingStreaming(content) {
     // site above does supply the prop — without this the renderer would receive
     // a value it never destructures.
     const rendererSignaturePattern =
-      /(\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,)(?!streamingThinking:)([A-Za-z_$][\w$]*:)/;
+      /([(,]\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,)(?!streamingThinking:)([A-Za-z_$][\w$]*:)/;
     output = output.replace(rendererSignaturePattern, (full, beforeStreamingThinking, afterStreamingThinking) => {
       if (full.includes("streamingThinking:")) {
         return full;
@@ -2401,10 +2404,16 @@ function patchCustomContextWindows(content) {
   // window. Calico keeps that default unless a launcher supplies an exact,
   // validated model-to-window map. Exact matching is intentional: a typo must
   // fail closed to Claude's stock behavior instead of widening another model.
+  // The two parameters were pinned as `e` and `t`, and the injected lookup
+  // emitted `e` verbatim. They are minified names: 2.1.257 renamed the second to
+  // `n`, which took this module from 4 candidates to 1. That still passed
+  // --assert-all, since it only fails at zero — a silent loss of coverage.
+  // Capture both and emit the captures.
   const resolverPattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{)(if\([A-Za-z_$][\w$]*\(e\)\)return 1e6;if\(t\?\.includes\()/g;
+    /(function [A-Za-z_$][\w$]*\()([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)(\)\{)(if\([A-Za-z_$][\w$]*\(\2\)\)return 1e6;if\(\3\?\.includes\()/g;
 
-  output = output.replace(resolverPattern, (full, functionStart, originalBody) => {
+  output = output.replace(resolverPattern, (full, functionOpen, modelParam, headersParam, brace, originalBody) => {
+    const functionStart = `${functionOpen}${modelParam},${headersParam}${brace}`;
     candidates += 1;
     const helpers =
       'function __calico_context_window(e){try{let t=process.env.CALICO_MODEL_CONTEXT_WINDOWS;if(!t)return null;let r=JSON.parse(t);if(!r||typeof r!=="object"||Array.isArray(r)||!Object.hasOwn(r,e))return null;let n=r[e];if(!Number.isInteger(n)||n<100000||n>1000000)return null;return n}catch{return null}}' +
@@ -2416,7 +2425,7 @@ function patchCustomContextWindows(content) {
       // called from the resolver body injected immediately after it.
       'globalThis.__calico_display_window=function(e){let t=Number(process.env.CALICO_CONTEXT_DISPLAY_PERCENT??100);if(!Number.isFinite(t)||t<1||t>100)return e;return Math.floor(e*t/100)};';
     const replacement =
-      `${helpers}${functionStart}let __calico_window=__calico_context_window(e);` +
+      `${helpers}${functionStart}let __calico_window=__calico_context_window(${modelParam});` +
       `if(__calico_window!==null)return __calico_window;${originalBody}`;
     patched += 1;
     return replacement;
@@ -2430,24 +2439,25 @@ function patchCustomContextWindows(content) {
   // → `return o-n`; elsewhere `let r=Math.min(...),n=...` → `return o-r`), so
   // capture the window and reserve locals instead of pinning `o`/`r`.
   const effectiveWindowPattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{let ([A-Za-z_$][\w$]*)=Math\.min\([A-Za-z_$][\w$]*\(e\),[A-Za-z_$][\w$]*\),([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\)\?t:void 0,\{window:([A-Za-z_$][\w$]*)\}=[A-Za-z_$][\w$]*\(e,\3\);return )(\4-\2)(\})/g;
+    /(function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=Math\.min\([A-Za-z_$][\w$]*\(\2\),[A-Za-z_$][\w$]*\),([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\)\?\3:void 0,\{window:([A-Za-z_$][\w$]*)\}=[A-Za-z_$][\w$]*\(\2,\5\);return )(\6-\4)(\})/g;
   output = output.replace(
     effectiveWindowPattern,
-    (full, prefix, reserveLocal, ctxLocal, windowLocal, originalReturn, suffix) => {
+    (full, prefix, modelParam, headersParam, reserveLocal, ctxLocal, windowLocal, originalReturn, suffix) => {
       candidates += 1;
       patched += 1;
       return `${prefix}process.env.CALICO_MODEL_CONTEXT_WINDOWS?${windowLocal}:${originalReturn}${suffix}`;
     }
   );
 
+  // Same pinned-parameter bug as the resolver above: 2.1.257 renamed them.
   const precomputePattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{)(return Math\.min\(e-Math\.round\(e\*t\.precomputeBufferFraction\),([A-Za-z_$][\w$]*)\(e,t\)\)\})/g;
+    /(function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{)(return Math\.min\(\2-Math\.round\(\2\*\3\.precomputeBufferFraction\),([A-Za-z_$][\w$]*)\(\2,\3\)\)\})/g;
   output = output.replace(
     precomputePattern,
-    (full, functionStart, originalBody, percentFn) => {
+    (full, functionStart, modelParam, headersParam, originalBody, percentFn) => {
       candidates += 1;
       patched += 1;
-      return `${functionStart}if(process.env.CALICO_MODEL_CONTEXT_WINDOWS)return ${percentFn}(e,t);${originalBody}`;
+      return `${functionStart}if(process.env.CALICO_MODEL_CONTEXT_WINDOWS)return ${percentFn}(${modelParam},${headersParam});${originalBody}`;
     }
   );
 
@@ -2478,27 +2488,50 @@ function patchBackgroundAgentUsage(content) {
   // field whose value contains braces will fail to match, which reports zero
   // candidates and fails --assert-all rather than quietly discarding state.
   const trackerPattern = new RegExp(
-    `function (${identifierPattern})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\]((?:,[^{}]*)?)\\}\\}`,
+    // Upstream adds fields on both sides of recentActivities, not only after it:
+    // 2.1.246 appended `seenToolUseIds:new Set`, and 2.1.257 inserted
+    // `streamedTokenEstimate`, `streamedTokenEstimateAtResponseStart` and
+    // `lastStampedResponseId` BEFORE it, which a pattern demanding
+    // `cumulativeOutputTokens:0,recentActivities:` could not match. Capture both
+    // runs of fields and re-emit them verbatim, so anything upstream adds keeps
+    // working and nothing is silently dropped from the tracker's state.
+    `function (${identifierPattern})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0((?:,[^{}\\[\\]]*)?),recentActivities:\\[\\]((?:,[^{}]*)?)\\}\\}`,
     "g"
   );
   const totalPattern = new RegExp(
-    `function (${identifierPattern})\\((${identifierPattern})\\)\\{return \\2\\.latestInputTokens\\+\\2\\.cumulativeOutputTokens\\}`,
+    // 2.1.257 extended the sum with `+e.streamedTokenEstimate`. The name is only
+    // captured to build the summary anchor below, so accept further terms.
+    `function (${identifierPattern})\\((${identifierPattern})\\)\\{return \\2\\.latestInputTokens\\+\\2\\.cumulativeOutputTokens(?:\\+\\2\\.${identifierPattern})*\\}`,
     "g"
   );
   const accountingPattern = new RegExp(
-    `if\\((${identifierPattern})\\.type!=="assistant"\\)return;let (${identifierPattern})=\\1\\.message\\.usage;(${identifierPattern})\\.latestInputTokens=\\2\\.input_tokens\\+\\(\\2\\.cache_creation_input_tokens\\?\\?0\\)\\+\\(\\2\\.cache_read_input_tokens\\?\\?0\\),\\3\\.cumulativeOutputTokens\\+=\\2\\.output_tokens;`,
+    // The two assignments are the anchor; whether they stand as their own
+    // statement is not. 2.1.257 folded them into the head of an `if(...)` comma
+    // expression so it could append its lastStampedResponseId bookkeeping, which
+    // took this from a match to none — and with it eventName, progressPattern and
+    // everything downstream, since the whole module keys off this one site.
+    // Accept either form and stop at the second assignment.
+    // Accept either form and capture which one it is. The folded form's trailing
+    // `,` belongs to a condition that continues after the match, so the
+    // replacement has to re-open the `if(` rather than swallow it — dropping it
+    // leaves a dangling `)` and the module stops parsing, which no text-level
+    // check notices because every marker is still present.
+    `if\\((${identifierPattern})\\.type!=="assistant"\\)return;let (${identifierPattern})=\\1\\.message\\.usage;(if\\()?(${identifierPattern})\\.latestInputTokens=\\2\\.input_tokens\\+\\(\\2\\.cache_creation_input_tokens\\?\\?0\\)\\+\\(\\2\\.cache_read_input_tokens\\?\\?0\\),\\4\\.cumulativeOutputTokens\\+=\\2\\.output_tokens([;,])`,
     "g"
   );
   const trackerMatches = [...content.matchAll(trackerPattern)];
   const totalMatches = [...content.matchAll(totalPattern)];
   const accountingMatches = [...content.matchAll(accountingPattern)];
   const trackerName = trackerMatches[0]?.[1];
-  const trackerUpstreamFields = trackerMatches[0]?.[2] ?? "";
+  const trackerLeadingFields = trackerMatches[0]?.[2] ?? "";
+  const trackerUpstreamFields = trackerMatches[0]?.[3] ?? "";
   const totalName = totalMatches[0]?.[1];
   const accountingMatch = accountingMatches[0];
   const eventVar = accountingMatch?.[1];
   const usageVar = accountingMatch?.[2];
-  const trackerVar = accountingMatch?.[3];
+  const accountingIfPrefix = accountingMatch?.[3] ?? "";
+  const trackerVar = accountingMatch?.[4];
+  const accountingTerminator = accountingMatch?.[5] ?? ";";
   const eventIndex = accountingMatch?.index ?? -1;
   const eventFunctionStart = eventIndex === -1 ? -1 : content.lastIndexOf("function ", eventIndex);
   const eventHeaderMatch =
@@ -2610,7 +2643,7 @@ function patchBackgroundAgentUsage(content) {
   const trackerReplacement =
     'function __calicoTrackAgentUsage(e,t,r,n){if(!t||typeof t!=="object")return;let o=["input_tokens","cache_creation_input_tokens","cache_read_input_tokens"].some((s)=>typeof t[s]==="number"),i=(t.input_tokens??0)+(t.cache_creation_input_tokens??0)+(t.cache_read_input_tokens??0);if(o&&(n||i>0))e.latestInputTokens=i;let s=typeof t.output_tokens==="number"&&Number.isFinite(t.output_tokens)?Math.max(0,t.output_tokens):0;if(r==null){if(s>0)e.cumulativeOutputTokens+=s;return}let a=e.responseOutputTokens.get(r)??0;if(s>a)e.cumulativeOutputTokens+=s-a;if(s>a||!e.responseOutputTokens.has(r))e.responseOutputTokens.set(r,Math.max(a,s))}' +
     'function __calicoRefreshAgentUsage(e,t){if(!Array.isArray(t))return;let r=!1;for(let n=t.length-1;n>=0;n--){let o=t[n];if(o?.type==="assistant")r=!0,__calicoTrackAgentUsage(e,o.message?.usage,o.message?.id,o.message?.stop_reason!=null);else if(o?.type==="user"&&r)break}}' +
-    `function ${trackerName}(){return{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:[]${trackerUpstreamFields},activeMessageId:null,responseOutputTokens:new Map}}`;
+    `function ${trackerName}(){return{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0${trackerLeadingFields},recentActivities:[]${trackerUpstreamFields},activeMessageId:null,responseOutputTokens:new Map}}`;
   const eventReplacement =
     `if(${eventVar}.type==="stream_event"){if(${eventVar}.event.type==="message_start")${trackerVar}.activeMessageId=${eventVar}.event.message.id,__calicoTrackAgentUsage(${trackerVar},${eventVar}.event.message.usage,${trackerVar}.activeMessageId,!1);else if(${eventVar}.event.type==="message_delta")__calicoTrackAgentUsage(${trackerVar},${eventVar}.event.usage,${trackerVar}.activeMessageId,${eventVar}.event.delta.stop_reason!=null);else if(${eventVar}.event.type==="message_stop")${trackerVar}.activeMessageId=null;return}if(${eventVar}.type!=="assistant")return;let ${usageVar}=${eventVar}.message.usage;__calicoTrackAgentUsage(${trackerVar},${usageVar},${eventVar}.message.id,${eventVar}.message.stop_reason!=null);`;
   const progressReplacement = `${eventName}(${progressMatch[1]},${progressMatch[2]},${progressMatch[3]},${progressMatch[4]}.options.tools),__calicoRefreshAgentUsage(${progressMatch[1]},${completionTranscript}),${progressMatch[5]}(${progressOwner},${summaryName}(${progressMatch[1]}),${progressStatus});`;
@@ -2621,7 +2654,12 @@ function patchBackgroundAgentUsage(content) {
   // reach .replace only via a callback — a plain-string 2nd argument would
   // let `$$`/`$&`/`$1`-`$9` in a captured name expand against these regexes.
   let output = original.replace(trackerPattern, () => trackerReplacement);
-  output = output.replace(accountingPattern, () => eventReplacement);
+  // When the assignments were folded into an `if(`, re-emit that `if(` after our
+  // call so the condition it opened — and its closing paren — stay balanced.
+  output = output.replace(
+    accountingPattern,
+    () => `${eventReplacement}${accountingIfPrefix}`
+  );
   output = output.replace(progressPattern, () => progressReplacement);
   output = output.replace(
     completionMatch.match[0],
@@ -2677,8 +2715,23 @@ function patchStatuslineCommittedUsage(content) {
   // so the call no longer closes right after the second argument. Accept a
   // trailing argument list, one level of call nesting deep so the callback body
   // does not terminate it early.
+  // 2.1.257 stopped placing the message object immediately after the
+  // destructuring — it inserts wire-tool-input bookkeeping between them
+  // (`$c=Ps?Yxe([Hs]):void 0;YD||=…;let Ay=$c?.inputs,`) — and added
+  // `wireToolInputs` and `apiBlockIndex` to the object before `requestId`.
+  // Neither is something the replacement needs; both are matched loosely and
+  // re-emitted from the matched text, so upstream can keep adding to either
+  // position. The bounded `[^{}]` runs keep this from swallowing a whole
+  // unrelated object.
+  // 2.1.257 stopped placing the message object immediately after the
+  // destructuring — it inserts wire-tool-input bookkeeping between them
+  // (`$c=Ps?Yxe([Hs]):void 0;YD||=…;let Ay=$c?.inputs,`) — and added
+  // `wireToolInputs` and `apiBlockIndex` to the object before `requestId`.
+  // Neither is something the replacement needs; both are matched loosely and
+  // re-emitted from the matched text, so upstream can keep adding to either
+  // position. The bounded runs keep this from swallowing an unrelated object.
   const batchWrapperPattern = new RegExp(
-    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\),(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
+    `let\\{content:(${identifierPattern}),batchToolUses:(${identifierPattern})\\}=(${identifierPattern})\\((${identifierPattern})\\(\\[(${identifierPattern})\\],(${identifierPattern}),(${identifierPattern})\\.agentId,\\{requestId:(${identifierPattern})\\?\\?void 0,messageId:(${identifierPattern})\\.id\\}(?:,${identifierPattern}(?:\\.${identifierPattern})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\)(?:[^{}]|\\{[^{}]*\\})*?,(${identifierPattern})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\}((?:,[^{}]*(?:\\{[^{}]*\\})?)*?),requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifierPattern})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifierPattern})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,\\.\\.\\.(${identifierPattern})&&\\{advisorModel:\\14\\},\\.\\.\\.(${identifierPattern})!==void 0&&\\{effort:(${identifierPattern})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
     "g"
   );
   const terminalPattern = new RegExp(
@@ -2725,11 +2778,14 @@ function patchStatuslineCommittedUsage(content) {
       effortCondition: match[11],
       effortProperty: match[12],
     })),
+    // Group 11 captures whatever upstream inserts between batchToolUses and
+    // requestId (2.1.257: wireToolInputs + apiBlockIndex), which shifts the
+    // trailing captures by one.
     ...[...content.matchAll(batchWrapperPattern)].map((match) => ({
       match,
       local: match[10],
-      effortCondition: match[14],
-      effortProperty: match[15],
+      effortCondition: match[15],
+      effortProperty: match[16],
     })),
   ];
   const wrapperMatch = wrapperMatches[0];
@@ -3732,24 +3788,28 @@ function patchActiveTurnPromptIdentity(content) {
   // Every spawned agent enters the same AsyncLocalStorage boundary. Freeze
   // the current prompt id there so a background agent keeps its spawning turn
   // even after the main session accepts another user prompt.
+  // The two parameters were pinned as the literals `e` and `t`, and the injected
+  // code emitted `e` verbatim. Those are minified names, not fixed syntax: 2.1.257
+  // renamed the second one to `n` and this matcher stopped matching, taking the
+  // module to 1 candidate / 0 patched. Capture both and emit the captures.
   const agentContextPattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{return )([A-Za-z_$][\w$]*)\.run\(e,t\)(\}function [A-Za-z_$][\w$]*\(\)\{return\{agentType:"main",agentId:)/g;
+    /(function [A-Za-z_$][\w$]*\()([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)(\)\{return )([A-Za-z_$][\w$]*)\.run\(\2,\3\)(\}function [A-Za-z_$][\w$]*\(\)\{return\{agentType:"main",agentId:)/g;
   output = output.replace(
     agentContextPattern,
-    (full, prefix, storage, suffix) => {
+    (full, prefix, contextParam, callbackParam, open, storage, suffix) => {
       agentCandidates += 1;
       agentPatched += 1;
-      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall}),${storage}.run(e,t)${suffix}`;
+      return `${prefix}${contextParam},${callbackParam}${open}${contextParam}&&process.env.REMORA_ACTIVE==="1"&&${contextParam}.__calicoPromptId===void 0&&(${contextParam}.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall}),${storage}.run(${contextParam},${callbackParam})${suffix}`;
     }
   );
   const attributedAgentContextPattern =
-    /(function [A-Za-z_$][\w$]*\(e,t\)\{)(if\(!\("turnAttributionKey"in e\)\)e\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return )([A-Za-z_$][\w$]*)(\.run\(e,\(\)=>[A-Za-z_$][\w$]*\(e\.turnAttributionKey,t\)\))(\}function [A-Za-z_$][\w$]*\(\)\{return\{agentType:"main",agentId:)/g;
+    /(function [A-Za-z_$][\w$]*\()([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)(\)\{)(if\(!\("turnAttributionKey"in \2\)\)\2\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return )([A-Za-z_$][\w$]*)(\.run\(\2,\(\)=>[A-Za-z_$][\w$]*\(\2\.turnAttributionKey,\3\)\))(\}function [A-Za-z_$][\w$]*\(\)\{return\{agentType:"main",agentId:)/g;
   output = output.replace(
     attributedAgentContextPattern,
-    (full, prefix, attribution, storage, run, suffix) => {
+    (full, prefix, contextParam, callbackParam, open, attribution, storage, run, suffix) => {
       agentCandidates += 1;
       agentPatched += 1;
-      return `${prefix}e&&process.env.REMORA_ACTIVE==="1"&&e.__calicoPromptId===void 0&&(e.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall});${attribution}${storage}${run}${suffix}`;
+      return `${prefix}${contextParam},${callbackParam}${open}${contextParam}&&process.env.REMORA_ACTIVE==="1"&&${contextParam}.__calicoPromptId===void 0&&(${contextParam}.__calicoPromptId=${storage}.getStore()?.__calicoPromptId??${promptGetterCall});${attribution}${storage}${run}${suffix}`;
     }
   );
 

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1426,6 +1426,16 @@ const CHECKS: Check[] = [
       if (!injectedLookup.test(content)) {
         return "custom context-window lookup is not wired into the resolver";
       }
+      // Separate injection, separate check. Replacing the old literal marker
+      // with the resolver check above left the precompute bypass unverified: if
+      // precomputePattern drifts, an explicitly mapped window silently gets the
+      // upstream precompute buffer subtracted from it and everything still
+      // reports clean. Parameter-agnostic, since those names are minified.
+      const precomputeBypass =
+        /if\(process\.env\.CALICO_MODEL_CONTEXT_WINDOWS\)return [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\);return Math\.min\(/;
+      if (!precomputeBypass.test(content)) {
+        return "precompute buffer is not bypassed for explicitly mapped context windows";
+      }
       // The effective-window gate reads `CALICO_MODEL_CONTEXT_WINDOWS?<window>:<window>-<reserve>`,
       // where both are minified locals that differ per platform build of the
       // same version (arm64 swaps the reserve/ctx bindings, yielding `?o:o-n`

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -646,8 +646,10 @@ const CHECKS: Check[] = [
       }
       const frozenAgentContext =
         /process\.env\.REMORA_ACTIVE==="1"&&[A-Za-z_$][\w$]*\.__calicoPromptId===void 0&&\([A-Za-z_$][\w$]*\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?globalThis\.__calicoPromptIdGet\(\)\),\1\.run\(/;
+      // The parameter names are minified and were pinned as `e`/`t` here as well;
+      // 2.1.257 renamed the second to `n`. Capture them and backreference.
       const frozenJournalContext =
-        /function [A-Za-z_$][\w$]*\(e,t\)\{e&&process\.env\.REMORA_ACTIVE==="1"&&e\.__calicoPromptId===void 0&&\(e\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?globalThis\.__calicoPromptIdGet\(\)\);if\(!\("turnAttributionKey"in e\)\)e\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return \1\.run\(e,\(\)=>[A-Za-z_$][\w$]*\(e\.turnAttributionKey,t\)\)/;
+        /function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{\1&&process\.env\.REMORA_ACTIVE==="1"&&\1\.__calicoPromptId===void 0&&\(\1\.__calicoPromptId=([A-Za-z_$][\w$]*)\.getStore\(\)\?\.__calicoPromptId\?\?globalThis\.__calicoPromptIdGet\(\)\);if\(!\("turnAttributionKey"in \1\)\)\1\.turnAttributionKey=[A-Za-z_$][\w$]*\(\);return \3\.run\(\1,\(\)=>[A-Za-z_$][\w$]*\(\1\.turnAttributionKey,\2\)\)/;
       if (!frozenAgentContext.test(content) && !frozenJournalContext.test(content)) {
         return "missing nested-agent prompt inheritance at AsyncLocalStorage boundary";
       }
@@ -810,7 +812,10 @@ const CHECKS: Check[] = [
       }
       const identifier = "[A-Za-z_$][\\w$]*";
       const trackerPattern = new RegExp(
-        `function (${identifier})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0,recentActivities:\\[\\](?:,[^{}]*?)?,activeMessageId:null,responseOutputTokens:new Map\\}\\}`,
+        // Upstream adds fields on both sides of recentActivities (2.1.246 after,
+        // 2.1.257 before). Kept in lockstep with trackerPattern in
+        // patch-claude-display.ts.
+        `function (${identifier})\\(\\)\\{return\\{toolUseCount:0,latestInputTokens:0,cumulativeOutputTokens:0(?:,[^{}\\[\\]]*?)?,recentActivities:\\[\\](?:,[^{}]*?)?,activeMessageId:null,responseOutputTokens:new Map\\}\\}`,
         "g"
       );
       const trackerMatches = [...content.matchAll(trackerPattern)];
@@ -937,8 +942,13 @@ const CHECKS: Check[] = [
       }
 
       const oldAssistantOnlyTracker =
-        'if(t.type!=="assistant")return;let o=t.message.usage;e.latestInputTokens=o.input_tokens+(o.cache_creation_input_tokens??0)+(o.cache_read_input_tokens??0),e.cumulativeOutputTokens+=o.output_tokens;';
-      return content.includes(oldAssistantOnlyTracker)
+        // 2.1.257 folds these two assignments into the head of an `if(...)` comma
+        // expression, so the trailing `;` is a `,` there. Match the assignments,
+        // not the statement boundary.
+        /if\([A-Za-z_$][\w$]*\.type!=="assistant"\)return;let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.message\.usage;(?:if\()?[A-Za-z_$][\w$]*\.latestInputTokens=\1\.input_tokens\+\(\1\.cache_creation_input_tokens\?\?0\)\+\(\1\.cache_read_input_tokens\?\?0\),[A-Za-z_$][\w$]*\.cumulativeOutputTokens\+=\1\.output_tokens[;,]/;
+      // .test, not .includes: a RegExp handed to includes() is stringified and
+      // never matches, which would silently disable this guard.
+      return oldAssistantOnlyTracker.test(content)
         ? "original assistant-only usage tracker is still present"
         : null;
     },
@@ -1022,7 +1032,10 @@ const CHECKS: Check[] = [
       // (`…messageId:Gr.id},i.storageV5)`), matched optionally so the patched
       // 2.1.237 and 2.1.238 binaries both verify.
       const batchWrapperPattern = new RegExp(
-        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\),(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\},requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
+        // 2.1.257 inserts statements between the destructuring and the message
+        // object, and adds fields to the object before `requestId`. Kept in
+        // lockstep with batchWrapperPattern in patch-claude-display.ts.
+        `let\\{content:(${identifier}),batchToolUses:(${identifier})\\}=(${identifier})\\((${identifier})\\(\\[(${identifier})\\],(${identifier}),(${identifier})\\.agentId,\\{requestId:(${identifier})\\?\\?void 0,messageId:(${identifier})\\.id\\}(?:,${identifier}(?:\\.${identifier})*)?\\),\\6(?:,(?:[^()]|\\([^()]*\\))*)?\\)(?:[^{}]|\\{[^{}]*\\})*?,(${identifier})=\\{message:\\{\\.\\.\\.\\9,content:\\1\\},\\.\\.\\.\\2\\.length>0&&\\{batchToolUses:\\2\\}(?:,[^{}]*(?:\\{[^{}]*\\})?)*?,requestId:\\8\\?\\?void 0,\\.\\.\\.(${identifier})\\(\\7\\.querySource,\\7\\.spawnedBySkill,\\7\\.activeSkill,\\7\\.activeMcpServer,\\7\\.activeMcpTool\\),type:"assistant",uuid:(${identifier})(?:\\.randomUUID)?\\(\\),timestamp:new Date\\(\\)\\.toISOString\\(\\),\\.\\.\\.!1,__calicoUsageState:\\{committed:!1,usage:null\\},\\.\\.\\.(${identifier})&&\\{advisorModel:\\13\\},\\.\\.\\.(${identifier})!==void 0&&\\{effort:(${identifier})\\}((?:,\\.\\.\\.\\{[^{}]*\\})*)\\};`,
         "g"
       );
       const wrapperMatches = [
@@ -1399,11 +1412,19 @@ const CHECKS: Check[] = [
         "CALICO_CONTEXT_DISPLAY_PERCENT",
         "__calico_context_window",
         "__calico_display_window",
-        "if(process.env.CALICO_MODEL_CONTEXT_WINDOWS)return",
       ];
       const missing = required.filter((marker) => !content.includes(marker));
       if (missing.length > 0) {
         return `missing marker(s): ${missing.join(", ")}`;
+      }
+      // The injected lookup reads the resolver's own first parameter, whose
+      // minified name changes between versions (2.1.257 renamed the second one),
+      // so pin the call shape rather than a literal `(e)`. Requiring the early
+      // return keeps this a check on the wiring, not just on the helper existing.
+      const injectedLookup =
+        /let __calico_window=__calico_context_window\(([A-Za-z_$][\w$]*)\);if\(__calico_window!==null\)return __calico_window;/;
+      if (!injectedLookup.test(content)) {
+        return "custom context-window lookup is not wired into the resolver";
       }
       // The effective-window gate reads `CALICO_MODEL_CONTEXT_WINDOWS?<window>:<window>-<reserve>`,
       // where both are minified locals that differ per platform build of the
@@ -1491,7 +1512,11 @@ const CHECKS: Check[] = [
       if (requiresRendererThreading) {
         // The renderer must declare the streamingThinking parameter…
         const rendererSignaturePattern =
-          /\(\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:[A-Za-z_$][\w$]*,/;
+          // 2.1.257 moved the destructuring out of the parameter list
+          // (`function f(p){let c=_(203),{messages:…}=p`), so the opener is a
+          // comma there and a paren before. Kept in lockstep with the anchors in
+          // patch-claude-display.ts.
+          /[(,]\{messages:[^}]*?streamingToolUses:[A-Za-z_$][\w$]*,streamingThinking:[A-Za-z_$][\w$]*,/;
         if (!rendererSignaturePattern.test(content)) {
           return "expected renderer signature to declare a streamingThinking parameter";
         }


### PR DESCRIPTION
The preflight gate caught 2.1.257 and refused to release, so nothing shipped broken. Four modules had drifted, and repairing them surfaced a fifth defect **that every existing check passed**.

## Pinned parameter names

`active-turn-prompt-id` and `custom-context-window` matched function headers as the literals `(e,t)` and emitted `e` verbatim in the injected code. Those are minified names, not syntax — 2.1.257 renamed the second to `n` and five matchers stopped matching at once. All now capture both parameters and backreference them.

The two modules failed **differently**, which is the part worth keeping:

| module | before | after | caught by `--assert-all`? |
| --- | --- | --- | --- |
| `active-turn-prompt-id` | 2/2 | 1/**0** | yes |
| `custom-context-window` | 4/4 | **1/1** | **no** — it only fails at zero |

That silent drop is also why I first concluded upstream had removed two call sites. All four were present the whole time.

## Three more shape changes

- **Fields inserted *before* existing ones.** `background-agent-usage` anchored on `cumulativeOutputTokens:0,recentActivities:`; 2.1.257 inserts three fields *between* them (earlier versions only ever appended after) and extends the total helper with `+e.streamedTokenEstimate`.
- **Assignments folded into an `if(...)`.** The same module keys everything off one accounting site, whose two assignments were folded into the head of an `if(...)` comma expression. The matcher required a statement ending in `;`, so the site vanished — and with it `eventName`, `progressPattern` and the rest of the module.
- **Statements inserted mid-shape.** `statusline-committed-usage` required the message object to follow the batch destructuring immediately; 2.1.257 puts bookkeeping in between and adds `wireToolInputs`/`apiBlockIndex` before `requestId`.

## The fifth defect: a patched binary that did not parse

Accepting the folded `if(` without re-emitting it left a **dangling `)`** — the replacement consumed the two assignments *and* the `if(` that opened the condition, while the condition's remainder and its closing paren stayed. The module stopped parsing; the binary died at startup with `SyntaxError: Unexpected token ')'`.

```
--assert-all              20/20        passed
verify-patched-binary     19 modules   passed
node suite                160 cases    passed
live-thinking (macOS)                  FAILED  ← the only one
```

Every passing check asks whether the expected constructs are **present**. None asks whether the output is still valid JavaScript. And the one that caught it runs on macos-arm64 only — the same drift on a Windows-only path would have shipped.

So the regression harness now **parses every Bun module** of the patched bundle with Bun's transpiler and diffs against the unpatched bundle, reporting only modules that broke under patching. Costs a few seconds; would have caught this immediately.

## Verifier, in lockstep

Tracker fields on both sides, the folded accounting form, the batch wrapper's inserted statements and fields, the renderer signature (2.1.257 moved it out of the parameter list into `function f(p){let c=_(203),{messages:…}=p`), and the context-window lookup — now checked by call shape rather than a literal `(e)`.

One verifier guard was also passing a **RegExp to `String.includes`**, where it is stringified and can never match. Switched to `.test`.

## Verification

```
regression 2.1.250 / 2.1.252 / 2.1.257  ×  linux-x64 + macos-arm64
  patch --assert-all · verify · (patched) marker · full-module parse
  18/18 PASS

2.1.257 macos-arm64   patch 20/20 (every module at its 2.1.252 count)
                      verify 19 modules clean
                      all 1640 Bun modules parse
node suite            160 passing
```

### Known gap, unchanged by this PR

The live-thinking integration test fails on 2.1.257 — but it fails **identically on the unpatched 2.1.257 binary**, so the mock endpoint is what 2.1.257 no longer accepts, not the patcher. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e