### PR TITLE
docs(local-auto-update): add a launchd timer for the update hook

### DIFF
--- a/.github/workflows/watch-claude-release.yml
+++ b/.github/workflows/watch-claude-release.yml
@@ -168,7 +168,12 @@ jobs:
           # reach the binary. Of everything under .github/, only patch-claude.yml
           # is part of the build definition — it runs the patcher and sets
           # DISABLED_MODULES. The rest decide when to build, or do not build.
-          NON_BUILD_PATHS='^(docs/|test/|tests/|tools/local-verify/|tools/watch-poke\.sh$|scripts/verify-patched-binary\.ts$|install-patched-claude\.|\.github/|bun\.lock$|\.gitignore$|.*\.md$)'
+          # examples/ holds material for running Calico on your own machine; the
+          # patch pipeline never reads it. The `.md` rule already covered every
+          # file there until a LaunchAgent plist was added, which would have
+          # rebuilt all five platforms for a file launchd reads and the patcher
+          # cannot see. Exclude the directory, not each new extension in turn.
+          NON_BUILD_PATHS='^(docs/|examples/|test/|tests/|tools/local-verify/|tools/watch-poke\.sh$|scripts/verify-patched-binary\.ts$|install-patched-claude\.|\.github/|bun\.lock$|\.gitignore$|.*\.md$)'
           BUILD_WORKFLOW='.github/workflows/patch-claude.yml'
           STALE=0
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ The official updater can install a new version and repoint the `claude` symlink 
 binary. The renamed Calico binary is immune to that, but it also stops receiving updates.
 
 [`examples/local-auto-update/`](./examples/local-auto-update/) closes that gap: a SessionStart hook
-that checks at most hourly and never blocks startup. Before anything is installed it verifies the
+that checks at most hourly and never blocks startup, plus an optional launchd timer for macOS —
+without one, a release published while you are not starting sessions waits until you next do.
+Before anything is installed it verifies the
 release checksum, and — when an authenticated `gh` is available — the build provenance attestation;
 without `gh` it logs a warning and proceeds on the checksum alone, so provenance is not a guarantee
 in that configuration. The downloaded build is then run and must report the exact expected version

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -120,11 +120,20 @@ that to at most an hour.
 
 ```bash
 mkdir -p ~/Library/LaunchAgents ~/Library/Logs
-sed "s|__HOME__|$HOME|g" examples/local-auto-update/com.calico.auto-update.plist \
-  > ~/Library/LaunchAgents/com.calico.auto-update.plist
+python3 - <<'PY' > ~/Library/LaunchAgents/com.calico.auto-update.plist
+import html, os
+tpl = open("examples/local-auto-update/com.calico.auto-update.plist").read()
+print(tpl.replace("__HOME__", html.escape(os.environ["HOME"], quote=False)), end="")
+PY
 plutil -lint ~/Library/LaunchAgents/com.calico.auto-update.plist
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.calico.auto-update.plist
 ```
+
+Python rather than `sed` because `&`, `<`, `>` and `|` are all legal in a macOS
+home path and all mean something to one of the two layers involved. `sed` reads
+`&` in a replacement as the whole match, so `HOME=/Users/a&b` writes
+`/Users/a__HOME__b` into valid XML that `plutil` and launchd both accept — a job
+pointed at a path that does not exist, with nothing to indicate why.
 
 If you track a fork, edit `CALICO_REPO` in the plist before loading it — and add
 any other `CALICO_*` override you rely on next to it. launchd starts the agent
@@ -189,6 +198,20 @@ left alone for a few months will quietly consume several gigabytes.
 provenance attestation cannot be checked and the script logs a warning and
 proceeds on the checksum alone. The checksum proves the file matches the release
 asset; the attestation proves the release asset came out of this repo's CI.
+
+The launchd timer needs that authentication to be **persistent** — `gh auth
+login`, which stores the credential on disk. launchd starts the agent with a
+clean environment, so a `GH_TOKEN` or `GITHUB_TOKEN` exported in your shell
+never reaches it: `gh auth status` fails there, every scheduled install skips
+attestation, and the job still exits 0. Do not work around that by putting a
+token in the plist — `~/Library/LaunchAgents` is not a credential store.
+
+The agent's log says which happened, the next time it actually installs
+something:
+
+```bash
+grep -E 'Attestation verified|gh unavailable' ~/Library/Logs/calico-auto-update.log
+```
 
 ## Verify it works
 

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -119,11 +119,16 @@ began. [`com.calico.auto-update.plist`](./com.calico.auto-update.plist) closes
 that to at most an hour.
 
 ```bash
+mkdir -p ~/Library/LaunchAgents ~/Library/Logs
 sed "s|__HOME__|$HOME|g" examples/local-auto-update/com.calico.auto-update.plist \
   > ~/Library/LaunchAgents/com.calico.auto-update.plist
 plutil -lint ~/Library/LaunchAgents/com.calico.auto-update.plist
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.calico.auto-update.plist
 ```
