### PR TITLE
fix(usage-wrapup): close the text gate that bypassed the renamed mode gate

### DIFF
--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2102,23 +2102,67 @@ function patchDisableUsageWrapUpHints(content) {
   // are the same length as the originals, so no preserveLength branch is
   // needed. Anchoring on the gate-name string literals (not minified locals)
   // keeps this stable across bundle rebuilds.
+  //
+  // The mode gate alone does not close the wrap-up path. The injector reads the
+  // text gate first and lets a non-empty value stand in for the mode:
+  //
+  //   let F = ran(P(nan, ""));                          // nan = ..._wick_text
+  //   B = F !== null ? "custom" : tan(P(ean, "off"));   // ean = ..._wick_mode
+  //   if (B !== "off") v.push(xe({ content: F ?? ..., isMeta: !0, ... }))
+  //
+  // so any server-supplied text short-circuits the renamed mode gate and the
+  // injection still fires. Measured on a patched 2.1.259 bundle before this
+  // change: _wick_mode and _vellum_anchor gone, _wick_text and _wick_release
+  // both still present. The release gate is reachable the same way, since its
+  // precondition is a wrap-up note the text path can produce. Renaming all four
+  // is what actually closes the path, not defence in depth.
+  //
+  // What gets injected is a `type: "user"` message carrying isMeta/turnCompanion
+  // and a usageLimitNote, i.e. it lands under the same role label as something
+  // the human typed. That is the reason to close it rather than tolerate it.
+  //
+  // `since` is the first version measured to carry the literal, and the gates
+  // did not arrive together: mode and vellum are present from 2.1.238, text and
+  // release first appear in 2.1.247 and are absent from 2.1.246. The
+  // all-or-nothing check below counts against the gates this bundle is old
+  // enough to have, not against the whole list, or 2.1.246 fails as a partial
+  // match for two literals it can never contain.
   const gateRenames = [
     // grace-window wrap-up injection ("off" | "basic" | "next-steps")
-    ['"tengu_lantern_wick_mode"', '"calico_lantern_wick_off"'],
+    { from: '"tengu_lantern_wick_mode"', to: '"calico_lantern_wick_off"', since: 238 },
+    // arbitrary server-supplied wrap-up text; non-empty implies mode "custom"
+    { from: '"tengu_lantern_wick_text"', to: '"calico_lantern_text_off"', since: 247 },
+    // arbitrary server-supplied text for the post-wrap-up release note
+    {
+      from: '"tengu_lantern_wick_release"',
+      to: '"calico_lantern_release_off"',
+      since: 247,
+    },
     // 95% near-limit "checkpoint now" injection + notice (boolean)
-    ['"tengu_vellum_anchor"', '"calico_vellum_gone_"'],
+    { from: '"tengu_vellum_anchor"', to: '"calico_vellum_gone_"', since: 238 },
   ];
 
-  const perGateCounts = gateRenames.map(([from]) => content.split(from).length - 1);
+  const bundleVersion = content
+    .match(/PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/)
+    ?.slice(1)
+    .map(Number);
+  // Unparseable metadata expects every gate, keeping the strict reading.
+  const inEra = (since) =>
+    bundleVersion === undefined ||
+    bundleVersion[0] > 2 ||
+    (bundleVersion[0] === 2 &&
+      (bundleVersion[1] > 1 || (bundleVersion[1] === 1 && bundleVersion[2] >= since)));
+
+  const perGateCounts = gateRenames.map(({ from }) => content.split(from).length - 1);
   const candidates = perGateCounts.reduce((sum, count) => sum + count, 0);
   const presentGates = perGateCounts.filter((count) => count > 0).length;
+  const expectedGates = gateRenames.filter(({ since }) => inEra(since)).length;
 
-  if (presentGates > 0 && presentGates < gateRenames.length) {
-    // Partial match: upstream changed or removed exactly one gate literal
-    // while keeping the other. Renaming only the survivor would ship a bundle
-    // with the other wrap-up injection path still active under its new gate
-    // name, so patch nothing and report zero patched to fail --assert-all
-    // loudly instead.
+  if (presentGates > 0 && presentGates < expectedGates) {
+    // Partial match: upstream changed or removed a gate literal while keeping
+    // the others. Renaming only the survivors would ship a bundle with a
+    // wrap-up injection path still active under its new gate name, so patch
+    // nothing and report zero patched to fail --assert-all loudly instead.
     return {
       content,
       candidates,
@@ -2157,7 +2201,7 @@ function patchDisableUsageWrapUpHints(content) {
   }
 
   let output = content;
-  for (const [from, to] of gateRenames) {
+  for (const { from, to } of gateRenames) {
     output = output.split(from).join(to);
   }
 

--- a/scripts/verify-patched-binary.ts
+++ b/scripts/verify-patched-binary.ts
@@ -1780,37 +1780,57 @@ const CHECKS: Check[] = [
     kind: "custom",
     // When this module is disabled, neither renamed calico gate may exist —
     // matching either one catches partially patched or transitional bundles.
-    disabledMarker: /"calico_lantern_wick_off"|"calico_vellum_gone_"/,
+    disabledMarker:
+      /"calico_lantern_wick_off"|"calico_lantern_text_off"|"calico_lantern_release_off"|"calico_vellum_gone_"/,
     describe:
       "usage-limit wrap-up statsig gate names renamed to dead calico gates",
     run: (content: string): string | null => {
-      // Bundles older than the feature carry neither the original gates nor
-      // the renames; that is a pass (nothing to neutralize). 2.1.238+ bundles
-      // must carry BOTH renamed gates, so a bundle where upstream changed or
-      // removed one gate literal while the patcher renamed only the survivor
-      // cannot pass as "nothing to neutralize" with an injection path left
-      // active under a new gate name.
+      // All four gates, not just the mode one. The injector reads the text gate
+      // first and treats a non-empty value as mode "custom", so leaving that
+      // literal live keeps the whole wrap-up path reachable no matter what the
+      // mode gate is called; the release gate follows from a wrap-up the text
+      // path can produce. Shipped bundles through 2.1.259 carried both live.
+      //
+      // Eras are per gate because they did not arrive together. Measured on
+      // macos-arm64 originals: the mode and vellum gates are present from
+      // 2.1.238, while the text and release gates first appear in 2.1.247 and
+      // are absent from 2.1.246. One shared threshold would fail 2.1.246 for
+      // renames it can never carry.
+      const gates = [
+        { original: "tengu_lantern_wick_mode", renamed: "calico_lantern_wick_off", since: 238 },
+        { original: "tengu_lantern_wick_text", renamed: "calico_lantern_text_off", since: 247 },
+        {
+          original: "tengu_lantern_wick_release",
+          renamed: "calico_lantern_release_off",
+          since: 247,
+        },
+        { original: "tengu_vellum_anchor", renamed: "calico_vellum_gone_", since: 238 },
+      ];
+
       const problems: string[] = [];
-      for (const gate of ["tengu_lantern_wick_mode", "tengu_vellum_anchor"]) {
-        if (content.includes(`"${gate}"`)) {
-          problems.push(`found residual usage wrap-up gate "${gate}"`);
+      for (const { original } of gates) {
+        if (content.includes(`"${original}"`)) {
+          problems.push(`found residual usage wrap-up gate "${original}"`);
         }
       }
+      // Bundles older than a gate carry neither its original nor its rename;
+      // that is a pass. From its era the rename is mandatory, so a bundle where
+      // upstream moved the literal and the patcher renamed only the survivors
+      // cannot pass as "nothing to neutralize" with a path left live under a
+      // name this check never looked for.
       const versionMatch = content.match(
         /PACKAGE_URL:"@anthropic-ai\/claude-code"[\s\S]{0,500}?VERSION:"(\d+)\.(\d+)\.(\d+)"/
       );
       if (versionMatch) {
         const [major, minor, micro] = versionMatch.slice(1).map(Number);
-        const featureEra =
-          major > 2 ||
-          (major === 2 && (minor > 1 || (minor === 1 && micro >= 238)));
-        if (featureEra) {
-          for (const renamed of ["calico_lantern_wick_off", "calico_vellum_gone_"]) {
-            if (!content.includes(`"${renamed}"`)) {
-              problems.push(
-                `expected renamed usage wrap-up gate "${renamed}" in a 2.1.238+ bundle`
-              );
-            }
+        for (const { renamed, since } of gates) {
+          const inEra =
+            major > 2 ||
+            (major === 2 && (minor > 1 || (minor === 1 && micro >= since)));
+          if (inEra && !content.includes(`"${renamed}"`)) {
+            problems.push(
+              `expected renamed usage wrap-up gate "${renamed}" in a 2.1.${since}+ bundle`
+            );
           }
         }
       }

--- a/tests/usage-wrapup-gates.test.js
+++ b/tests/usage-wrapup-gates.test.js
@@ -10,23 +10,55 @@ const { evaluatePatchModule } = require("../scripts/verify-patched-binary.ts");
 
 const patcherPath = path.join(__dirname, "..", "patch-claude-display.ts");
 
-// Mirrors the 2.1.238 bundle shape: gate names assigned to minified vars, then
-// read through the statsig getter `it(gate, default)` at the two injection
-// sites (grace-window wrap-up and 95% near-limit checkpoint).
+// Mirrors the 2.1.247+ bundle shape: gate names assigned to minified vars,
+// then read through the statsig getter `it(gate, default)` at the injection
+// sites (grace-window wrap-up, its release note, and the 95% near-limit
+// checkpoint). The text gate is read FIRST and a non-empty value stands in for
+// the mode, which is why renaming the mode gate alone leaves the path live.
 const fixture =
-  'var GIS=3600000,VIS=300000,KIS,WHp,GHp="tengu_lantern_wick_mode",KHp,_3n="tengu_vellum_anchor",' +
+  'var GIS=3600000,VIS=300000,KIS,WHp,GHp="tengu_lantern_wick_mode",nan="tengu_lantern_wick_text",' +
+  'u6o="tengu_lantern_wick_release",KHp,_3n="tengu_vellum_anchor",' +
   'YHp="[Usage limit approaching. Checkpoint now: finish the current step, then list up to 3 short bullets of the most impactful remaining work.]";' +
-  'if(!Ne&&te&&cNp(Pe.depth===0)){let Wr=VHp(it(GHp,"off"));if(Wr!=="off"){inject(Wr==="next-steps"?KHp:WHp)}}' +
+  'if(!Ne&&te&&cNp(Pe.depth===0)){let F=ran(it(nan,"")),Wr=F!==null?"custom":VHp(it(GHp,"off"));' +
+  'if(Wr!=="off"){inject(F??(Wr==="next-steps"?KHp:WHp))}}' +
+  'if(Pe.depth===0&&f6o(e)){let F=d6o(it(u6o,""));if(F)inject(F)}' +
   "if(!Ne&&te&&Pe.depth>0&&uNp()){if(it(_3n,!1)){notice(JHp);inject(YHp)}}";
 
-test("renames both usage wrap-up statsig gates to dead calico gates", () => {
+test("renames every usage wrap-up statsig gate to a dead calico gate", () => {
   const result = patchDisableUsageWrapUpHints(fixture);
-  assert.equal(result.candidates, 2);
-  assert.equal(result.patched, 2);
-  assert.ok(!result.content.includes('"tengu_lantern_wick_mode"'));
-  assert.ok(!result.content.includes('"tengu_vellum_anchor"'));
-  assert.ok(result.content.includes('"calico_lantern_wick_off"'));
-  assert.ok(result.content.includes('"calico_vellum_gone_"'));
+  assert.equal(result.candidates, 4);
+  assert.equal(result.patched, 4);
+  for (const gate of [
+    "tengu_lantern_wick_mode",
+    "tengu_lantern_wick_text",
+    "tengu_lantern_wick_release",
+    "tengu_vellum_anchor",
+  ]) {
+    assert.ok(!result.content.includes(`"${gate}"`), gate);
+  }
+  for (const renamed of [
+    "calico_lantern_wick_off",
+    "calico_lantern_text_off",
+    "calico_lantern_release_off",
+    "calico_vellum_gone_",
+  ]) {
+    assert.ok(result.content.includes(`"${renamed}"`), renamed);
+  }
+});
+
+// The reason the text gate has to be renamed: it is consulted before the mode
+// gate and a non-empty value makes the mode irrelevant, so a bundle with only
+// the mode gate renamed still injects whatever the server supplies.
+test("renaming the mode gate alone leaves the text path live", () => {
+  const modeOnly = fixture.replace(
+    '"tengu_lantern_wick_mode"',
+    '"calico_lantern_wick_off"'
+  );
+  assert.ok(modeOnly.includes('"tengu_lantern_wick_text"'));
+  assert.match(
+    evaluatePatchModule("disable-usage-wrapup", versionedBundle("2.1.259", modeOnly)),
+    /residual usage wrap-up gate "tengu_lantern_wick_text"/
+  );
 });
 
 test("replacement gate names preserve byte length", () => {
@@ -48,6 +80,38 @@ test("leaves pre-feature bundles untouched", () => {
   assert.equal(result.candidates, 0);
   assert.equal(result.patched, 0);
   assert.equal(result.content, oldBundle);
+});
+
+// The text and release gates first appear in 2.1.247; 2.1.246 carries only the
+// mode and vellum ones. Counting a missing 2.1.247 gate as a partial match on a
+// 2.1.246 bundle would refuse to patch it at all, disabling nothing.
+test("patches a 2.1.246 bundle that predates the text and release gates", () => {
+  const bundle = versionedBundle(
+    "2.1.246",
+    'GHp="tengu_lantern_wick_mode",_3n="tengu_vellum_anchor";it(GHp,"off");it(_3n,!1)'
+  );
+  const result = patchDisableUsageWrapUpHints(bundle);
+  assert.equal(result.patched, 2);
+  assert.ok(!result.skipped);
+  assert.ok(result.content.includes('"calico_lantern_wick_off"'));
+  assert.ok(result.content.includes('"calico_vellum_gone_"'));
+  assert.equal(evaluatePatchModule("disable-usage-wrapup", result.content), null);
+});
+
+test("verifier requires the text and release renames from 2.1.247", () => {
+  const body =
+    'GHp="calico_lantern_wick_off",_3n="calico_vellum_gone_";it(GHp,"off");it(_3n,!1)';
+  // Same body, one version either side of the boundary.
+  assert.equal(
+    evaluatePatchModule("disable-usage-wrapup", versionedBundle("2.1.246", body)),
+    null
+  );
+  const verdict = evaluatePatchModule(
+    "disable-usage-wrapup",
+    versionedBundle("2.1.247", body)
+  );
+  assert.match(verdict, /calico_lantern_text_off/);
+  assert.match(verdict, /calico_lantern_release_off/);
 });
 
 function versionedBundle(version, body) {
@@ -74,10 +138,12 @@ test("does not mark unparseable-version bundles as skipped", () => {
 });
 
 test("never reports skipped when gates are present and patched", () => {
+  // 2.1.247, matching the fixture's shape: labelling a four-gate body 2.1.238
+  // would ask for two gates it predates.
   const result = patchDisableUsageWrapUpHints(
-    versionedBundle("2.1.238", fixture)
+    versionedBundle("2.1.247", fixture)
   );
-  assert.equal(result.patched, 2);
+  assert.equal(result.patched, 4);
   assert.ok(!result.skipped);
 });
 


### PR DESCRIPTION
disable-usage-wrapup renamed two statsig gates. Shipped binaries through
2.1.259 still carried the other two live, and one of them reopens the path the
module exists to close.

The injector reads the text gate before the mode gate and lets a non-empty
value stand in for it:

    let F = ran(P(nan, ""));                          // nan = ..._wick_text
    B = F !== null ? "custom" : tan(P(ean, "off"));   // ean = ..._wick_mode
    if (B !== "off") v.push(xe({ content: F ?? ..., isMeta: !0, ... }))

So a server-supplied value for tengu_lantern_wick_text injects regardless of
what the mode gate is called, and tengu_lantern_wick_release follows from a
wrap-up note that path can produce. Measured on a patched 2.1.259 bundle before
this change: _wick_mode 0, _vellum_anchor 0, _wick_text 1, _wick_release 1.

What gets injected is a `type: "user"` message carrying isMeta, turnCompanion
and usageLimitNote — the generator filters on `I.type === "user"` and the
release path scans back for `r?.type !== "user"`. It lands under the same role
label as something the human typed, which is what makes it worth closing rather
than tolerating. The hardcoded texts are bracketed English usage-limit notices;
the gate-supplied ones are bracketed too, since both wrappers emit `[${n}]`.

Both new gates are renamed to equal-length dead names, matching the existing
pair.

The all-or-nothing guard needed an era. It refused to patch when some but not
all gate literals were present, which is right when they arrive together and
wrong now: measured across macos-arm64 originals, the mode and vellum gates are
present from 2.1.238 while text and release first appear in 2.1.247 and are
absent from 2.1.246. Adding them naively made 2.1.246 a partial match, and the
module patched nothing — 18 verifier failures on a bundle that had been clean.
Each gate now carries the version it was first measured in, and the guard counts
against the gates a bundle is old enough to have. The verifier check is in
lockstep, per gate.

Verified on real binaries, not fixtures: 2.1.246, .252, .257 and .259 each
patched from its original, code-signed, all 20 modules verified, live-thinking
integration test passing, correct version and (patched) on startup. Gate
residue is 0,0,0,0 on every one, and 2.1.246 patches 3 literals rather than
bailing. Four new tests, all confirmed to fail with the two source files
stashed: every gate renamed; the mode-only rename rejected by the verifier
because the text gate survives; 2.1.246 patched rather than refused; and the
text and release renames required from 2.1.247 but not 2.1.246. 167 unit tests
pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e