### PR TITLE
fix(verify): stop requiring PATH to sit next to the gateway locator

### DIFF
--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -616,6 +616,21 @@ const CHECKS: Check[] = [
         return "shared locator is detached from the worker/respawn dispatch record";
       }
       const dispatchRecord = dispatchRecords[0];
+      // Object spreads are last-write-wins, and the containment checks above
+      // only establish where the injection sits — not that it survives to the
+      // end of the object. A later spread assigning the same key, e.g.
+      // `...{CALICO_GATEWAY_FAST_STATE_FILE:void 0}`, would silently win and
+      // every worker would come up without the shared locator. Requiring the
+      // key to be written exactly once inside this env object is the property
+      // itself rather than a proxy for it; the injection writes it once.
+      const envObject = workerSegment.slice(
+        dispatchRecord.envIndex,
+        dispatchRecord.envEnd + 1
+      );
+      const locatorWrites = envObject.split("CALICO_GATEWAY_FAST_STATE_FILE:").length - 1;
+      if (locatorWrites !== 1) {
+        return `expected the worker env to assign the shared locator once, found ${locatorWrites}`;
+      }
       const dispatchRecordLocal = dispatchRecord.match[1];
       // 2.1.239 appended arguments to the dispatch call; accept a trailing
       // argument list one level of call nesting deep, matching the patcher.

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -627,9 +627,20 @@ const CHECKS: Check[] = [
         dispatchRecord.envIndex,
         dispatchRecord.envEnd + 1
       );