+
+If you track a fork, edit `CALICO_REPO` in the plist before loading it — and add
+any other `CALICO_*` override you rely on next to it. launchd starts the agent
+with a clean environment, so what you export in your shell does not reach it.
 
 `RunAtLoad` makes it run immediately, so you can read the result rather than
 assume it:
@@ -133,11 +138,13 @@ launchctl list | grep com.calico.auto-update   # second column is the last exit 
 tail ~/Library/Logs/calico-auto-update.log
 ```
 
-Three choices in that file are deliberate, and the comments say why: it calls
-`--run` rather than `--hook`, it sets `PATH`, and it logs somewhere other than
-`update.log`. The `PATH` one is the least obvious — without it `gh` is not on
-the timer's path, so every run installs on the checksum alone and skips
-attestation, while still exiting 0.
+Four choices in that file are deliberate, and the comments say why: it calls
+`--run` rather than `--hook`, it sets `PATH`, it writes `CALICO_REPO` out
+explicitly, and it logs somewhere other than `update.log`. The middle two both
+exist because launchd hands the agent a clean environment, and both fail
+quietly: without `PATH`, `gh` is missing and every run installs on the checksum
+alone with attestation skipped; without `CALICO_REPO`, a fork's timer checks the
+upstream repo. Neither shows up as a failed job.
 
 The timer does not touch the `last-check` stamp, so the SessionStart hook keeps
 its own schedule. Both can check within the same hour; the cost is one extra

--- a/examples/local-auto-update/README.md
+++ b/examples/local-auto-update/README.md
@@ -110,6 +110,42 @@ stdin payload. `async: true` plus the short timeout are belt and braces.
 
 An updated binary is picked up by the **next** session, not the running one.
 
+**4. Optional — add a launchd timer (macOS).**
+
+The hook only fires when a session starts, so a release published while you are
+not opening sessions waits. Observed on one machine: `v2.1.258-macos-arm64`
+published at 08:08 local and was installed at 12:00, the next time a session
+began. [`com.calico.auto-update.plist`](./com.calico.auto-update.plist) closes
+that to at most an hour.
+
+```bash
+sed "s|__HOME__|$HOME|g" examples/local-auto-update/com.calico.auto-update.plist \
+  > ~/Library/LaunchAgents/com.calico.auto-update.plist
+plutil -lint ~/Library/LaunchAgents/com.calico.auto-update.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.calico.auto-update.plist
+```
+
+`RunAtLoad` makes it run immediately, so you can read the result rather than
+assume it:
+
+```bash
+launchctl list | grep com.calico.auto-update   # second column is the last exit status
+tail ~/Library/Logs/calico-auto-update.log
+```
+
+Three choices in that file are deliberate, and the comments say why: it calls
+`--run` rather than `--hook`, it sets `PATH`, and it logs somewhere other than
+`update.log`. The `PATH` one is the least obvious — without it `gh` is not on
+the timer's path, so every run installs on the checksum alone and skips
+attestation, while still exiting 0.
+
+The timer does not touch the `last-check` stamp, so the SessionStart hook keeps
+its own schedule. Both can check within the same hour; the cost is one extra
+release lookup.
+
+Remove it with `launchctl bootout gui/$(id -u)/com.calico.auto-update` and
+deleting the plist.
+
 ## Modes
 
 | Mode | Effect |

--- a/examples/local-auto-update/com.calico.auto-update.plist
+++ b/examples/local-auto-update/com.calico.auto-update.plist
@@ -8,10 +8,11 @@
     <string>/bin/bash</string>
     <!-- launchd does not expand ~ or $HOME here. Substitute your own path. -->
     <string>__HOME__/.claude/calico/update.sh</string>
-    <!-- --run, not --hook: --hook spawns a detached child and exits 0
-         immediately, so launchd would record success for a job whose real work
-         it can neither wait for nor report on. --run does the work in the
-         foreground, so the exit status and the output belong to the job. -->
+    <!-- Run mode, not hook mode. Hook mode stamps the throttle file, spawns a
+         detached child through nohup, and exits 0 at once; launchd would then
+         record success for work it never waited for and cannot report on. Run
+         mode does the work in the foreground, so the exit status and the log
+         describe the actual update. -->
     <string>--run</string>
   </array>
   <key>EnvironmentVariables</key>
@@ -21,9 +22,18 @@
          /usr/bin/python3), but gh does not: `command -v gh` fails, the script
          logs "gh unavailable or not authenticated; skipping attestation
          verification", and installs on the checksum alone. The job still exits
-         0, so the downgrade is silent. Point PATH at wherever gh lives —
-         /opt/homebrew/bin on Apple Silicon, /usr/local/bin on Intel. -->
-    <key>PATH</key><string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+         0, so the downgrade is silent. Both Homebrew prefixes are listed —
+         /opt/homebrew/bin on Apple Silicon, /usr/local/bin on Intel — so this
+         entry needs no editing per machine. -->
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <!-- launchd starts the agent with a clean environment, so every CALICO_*
+         override you set in your shell is absent here and update.sh falls back
+         to its defaults. The repo is the one that matters: left implicit, a
+         timer installed by someone tracking a fork would quietly check and
+         install from the upstream repo instead. It is written out rather than
+         left to a default so the target is visible in the installed file.
+         Add any other CALICO_* override you rely on alongside it. -->
+    <key>CALICO_REPO</key><string>Nanako0129/calico-claude</string>
   </dict>
   <key>StartInterval</key><integer>3600</integer>
   <key>RunAtLoad</key><true/>

--- a/examples/local-auto-update/com.calico.auto-update.plist
+++ b/examples/local-auto-update/com.calico.auto-update.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.calico.auto-update</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <!-- launchd does not expand ~ or $HOME here. Substitute your own path. -->
+    <string>__HOME__/.claude/calico/update.sh</string>
+    <!-- --run, not --hook: --hook spawns a detached child and exits 0
+         immediately, so launchd would record success for a job whose real work
+         it can neither wait for nor report on. --run does the work in the
+         foreground, so the exit status and the output belong to the job. -->
+    <string>--run</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- launchd's default PATH is /usr/bin:/bin:/usr/sbin:/sbin, and update.sh
+         sets no PATH of its own. python3 survives that (macOS ships
+         /usr/bin/python3), but gh does not: `command -v gh` fails, the script
+         logs "gh unavailable or not authenticated; skipping attestation
+         verification", and installs on the checksum alone. The job still exits
+         0, so the downgrade is silent. Point PATH at wherever gh lives —
+         /opt/homebrew/bin on Apple Silicon, /usr/local/bin on Intel. -->
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>StartInterval</key><integer>3600</integer>
+  <key>RunAtLoad</key><true/>
+  <!-- Deliberately not update.log: update.sh rotates that file itself, and a
+       launchd-held descriptor would keep writing into the renamed inode. -->
+  <key>StandardOutPath</key><string>__HOME__/Library/Logs/calico-auto-update.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/Library/Logs/calico-auto-update.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
The SessionStart hook only checks when a session starts, so a release published
while nobody opens one waits. Measured on one machine: v2.1.258-macos-arm64
published at 08:08 local and the hook installed it at 12:00, the next time a
session began — a 3h52m gap with the release sitting there the whole time.

Adds examples/local-auto-update/com.calico.auto-update.plist, a StartInterval
3600 LaunchAgent calling update.sh, plus an Install step 4 covering the sed
substitution (launchd expands neither ~ nor $HOME in ProgramArguments), plutil
lint, bootstrap, and how to read the result. The top-level README's one-line
description of the example now mentions the timer and the lag it removes.

Three choices in the plist are load-bearing and carry their reasons inline.

It calls --run, not --hook. --hook stamps the throttle file, spawns a detached
--run via nohup, and exits 0 immediately; under launchd that means the job
reports success for work it neither waited for nor can report on, and a child
that outlives its job is not something to rely on. --run does the work in the
foreground, so the exit status in `launchctl list` and the output in the log
both describe the actual update.

It sets PATH. This was measured rather than assumed, and the first assumption
was wrong: the guess was that python3 would be missing, but macOS ships
/usr/bin/python3 and `--check` runs fine under launchd's default
/usr/bin:/bin:/usr/sbin:/sbin. gh is the one that disappears. update.sh gates
attestation on `command -v gh && gh auth status`, so on the default PATH every
run logs "gh unavailable or not authenticated; skipping attestation
verification" and installs on the checksum alone — while still exiting 0. The
degradation is silent and security-relevant, which is why the PATH entry is not
optional tidiness.

It logs to ~/Library/Logs/calico-auto-update.log rather than update.log.
update.sh rotates update.log itself; a descriptor launchd holds across that
rename would keep writing into the orphaned inode.

The timer does not write last-check, so the SessionStart hook keeps its own
throttle and the two can both check within an hour. That costs one extra
release lookup and cannot produce a wrong install: --run re-reads the installed
version each time.

Verified by installing the generated plist on macOS 26 (arm64) and observing it
work, not by inspection: plutil lint passes, `launchctl bootstrap` loads it,
RunAtLoad fires immediately, and the log shows the run resolving the release and
declining to act —

    2026-09-02 13:24:00 [calico] Installed version: 2.1.258 (macos-arm64)
    2026-09-02 13:24:01 [calico] Latest release: 2.1.258 (tag v2.1.258-macos-arm64)
    2026-09-02 13:24:01 [calico] up to date; nothing to do. Exiting.

with exit status 0 in `launchctl list`. The committed example was then rendered
through the documented sed command and diffed against that working file: the
key/value payloads are identical, only comments differ. The hourly repeat is
StartInterval configuration and has not been observed firing a second time.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e