### PR TITLE
fix(custom-context-window): accept a wrapped headers parameter in the resolver

### DIFF
--- a/patch-claude-display.ts
+++ b/patch-claude-display.ts
@@ -2496,8 +2496,19 @@ function patchCustomContextWindows(content) {
   // `n`, which took this module from 4 candidates to 1. That still passed
   // --assert-all, since it only fails at zero — a silent loss of coverage.
   // Capture both and emit the captures.
+  //
+  // 2.1.260 stopped reading the headers parameter directly and passes it
+  // through a helper first:
+  //
+  //   2.1.259  function wL(e,n){if(ou(e))return 1e6;if(n?.includes(vx.header)…
+  //   2.1.260  function tU(e,n){if(Vc(e))return 1e6;if(RYe(n)?.includes(rP.header)…
+  //
+  // Pinning `\3?.includes(` took this module from 4 candidates to 3 — the
+  // resolver site, and with it both injected markers. --assert-all still
+  // passed, so the loss was silent again; the verifier is what failed the
+  // build. Accept the parameter bare or wrapped in one call.
   const resolverPattern =
-    /(function [A-Za-z_$][\w$]*\()([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)(\)\{)(if\([A-Za-z_$][\w$]*\(\2\)\)return 1e6;if\(\3\?\.includes\()/g;
+    /(function [A-Za-z_$][\w$]*\()([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)(\)\{)(if\([A-Za-z_$][\w$]*\(\2\)\)return 1e6;if\((?:\3|[A-Za-z_$][\w$]*\(\3\))\?\.includes\()/g;
 
   output = output.replace(resolverPattern, (full, functionOpen, modelParam, headersParam, brace, originalBody) => {
     const functionStart = `${functionOpen}${modelParam},${headersParam}${brace}`;

--- a/tests/custom-context-window-resolver.test.js
+++ b/tests/custom-context-window-resolver.test.js
@@ -1,0 +1,47 @@
+// The context-window resolver has been reshaped twice by upstream, and both
+// times the module kept applying with fewer candidates instead of failing:
+// 2.1.257 renamed the second parameter (4 -> 1), and 2.1.260 stopped reading it
+// directly, wrapping it in a helper call (4 -> 3). `--assert-all` only fails at
+// zero, so neither loss was visible there; on 2.1.260 the verifier caught it,
+// because the resolver site is what injects both markers.
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { patchCustomContextWindows } = require("../patch-claude-display.ts");
+
+// Both spellings of the same resolver, minified names and all.
+const bare =
+  "function wL(e,n){if(ou(e))return 1e6;if(n?.includes(vx.header)&&wv(e))return 1e6;" +
+  "let r=Vvn(e);if(r!==void 0)return tCt(e)??r.believed;return 200000}";
+const wrapped =
+  "function tU(e,n){if(Vc(e))return 1e6;if(RYe(n)?.includes(rP.header)&&RC(e))return 1e6;" +
+  "let r=jEn(e);if(r!==void 0)return oEt(e)??r.believed;return 200000}";
+
+for (const [name, fixture] of [
+  ["2.1.259 reads the headers parameter directly", bare],
+  ["2.1.260 passes it through a helper first", wrapped],
+]) {
+  test(`resolver is patched when ${name}`, () => {
+    const result = patchCustomContextWindows(fixture);
+    assert.equal(result.candidates, 1);
+    assert.equal(result.patched, 1);
+    // Both markers the verifier checks come from this site.
+    assert.ok(result.content.includes("__calico_context_window"));
+    assert.ok(result.content.includes("CALICO_CONTEXT_DISPLAY_PERCENT"));
+    // The lookup must read the model parameter, and the original body must
+    // survive after the early return.
+    assert.match(result.content, /let __calico_window=__calico_context_window\(e\);/);
+    assert.ok(result.content.includes("if(__calico_window!==null)return __calico_window;"));
+    assert.ok(result.content.includes("return 200000}"));
+  });
+}
+
+// The relaxation admits one wrapping call, not any expression: a resolver whose
+// second `if` tests something unrelated is not this site.
+test("a resolver that does not test the headers parameter is left alone", () => {
+  const unrelated =
+    "function tU(e,n){if(Vc(e))return 1e6;if(RYe(z)?.includes(rP.header)&&RC(e))return 1e6;return 200000}";
+  const result = patchCustomContextWindows(unrelated);
+  assert.equal(result.patched, 0);
+  assert.equal(result.content, unrelated);
+});


### PR DESCRIPTION
2.1.260 cannot be released without this. The module still applies — 20/20, no
--assert-all failure — but at 3 candidates instead of 4, and the site it loses
is the one that injects both markers the verifier checks:

    custom-context-window: missing marker(s): CALICO_CONTEXT_DISPLAY_PERCENT,
    __calico_context_window

`Verify patched bundle` runs on every platform leg, so all five would fail
before publishing. Nothing broken ships; the build just stops.

Upstream stopped reading the headers parameter directly and passes it through a
helper first:

    2.1.259  function wL(e,n){if(ou(e))return 1e6;if(n?.includes(vx.header)…
    2.1.260  function tU(e,n){if(Vc(e))return 1e6;if(RYe(n)?.includes(rP.header)…

The matcher pinned `\3?.includes(`, so it matched neither. It now accepts the
captured parameter bare or wrapped in exactly one call. Not a wildcard: the
anchor is still `function X(a,b){if(Y(a))return 1e6;if(<b|f(b)>?.includes(`, and
a resolver whose second test reads some other identifier is left alone.

This is the second reshape of this same resolver, and both were silent in the
same way. 2.1.257 renamed the second parameter and took the module from 4 to 1;
2.1.260 wrapped it and took it from 4 to 3. `--assert-all` only fails at zero,
so a falling count is invisible to it — the verifier is what failed the build
both times, because it asserts on markers rather than on counts.

Regression over five macos-arm64 bundles — 2.1.252, .257, .258, .259 and .260 —
each patched from its original, code-signed, verified and driven through the
live-thinking mock: custom-context-window back to 4 on every one, zero verifier
failures, live-thinking PASS, correct version and (patched) on startup. The new
tests carry both spellings of the resolver plus a negative control; the 2.1.260
case was confirmed to fail with the patcher change stashed, and the other two to
be unaffected by it. 170 unit tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9nhh4HmGpTFHSMbHDso8e