-      const locatorWrites = envObject.split("CALICO_GATEWAY_FAST_STATE_FILE:").length - 1;
-      if (locatorWrites !== 1) {
-        return `expected the worker env to assign the shared locator once, found ${locatorWrites}`;
+      //
+      // Count the bare name, not `NAME:`. A quoted key — `{"CALICO_GATEWAY_
+      // FAST_STATE_FILE":void 0}` — puts a quote between the name and the
+      // colon and slips past a `NAME:` count while overwriting the value just
+      // the same. The locator pattern above pins the injection to
+      // `...X.NAME&&{NAME:X.NAME}`, which mentions it three times, and the name
+      // is ours: nothing upstream has any reason to write it in this object, so
+      // anything beyond those three means something else is touching the key.
+      //
+      // A computed key holding the name in a variable would still pass. No scan
+      // of the text can see that one; it is named here rather than implied away.
+      const locatorMentions = envObject.split("CALICO_GATEWAY_FAST_STATE_FILE").length - 1;
+      if (locatorMentions !== 3) {
+        return `expected the worker env to mention the shared locator 3 times, found ${locatorMentions}`;
       }
       const dispatchRecordLocal = dispatchRecord.match[1];
       // 2.1.239 appended arguments to the dispatch call; accept a trailing

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -532,8 +532,20 @@ const CHECKS: Check[] = [
         return "request-time mode application is not between native parsing and beta merge";
       }
 
+      // Locator only. What proves the injection landed correctly is the
+      // structural work below: this offset has to sit inside the `env:{…}` of a
+      // dispatch record carrying proto/short/sessionId and respawnFlags, with
+      // the env object nested inside the record. The patcher guarantees the
+      // CALICO entry follows CLAUDE_CODE_EXTRA_BODY and reads the same source
+      // object, so those two are the anchor.
+      //
+      // This used to require `...X.PATH&&{PATH:X.PATH}` immediately after as
+      // well. That neighbour proved nothing the containment check did not, and
+      // 2.1.259 broke it by emitting `...{},` between the CALICO entry and PATH
+      // — a cosmetic empty spread. The patch was correct and the verifier
+      // failed it. A redundant check can still be wrong, and this one was.
       const workerPattern = new RegExp(
-        `\\.\\.\\.(${identifier})\\.CLAUDE_CODE_EXTRA_BODY&&\\{CLAUDE_CODE_EXTRA_BODY:\\1\\.CLAUDE_CODE_EXTRA_BODY\\},\\.\\.\\.\\1\\.CALICO_GATEWAY_FAST_STATE_FILE&&\\{CALICO_GATEWAY_FAST_STATE_FILE:\\1\\.CALICO_GATEWAY_FAST_STATE_FILE\\},\\.\\.\\.\\1\\.PATH&&\\{PATH:\\1\\.PATH\\}`,
+        `\\.\\.\\.(${identifier})\\.CLAUDE_CODE_EXTRA_BODY&&\\{CLAUDE_CODE_EXTRA_BODY:\\1\\.CLAUDE_CODE_EXTRA_BODY\\},\\.\\.\\.\\1\\.CALICO_GATEWAY_FAST_STATE_FILE&&\\{CALICO_GATEWAY_FAST_STATE_FILE:\\1\\.CALICO_GATEWAY_FAST_STATE_FILE\\}`,
         "g"
       );
       const workerMatches = [...content.matchAll(workerPattern)];

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -513,15 +513,24 @@ test("binary verifier accepts an unrelated spread between the locator and PATH",
 test("binary verifier rejects a later spread that overwrites the worker locator", () => {
   const patched = patchGatewayFastMode(fixture).content;
 
-  const overwritten = patched.replace(
-    "...ye.PATH&&{PATH:ye.PATH}",
-    "...ye.PATH&&{PATH:ye.PATH},...{CALICO_GATEWAY_FAST_STATE_FILE:void 0}"
-  );
-  assert.notEqual(overwritten, patched);
-  assert.match(
-    evaluatePatchModule("gateway-fast-mode", overwritten),
-    /assign the shared locator once, found 2/
-  );
+  // Both spellings of the same overwrite. The quoted one is why the check
+  // counts the bare name: a quote between the name and the colon slips past a
+  // `NAME:` count while overwriting the value just the same.
+  for (const key of [
+    "CALICO_GATEWAY_FAST_STATE_FILE",
+    '"CALICO_GATEWAY_FAST_STATE_FILE"',
+  ]) {
+    const overwritten = patched.replace(
+      "...ye.PATH&&{PATH:ye.PATH}",
+      `...ye.PATH&&{PATH:ye.PATH},...{${key}:void 0}`
+    );
+    assert.notEqual(overwritten, patched);
+    assert.match(
+      evaluatePatchModule("gateway-fast-mode", overwritten),
+      /mention the shared locator 3 times, found 4/,
+      key
+    );
+  }
 
   // Outside this worker env the same text is not an overwrite and must not trip
   // the check — otherwise the guard fires on unrelated drift.

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -507,6 +507,28 @@ test("binary verifier accepts an unrelated spread between the locator and PATH",
   assert.notEqual(evaluatePatchModule("gateway-fast-mode", detachedFromExtraBody), null);
 });
 
+// Spreads are last-write-wins, so an intervening spread is only harmless while
+// nothing after it reassigns the key. Locating the injection does not prove it
+// survives to the end of the object.
+test("binary verifier rejects a later spread that overwrites the worker locator", () => {
+  const patched = patchGatewayFastMode(fixture).content;
+
+  const overwritten = patched.replace(
+    "...ye.PATH&&{PATH:ye.PATH}",
+    "...ye.PATH&&{PATH:ye.PATH},...{CALICO_GATEWAY_FAST_STATE_FILE:void 0}"
+  );
+  assert.notEqual(overwritten, patched);
+  assert.match(
+    evaluatePatchModule("gateway-fast-mode", overwritten),
+    /assign the shared locator once, found 2/
+  );
+
+  // Outside this worker env the same text is not an overwrite and must not trip
+  // the check — otherwise the guard fires on unrelated drift.
+  const elsewhere = patched + ";var unrelated={CALICO_GATEWAY_FAST_STATE_FILE:1};";
+  assert.equal(evaluatePatchModule("gateway-fast-mode", elsewhere), null);
+});
+
 test("binary verifier rejects detached helpers and broken gateway ownership", () => {
   const patched = patchGatewayFastMode(fixture).content;
   const helperStart = patched.indexOf("var __calicoGatewayFastNode=");

--- a/tests/gateway-fast-mode.test.js
+++ b/tests/gateway-fast-mode.test.js
@@ -480,6 +480,33 @@ test("binary verifier accepts the complete gateway fast-mode structure", () => {
   );
 });
 
+// 2.1.259 emitted a bare `...{},` between the injected CALICO entry and PATH in
+// the worker env — a cosmetic empty spread that changes nothing. The verifier
+// had required the two to be textually adjacent and failed a correct patch,
+// which would have blocked the release on every platform. Position is proved by
+// the containment checks (inside the env of a dispatch record carrying
+// respawnFlags), not by whichever spread happens to come next.
+test("binary verifier accepts an unrelated spread between the locator and PATH", () => {
+  const patched = patchGatewayFastMode(fixture).content;
+  assert.equal(evaluatePatchModule("gateway-fast-mode", patched), null);
+
+  const withInterveningSpread = patched.replace(
+    "...ye.PATH&&{PATH:ye.PATH}",
+    "...{},...ye.PATH&&{PATH:ye.PATH}"
+  );
+  assert.notEqual(withInterveningSpread, patched);
+  assert.equal(evaluatePatchModule("gateway-fast-mode", withInterveningSpread), null);
+
+  // The relaxation must not reach the injected entry itself: detaching it from
+  // CLAUDE_CODE_EXTRA_BODY still has to fail.
+  const detachedFromExtraBody = withInterveningSpread.replace(
+    "...ye.CALICO_GATEWAY_FAST_STATE_FILE&&",
+    "...{},...ye.CALICO_GATEWAY_FAST_STATE_FILE&&"
+  );
+  assert.notEqual(detachedFromExtraBody, withInterveningSpread);
+  assert.notEqual(evaluatePatchModule("gateway-fast-mode", detachedFromExtraBody), null);
+});
+
 test("binary verifier rejects detached helpers and broken gateway ownership", () => {
   const patched = patchGatewayFastMode(fixture).content;
   const helperStart = patched.indexOf("var __calicoGatewayFastNode=");


### PR DESCRIPTION
2.1.259 cannot be released without this. The patcher applies cleanly — 20/20
modules, gateway-fast-mode 6/6 — but `Verify patched bundle` fails with "worker
dispatch does not propagate exactly one shared-state locator", and that step
runs on every platform leg, so all five would fail before publishing anything.

The patch is correct and the verifier is wrong. Upstream now emits a bare
`...{},` in the worker env spread list, between the injected entry and PATH:

    2.1.258  ...a.CLAUDE_CODE_EXTRA_BODY&&{…},...a.PATH&&{PATH:a.PATH},
    2.1.259  ...a.CLAUDE_CODE_EXTRA_BODY&&{…},...{},...a.PATH&&{PATH:a.PATH},

An empty spread contributes nothing at runtime. The injection still lands where
it belongs, immediately after CLAUDE_CODE_EXTRA_BODY and reading the same source
object, confirmed by dumping the patched 2.1.259 bundle.

The locator regex had demanded all three spreads be textually adjacent. Only the
first two are the patcher's guarantee; the PATH neighbour was incidental. And it
proved nothing the code below it does not already prove structurally: that
offset must fall inside the `env:{…}` of a dispatch record carrying
proto/short/sessionId and respawnFlags, with the env object nested inside the
record — checks that survive an unrelated spread appearing anywhere in the list.
A redundant check can still be wrong, and this one failed in the direction that
blocks a release for a cosmetic upstream change. Dropped rather than loosened
with a wildcard, which would have re-admitted the drift class next time.

Regression over four macos-arm64 bundles — 2.1.252, .257, .258, .259 — each
patched from its original, code-signed, verified and driven through the
live-thinking mock: thinking-streaming 13, zero verifier failures, live-thinking
PASS, correct version and `(patched)` on startup for all four. Negative control
held: unpatched 2.1.259 still fails gateway-fast-mode.

The new test mirrors the exact 2.1.259 shape and was confirmed to fail with the
verifier change stashed. It also asserts the relaxation did not reach the
injected entry itself — detaching it from CLAUDE_CODE_EXTRA_BODY must still be
rejected. 163 unit tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e