### PR TITLE
fix(thinking-streaming): patch the React-Compiler form of the inline extras memo

### DIFF
--- a/.github/workflows/patch-claude.yml
+++ b/.github/workflows/patch-claude.yml
@@ -368,25 +368,17 @@ jobs:
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: work/${{ matrix.patched_asset_name }}
-      # Reports, does not block. This test is the only check that can see live
-      # thinking actually rendering, and it runs on macos-arm64 only, so when it
-      # fails for a reason unrelated to the patcher it takes that one platform's
-      # release with it. That is what happened on 2.1.257 and 2.1.258: the client
-      # no longer renders thinking from this mock (the *unpatched* binary fails
-      # identically), yet macOS published nothing while four platforms shipped.
-      #
-      # Be clear about what this costs: there is NO pre-merge equivalent. The
-      # regression harness that runs this test is a local script, not CI, and no
-      # PR workflow sets CLAUDE_NATIVE_BINARY. So while this step is tolerated,
-      # a genuine live-thinking regression can reach a release. One cannot be
-      # added yet either: the test is currently red for environmental reasons, so
-      # gating PRs on it would block every PR. This is a deliberate, temporary
-      # reduction in coverage to stop shipping versions that exist for four
-      # platforms out of five — to be reverted once the mock incompatibility is
-      # understood and the test is green again.
+      # Blocking. This is the only check in the pipeline that can observe live
+      # thinking actually rendering, and it was right when everything else was
+      # wrong: on 2.1.257 it failed while --assert-all reported 20/20 and the
+      # verifier reported all 20 modules ok. It was briefly made non-blocking on
+      # the theory that the mock had gone stale, which was never established —
+      # the control was never run. Running it settles it: patched 2.1.252 passes,
+      # *unpatched* 2.1.252 fails, patched 2.1.257 fails. The mock was fine and
+      # the patch was dead, so 2.1.257 and 2.1.258 shipped without live thinking.
+      # Do not weaken this step again without that control in hand.
       - name: Test live thinking without credentials
         id: live_thinking
-        continue-on-error: true
         if: steps.check.outputs.skip != 'true' && matrix.platform_label == 'macos-arm64'
         env:
           CLAUDE_NATIVE_BINARY: work/${{ matrix.patched_asset_name }}
@@ -447,36 +439,6 @@ jobs:
             work/metadata.txt \
             work/checksums.txt \
             "$PATCHED_PATH"
-      # Placed after the release step: this message says the build published,
-      # and running it earlier would leave that claim standing in Discord even
-      # when a later step failed and nothing was released.
-      #
-      # continue-on-error leaves the job and the workflow successful, so the
-      # notify-failure job (if: failure()) never runs for this. Post to the
-      # webhook here or the failure is an Actions warning nobody reads.
-      - name: Report live-thinking result
-        if: steps.check.outputs.skip != 'true' && matrix.platform_label == 'macos-arm64'
-        env:
-          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          VERSION: ${{ steps.native.outputs.version }}
-        run: |
-          set -uo pipefail
-          if [ "${{ steps.live_thinking.outcome }}" = "success" ]; then
-            echo "live thinking verified on the patched binary"
-            exit 0
-          fi
-          echo "::warning title=live-thinking::The live-thinking integration test failed on this build. The release still published; live thinking is unverified for this version." >&2
-          if [ -n "${WEBHOOK:-}" ]; then
-            jq -n --arg v "$VERSION" --arg u "$RUN_URL" '{embeds:[{
-              title:"live thinking unverified (release still published)",
-              description:("macos-arm64 release for Claude " + $v + " published, but the live-thinking integration test failed. Check whether the mock endpoint or the patcher is at fault."),
-              url:$u, color:16098851}]}' \
-              | curl -sfS -X POST -H "content-type: application/json" -d @- "$WEBHOOK" >/dev/null \
-              || echo "::warning::could not post the live-thinking warning to Discord" >&2
-          fi
-
-
 
   # Failure notification to the community Discord's #github channel.
   # This lives INSIDE the pipeline because workflow_run cannot see these runs:

