### PR TITLE
fix(watch-poke): do not read a failed release lookup as a missing release

### DIFF
--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -111,9 +111,26 @@ if [ -z "$VERSION" ]; then
   exit 0
 fi
 
+# One listing, then match locally. `gh release view` exits non-zero for a tag
+# that does not exist AND for a lookup that could not be answered — a network
+# blip, a rate limit, a 5xx — and prints "release not found" either way, so
+# there is nothing in it to tell the two apart. Treating both as "missing" makes
+# a failed API call dispatch a five-platform rebuild. That fired at
+# 2026-09-03T01:37:29Z; only the dispatch call failing too kept it from
+# rebuilding, which is luck, not design.
+#
+# `gh release list` fails as a unit and says why, so its exit status carries the
+# distinction. Releases come back newest-first and the version we ask about is
+# the newest, so its tags sit at the top; the limit only needs to clear the
+# rebuild suffixes of recent versions.
+if ! RELEASE_TAGS="$(gh release list --repo "$REPO" --limit 60 --json tagName --jq '.[].tagName' 2>/dev/null)"; then
+  log "could not list releases for $REPO; skipping this tick"
+  exit 0
+fi
+
 MISSING=0
 for suffix in "${PLATFORMS[@]}"; do
-  if ! gh release view "v${VERSION}-${suffix}" --repo "$REPO" >/dev/null 2>&1; then
+  if ! printf '%s\n' "$RELEASE_TAGS" | grep -qxF "v${VERSION}-${suffix}"; then
     MISSING=1
     break
   fi

--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -119,11 +119,17 @@ fi
 # 2026-09-03T01:37:29Z; only the dispatch call failing too kept it from
 # rebuilding, which is luck, not design.
 #
-# `gh release list` fails as a unit and says why, so its exit status carries the
-# distinction. Releases come back newest-first and the version we ask about is
-# the newest, so its tags sit at the top; the limit only needs to clear the
-# rebuild suffixes of recent versions.
-if ! RELEASE_TAGS="$(gh release list --repo "$REPO" --limit 60 --json tagName --jq '.[].tagName' 2>/dev/null)"; then
+# A paginated listing fails as a unit and reports why, so its exit status
+# carries the distinction the per-tag check could not express.
+#
+# Paginated rather than a capped `--limit`, because any cap is a bet on
+# position. Releases come back newest-first, and each rebuild of the current
+# version adds five entries ahead of that version's base tags: twelve rebuilds
+# push them past a limit of 60. The base tags would then read as missing and the
+# agent would dispatch every hour until upstream moved — the same "cannot tell
+# absent from unseen" mistake this commit is fixing, one layer out. Fetching all
+# of them costs seconds once an hour (measured: 214 releases, 3.8s).
+if ! RELEASE_TAGS="$(gh api --paginate "repos/${REPO}/releases" --jq '.[].tag_name' 2>/dev/null)"; then
   log "could not list releases for $REPO; skipping this tick"
   exit 0
 fi

--- a/tools/watch-poke.sh
+++ b/tools/watch-poke.sh
@@ -134,9 +134,17 @@ if ! RELEASE_TAGS="$(gh api --paginate "repos/${REPO}/releases" --jq '.[].tag_na
   exit 0
 fi
 
+# A here-string, not `printf … | grep`. grep exits at the first match, and once
+# the listing outgrows the pipe capacity printf is still writing when it does,
+# takes SIGPIPE, and `pipefail` turns a successful match into a non-zero
+# pipeline — read here as "this platform has no release". Measured: a match at
+# the top of a 5.5KB list is found, the same match in a 144KB list reports
+# missing. Today's listing is 4.4KB, so this is the third form of the same
+# defect on this branch, waiting on repository growth rather than on an API
+# failure. A here-string is not a pipeline and cannot signal the writer.
 MISSING=0
 for suffix in "${PLATFORMS[@]}"; do
-  if ! printf '%s\n' "$RELEASE_TAGS" | grep -qxF "v${VERSION}-${suffix}"; then
+  if ! grep -qxF "v${VERSION}-${suffix}" <<<"$RELEASE_TAGS"; then
     MISSING=1
     break
   fi


### PR DESCRIPTION
At 2026-09-03T01:37:29Z the agent logged "failed to dispatch
watch-claude-release.yml for upstream 2.1.259" — an hour after logging "already
released on all platforms; no dispatch" for the same version, with all five
2.1.259 tags present the whole time. Nothing was missing. The lookup failed, and
the agent could not tell the difference.

`gh release view` exits non-zero both for a tag that does not exist and for a
lookup that cannot be answered — a network blip, a rate limit, a 5xx — and
prints "release not found" either way. Measured against this repo: a missing tag
and an unreachable repository produce the identical message. The loop treated
any non-zero exit as "this platform has no release", so one failed API call was
enough to conclude that five platforms needed rebuilding. On that tick the
dispatch call failed too, which is the only reason a spurious five-platform
rebuild did not happen. That is luck, not a guard.

Replaced with a single `gh release list`, which fails as a unit and reports why,
so its exit status carries the distinction the per-tag check could not express.
A failed listing now logs and skips the tick instead of inventing missing
releases; membership is then a local match. Releases come back newest-first and
the version being asked about is the newest, so its tags sit at the top of the
listing.

Verified by reproducing the incident rather than by inspection. Running the
script against an unreachable repository, log path redirected so the real log
stayed clean:

    before  failed to dispatch watch-claude-release.yml for upstream 2.1.259  (exit 1)
    after   could not list releases for …; skipping this tick                 (exit 0)

The before line is the 01:37 entry, word for word — the old code reaches the
dispatch. The after path never gets there. Against the real repository the fixed
script still logs "upstream 2.1.259 already released on all platforms; no
dispatch", so the case that must keep working does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e