--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -1339,6 +1339,49 @@ function patchThinkingStreaming(content) {
         return `${extrasVar}=${memoCall}(()=>{let __cc_streamingToolUseExtras=${streamingToolUsesVar}.map((${toolUseEntryVar})=>{let{id:${toolUseIdVar},minted:${mintedVar}}=${resolveToolUseIdHelper}(${toolUseEntryVar}),${toolUseMessageVar}=${createMessageHelper}({content:[${mintedVar}?{...${toolUseEntryVar}.contentBlock,id:${toolUseIdVar}}:${toolUseEntryVar}.contentBlock]});return ${toolUseMessageVar}.uuid=${mintedVar}?${toolUseIdVar}:${createUUIDHelper}(${toolUseIdVar},0),{index:${toolUseEntryVar}.index??9007199254740991,messages:${normalizeMessagesHelper}([${toolUseMessageVar}])}}),__cc_streamingThinkingExtras=(${transcriptStreamingThinkingVar}?.messages??[]).map((__cc_entry,__cc_index)=>({index:__cc_entry.index??9007199254740991+__cc_index,messages:${normalizeMessagesHelper}([__cc_entry.message??__cc_entry])}));return[...__cc_streamingToolUseExtras,...__cc_streamingThinkingExtras].sort((__cc_a,__cc_b)=>__cc_a.index===__cc_b.index?0:__cc_a.index-__cc_b.index).flatMap((__cc_entry)=>__cc_entry.messages)},[${streamingToolUsesVar},${resolveToolUseIdHelper},${transcriptStreamingThinkingVar}])`;
       }
     );
+    // 2.1.257 runs this region through the React Compiler, so neither hand
+    // written shape above survives: the entry mapper is hoisted into its own
+    // memo slot and the `flatMap` into another, leaving no `memo(()=>…,[deps])`
+    // call to rewrite. Same construct, third spelling — match the compiled
+    // guard/mapper/flatMap triple instead.
+    const compiledInlineThinkingPattern = new RegExp(
+      `if\\((?<cache>${identifierPattern})\\[(?<g1>\\d+)\\]!==(?<resolver>${identifierPattern})\\|\\|\\k<cache>\\[(?<g2>\\d+)\\]!==(?<list>${identifierPattern})\\)\\{` +
+        `let (?<mapper>${identifierPattern});` +
+        `if\\(\\k<cache>\\[(?<g3>\\d+)\\]!==\\k<resolver>\\)\\k<mapper>=\\((?<entry>${identifierPattern})\\)=>\\{` +
+        `let\\{id:(?<id>${identifierPattern}),minted:(?<minted>${identifierPattern})\\}=\\k<resolver>\\(\\k<entry>\\);` +
+        `let (?<msg>${identifierPattern})=(?<create>${identifierPattern})\\(\\{content:\\[\\k<minted>\\?\\{\\.\\.\\.\\k<entry>\\.contentBlock,id:\\k<id>\\}:\\k<entry>\\.contentBlock\\]\\}\\);` +
+        `return \\k<msg>\\.uuid=\\k<minted>\\?\\k<id>:(?<uuid>${identifierPattern})\\(\\k<id>,0\\),(?<normalize>${identifierPattern})\\(\\[\\k<msg>\\]\\)\\},` +
+        `\\k<cache>\\[\\k<g3>\\]=\\k<resolver>,\\k<cache>\\[(?<g4>\\d+)\\]=\\k<mapper>;else \\k<mapper>=\\k<cache>\\[\\k<g4>\\];` +
+        `(?<result>${identifierPattern})=\\k<list>\\.flatMap\\(\\k<mapper>\\);` +
+        `\\k<cache>\\[\\k<g1>\\]=\\k<resolver>,\\k<cache>\\[\\k<g2>\\]=\\k<list>,\\k<cache>\\[(?<g5>\\d+)\\]=\\k<result>\\}else \\k<result>=\\k<cache>\\[\\k<g5>\\];`,
+      "g"
+    );
+    output = output.replace(compiledInlineThinkingPattern, (...args) => {
+      const g = args[args.length - 1];
+      inlineThinkingCandidates += 1;
+      inlineThinkingPatched += 1;
+      createVirtualMessageHelper = g.create;
+      // The compiler keyed this slot on the tool-use list and the id resolver
+      // only, and there is no slot left to key the thinking store on: growing
+      // the cache array means rewriting its `new Array(N)` literal, which moves
+      // every downstream index. Force the guard instead. The cost is that the
+      // merged list rebuilds each render of the transcript, which is what
+      // upstream did before it memoized this in 2.1.250.
+      return (
+        `if(!0||${g.cache}[${g.g1}]!==${g.resolver}||${g.cache}[${g.g2}]!==${g.list}){` +
+        `let ${g.mapper};` +
+        `if(${g.cache}[${g.g3}]!==${g.resolver})${g.mapper}=(${g.entry})=>{` +
+        `let{id:${g.id},minted:${g.minted}}=${g.resolver}(${g.entry});` +
+        `let ${g.msg}=${g.create}({content:[${g.minted}?{...${g.entry}.contentBlock,id:${g.id}}:${g.entry}.contentBlock]});` +
+        `return ${g.msg}.uuid=${g.minted}?${g.id}:${g.uuid}(${g.id},0),${g.normalize}([${g.msg}])},` +
+        `${g.cache}[${g.g3}]=${g.resolver},${g.cache}[${g.g4}]=${g.mapper};else ${g.mapper}=${g.cache}[${g.g4}];` +
+        `${g.result}=(()=>{let __cc_streamingToolUseExtras=${g.list}.map((__cc_entry)=>({index:__cc_entry.index??9007199254740991,messages:${g.mapper}(__cc_entry)})),` +
+        `__cc_streamingThinkingExtras=(${transcriptStreamingThinkingVar}?.messages??[]).map((__cc_entry,__cc_index)=>({index:__cc_entry.index??9007199254740991+__cc_index,messages:${g.normalize}([__cc_entry.message??__cc_entry])}));` +
+        `return[...__cc_streamingToolUseExtras,...__cc_streamingThinkingExtras].sort((__cc_a,__cc_b)=>__cc_a.index===__cc_b.index?0:__cc_a.index-__cc_b.index).flatMap((__cc_entry)=>__cc_entry.messages)})();` +
+        `${g.cache}[${g.g1}]=${g.resolver},${g.cache}[${g.g2}]=${g.list},${g.cache}[${g.g5}]=${g.result}}else ${g.result}=${g.cache}[${g.g5}];`
+      );
+    });
+
     candidates += inlineThinkingCandidates;
     patched += inlineThinkingPatched;
   }

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1662,8 +1662,19 @@ const CHECKS: Check[] = [
           version[0] > 2 ||
           (version[0] === 2 &&
             (version[1] > 1 || (version[1] === 1 && version[2] >= 246)));
+        // Pinned to the memo's full 2.1.245 spelling, this regex missed both
+        // later ones — the deduped `{id,minted}` shape and 2.1.257's
+        // React-Compiler output, where the mapper and the flatMap sit in
+        // separate cache slots and no `memo(()=>…)` call remains. Each time,
+        // the site was still there and still unpatched, and each time this
+        // waived it: 2.1.257 and 2.1.258 shipped with live thinking dead and
+        // every module reported ok. Match only the message construction at the
+        // core of the site, which all three spellings share and which nothing
+        // else in the bundle builds. This text also survives in patched output,
+        // which is harmless — the check is reached only when the extras marker
+        // is absent, i.e. only when the patch did not fire.
         const unpatchedExtrasMemo =
-          /=[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\(\)=>[A-Za-z_$][\w$]*\.flatMap\(\([A-Za-z_$][\w$]*\)=>\{let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{content:\[[A-Za-z_$][\w$]*\.contentBlock\]\}\)/;
+          /\(\{content:\[(?:[A-Za-z_$][\w$]*\?\{\.\.\.[A-Za-z_$][\w$]*\.contentBlock,id:[A-Za-z_$][\w$]*\}:)?[A-Za-z_$][\w$]*\.contentBlock\]\}\)/;
         let extrasWaived = false;
         if (!content.includes("__cc_streamingThinkingExtras")) {
           if (!allowsMissingExtras) {

--- a/tests/thinking-streaming-compiled-extras.test.js
+++ b/tests/thinking-streaming-compiled-extras.test.js
@@ -1,0 +1,73 @@
+// 2.1.257 ran the inline streaming-thinking extras memo through the React
+// Compiler. The mapper moved into one cache slot and the `flatMap` into
+// another, so the `memo(()=>list.flatMap(fn),[deps])` call the patcher rewrote
+// no longer exists in any form. Neither hand-written pattern matched, the
+// module's count fell from 13 to 12, and --assert-all only fails at zero — so
+// 2.1.257 and 2.1.258 shipped with live thinking dead. The verifier waived it
+// too: its unpatched-site regex was pinned to the 2.1.245 spelling, so a site
+// that was present and unpatched read as a site that no longer exists.
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { patchThinkingStreaming } = require("../patch-claude-display.ts");
+const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
+
+// The shape as it appears in 2.1.257, minified names and all.
+const compiledExtrasSite =
+  "let aT=fUt,bUt;if(Sl[31]!==aT||Sl[32]!==rQe){let CJ;if(Sl[34]!==aT)CJ=(aQe)=>{" +
+  "let{id:lQe,minted:kUt}=aT(aQe);" +
+  "let wUt=fu({content:[kUt?{...aQe.contentBlock,id:lQe}:aQe.contentBlock]});" +
+  "return wUt.uuid=kUt?lQe:AEe(lQe,0),cm([wUt])}," +
+  "Sl[34]=aT,Sl[35]=CJ;else CJ=Sl[35];" +
+  "bUt=rQe.flatMap(CJ);" +
+  "Sl[31]=aT,Sl[32]=rQe,Sl[33]=bUt}else bUt=Sl[33];let cQe=bUt,";
+
+// patchThinkingStreaming only reaches the inline-extras section once it has
+// resolved the transcript's streamingThinking local, which it reads off the
+// renderer signature it injected earlier in the same pass.
+const rendererSignature =
+  "streamingToolUses:x1,extra:1,streamingThinking:__cc_streamingThinking,streamingText:";
+
+test("the compiled 2.1.257 extras site is rewritten to merge streaming thinking", () => {
+  const result = patchThinkingStreaming(rendererSignature + compiledExtrasSite);
+
+  assert.ok(
+    result.content.includes("__cc_streamingThinkingExtras"),
+    "expected the merged extras construction to be injected"
+  );
+  // The merge has to be keyed on the thinking store, or the transcript keeps
+  // serving the cached tool-use-only list while thinking streams in.
+  assert.match(result.content, /__cc_streamingThinking\?\.messages\?\?\[\]/);
+  // The compiler keyed the outer slot on the tool-use list and the resolver
+  // only. Without forcing it, the rewritten body never runs.
+  assert.ok(
+    result.content.includes("if(!0||Sl[31]!==aT||Sl[32]!==rQe)"),
+    "expected the owning memo guard to be forced"
+  );
+  // The mapper's own memo slot must survive untouched: rebuilding it per render
+  // would give every tool-use entry a fresh identity downstream.
+  assert.ok(
+    result.content.includes("if(Sl[34]!==aT)CJ=(aQe)=>{"),
+    "expected the inner mapper memo to be left intact"
+  );
+  assert.ok(result.content.includes("Sl[33]=bUt}else bUt=Sl[33];"));
+
+  const output = patchThinkingStreaming(rendererSignature + compiledExtrasSite).content;
+  assert.ok(!output.includes("bUt=rQe.flatMap(CJ);"), "expected the bare flatMap to be replaced");
+});
+
+test("the verifier rejects a compiled extras site left unpatched", () => {
+  // Everything else the module wants is present and correct; only the extras
+  // site is unpatched. This is the exact binary that shipped as 2.1.257.
+  const bundle =
+    'PACKAGE_URL:"@anthropic-ai/claude-code",VERSION:"2.1.257" __cc_streamingThinking ' +
+    'if(a?.type==="thinking"||a?.type==="redacted_thinking")return!0;if(a?.type==="tool_use" ' +
+    "({messages:e,streamingToolUses:a,streamingThinking:__cc_streamingThinking, " +
+    "screen:l,streamingToolUses:c,streamingThinking:ds, " +
+    compiledExtrasSite;
+
+  assert.match(
+    evaluatePatchModule("thinking-streaming", bundle),
+    /transcript extras site is present but was not patched/
+  );
+});


### PR DESCRIPTION
2.1.257 and 2.1.258 shipped with live thinking dead. The transcript never
rendered streamed thinking; it appeared only when the turn completed, which is
the symptom originally reported against this repository.

Root cause. `patchThinkingStreaming` rewrites the memo that materialises
streamed content into the transcript — the one that maps streaming tool uses
into virtual messages — so that it also folds in the streaming thinking store
and sorts the two by index. It knew two spellings of that memo: the 2.1.245
`memo(()=>list.flatMap((e)=>{let m=create({content:[e.contentBlock]})…}),[…])`
and the later deduped `{id,minted}` variant. 2.1.257 ran the region through the
React Compiler. The entry mapper is hoisted into its own cache slot
(`if(Sl[34]!==aT)CJ=(aQe)=>{…},Sl[34]=aT,Sl[35]=CJ;else CJ=Sl[35];`) and the
`flatMap` into another (`if(Sl[31]!==aT||Sl[32]!==rQe){…bUt=rQe.flatMap(CJ);…}`),
leaving no `memo(()=>…)` call to rewrite. Neither pattern matched, the module's
count fell from 13 to 12, and the site went out unpatched.

Added a third matcher for the compiled triple — guard, hoisted mapper, flatMap —
that re-emits the mapper memo verbatim and replaces only the `flatMap` with the
merged tool-use + streaming-thinking construction the other two shapes produce.
The compiler keyed the outer slot on the tool-use list and the id resolver only,
and there is no free slot to key the thinking store on: claiming one means
rewriting the cache array's `new Array(N)` literal and shifting every downstream
index. The guard is forced with `!0||` instead, as sticky-prompt-header already
does. The cost is that the merged list rebuilds each render of the transcript,
which is what upstream did before it memoized this in 2.1.250.

Why nothing caught it. Three checks looked at this build and all three passed.
`--assert-all` only fails at zero patches, so 13 -> 12 is invisible to it. The
verifier has a check for exactly this — an unpatched extras site must fail even
on 2.1.246+, where the site is allowed to be absent — but its unpatched-shape
regex was pinned to the full 2.1.245 spelling and matched neither later form, so
a site that was present and unpatched read as a site that no longer exists. Its
own comment predicted this ("relaxing on the absence of an exact unpatched-shape
regex would let a bundle whose shape merely drifted pass") and it happened
twice. That regex now matches only the message construction at the core of the
site, `({content:[<minted?{...e.contentBlock,id}:>e.contentBlock]})`, which all
three spellings share and nothing else in the bundle builds. The text survives
in patched output, which is harmless: the check is reached only when the extras
marker is absent, i.e. only when the patch did not fire.

The third check was the live-thinking integration test, which was correct all
along. It was made non-blocking on the theory that the mock had gone stale after
2.1.257 added `HEAD /api/hello` — a theory never tested, because the control was
never run. Running it settles it: patched 2.1.252 passes, *unpatched* 2.1.252
fails, patched 2.1.257 fails. The mock was fine and the patch was dead. The step
is blocking again, and the comment records the control so the next person does
not re-derive it. The `Report live-thinking result` step is removed with it: its
failure branch is unreachable once the step blocks, and notify-failure already
posts to the same webhook.

Verification. Regression over seven macos-arm64 bundles — 2.1.246, .247, .248,
.250, .252, .257, .258 — each patched from its original, code-signed, verified,
and driven through the live-thinking mock end to end: thinking-streaming patched
13 (14 on .246), zero verifier failures, and live-thinking PASS on all seven.
2.1.257 goes from a 25s timeout to passing in 2.35s. Both new unit tests were
confirmed to fail with the two fixes stashed, not merely to pass with them;
162 unit tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e